### PR TITLE
Allow previously disallowed rules for specified patters

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Use them to add rules to your `phpstan.neon` config file. Here's an example, upd
 
 ```
 services:
+    - Spaze\PHPStan\Rules\Disallowed\DisallowedHelper
     -
         class: Spaze\PHPStan\Rules\Disallowed\MethodCalls
         tags:
@@ -72,7 +73,7 @@ services:
                     message: 'use logger instead'
 ```
 
-The `message` key is optional.
+The `message` key is optional. Don't forget to add the `DisallowedHelper` service.
 
 ## Example output
 
@@ -100,6 +101,27 @@ ignoreErrors:
             - application/libraries/Tls/CertificateSigningRequest.php
             - application/libraries/Tls/PublicKey.php
 ```
+
+You can also allow some previously disallowed calls using the `allowIn` configuration key, for example:
+
+```
+services:
+    - Spaze\PHPStan\Rules\Disallowed\DisallowedHelper
+    -
+        class: Spaze\PHPStan\Rules\Disallowed\MethodCalls
+        tags:
+            - phpstan.rules.rule
+        arguments:
+            forbiddenCalls:
+                -
+                    method: 'PotentiallyDangerous\Logger::log()'
+                    message: 'use our own logger instead'
+                    allowIn:
+                        - path/to/some/file-*.php
+                        - tests/*.test.php
+```
+
+The paths in `allowIn` are relative to the config file location and support [fnmatch()](https://www.php.net/function.fnmatch) patterns.
 
 ## Running tests
 

--- a/src/DisallowedHelper.php
+++ b/src/DisallowedHelper.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Rules\Disallowed;
+
+use PHPStan\File\FileHelper;
+
+class DisallowedHelper
+{
+
+	/** @var FileHelper */
+	private $fileHelper;
+
+
+	public function __construct(FileHelper $fileHelper)
+	{
+		$this->fileHelper = $fileHelper;
+	}
+
+
+	/**
+	 * @param string $file
+	 * @param string[] $config
+	 * @return boolean
+	 */
+	public function isAllowed(string $file, array $config): bool
+	{
+		foreach (($config['allowIn'] ?? []) as $allowedPath) {
+			if (fnmatch($this->fileHelper->absolutizePath($allowedPath), $file)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+}

--- a/tests/FunctionCallsTest.php
+++ b/tests/FunctionCallsTest.php
@@ -3,6 +3,7 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Rules\Disallowed;
 
+use PHPStan\File\FileHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 
@@ -12,21 +13,38 @@ class FunctionCallsTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		return new FunctionCalls(
+			new DisallowedHelper(new FileHelper(__DIR__)),
 			[
 				[
 					'function' => 'var_dump()',
 					'message' => 'use logger instead',
+					'allowIn' => [
+						'data/*-allowed.php',
+						'data/*-allowed.*',
+					],
 				],
 				[
 					'function' => 'print_r()',
 					'message' => 'nope',
+					'allowIn' => [
+						'data/*-allowed.php',
+						'data/*-allowed.*',
+					],
 				],
 				[
 					'function' => 'printf()',
+					'allowIn' => [
+						'data/*-allowed.php',
+						'data/*-allowed.*',
+					],
 				],
 				[
 					'function' => 'Foo\Bar\waldo()',
 					'message' => 'whoa, a namespace',
+					'allowIn' => [
+						'data/*-allowed.php',
+						'data/*-allowed.*',
+					],
 				],
 			]
 		);
@@ -57,6 +75,7 @@ class FunctionCallsTest extends RuleTestCase
 				11,
 			],
 		]);
+		$this->analyse([__DIR__ . '/data/disallowed-calls-allowed.php'], []);
 	}
 
 }

--- a/tests/MethodCallsTest.php
+++ b/tests/MethodCallsTest.php
@@ -3,8 +3,8 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Rules\Disallowed;
 
+use PHPStan\File\FileHelper;
 use PHPStan\Rules\Rule;
-use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Testing\RuleTestCase;
 
 class MethodCallsTest extends RuleTestCase
@@ -14,10 +14,15 @@ class MethodCallsTest extends RuleTestCase
 	{
 		return new MethodCalls(
 			$this->createBroker(),
+			new DisallowedHelper(new FileHelper(__DIR__)),
 			[
 				[
 					'method' => 'Waldo\Quux\Blade::runner()',
 					'message' => "I've seen tests you people wouldn't believe",
+					'allowIn' => [
+						'data/*-allowed.php',
+						'data/*-allowed.*',
+					],
 				],
 			]
 		);
@@ -32,6 +37,7 @@ class MethodCallsTest extends RuleTestCase
 				25,
 			],
 		]);
+		$this->analyse([__DIR__ . '/data/disallowed-calls-allowed.php'], []);
 	}
 
 }

--- a/tests/StaticCallsTest.php
+++ b/tests/StaticCallsTest.php
@@ -3,6 +3,7 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Rules\Disallowed;
 
+use PHPStan\File\FileHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 
@@ -12,10 +13,15 @@ class StaticCallsTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		return new StaticCalls(
+			new DisallowedHelper(new FileHelper(__DIR__)),
 			[
 				[
 					'method' => 'Fiction\Pulp\Royale::withCheese()',
 					'message' => 'a Quarter Pounder with Cheese?',
+					'allowIn' => [
+						'data/*-allowed.php',
+						'data/*-allowed.*',
+					],
 				],
 			]
 		);
@@ -34,6 +40,7 @@ class StaticCallsTest extends RuleTestCase
 				18,
 			],
 		]);
+		$this->analyse([__DIR__ . '/data/disallowed-calls-allowed.php'], []);
 	}
 
 }

--- a/tests/data/disallowed-calls-allowed.php
+++ b/tests/data/disallowed-calls-allowed.php
@@ -1,0 +1,27 @@
+<?php
+// This is a copy of disallowed-calls.php to test disallowed-but-allowed calls
+declare(strict_types = 1);
+
+use function Foo\Bar\waldo;
+
+var_dump('foo');
+print_r('bar');
+\printf('foobar');
+var_export('not disallowed');
+\Foo\Bar\waldo();
+waldo();
+
+
+\Fiction\Pulp\Royale::withCheese();
+
+use Fiction\Pulp;
+
+Pulp\Royale::withCheese();
+Pulp\Royale::leBigMac();
+
+
+use Waldo\Quux;
+
+$blade = new Quux\Blade();
+$blade->runner();
+$blade->server();


### PR DESCRIPTION
From README:

You can also allow some previously disallowed calls using the `allowIn` configuration key, for example:

```
services:
    - Spaze\PHPStan\Rules\Disallowed\DisallowedHelper
    -
        class: Spaze\PHPStan\Rules\Disallowed\MethodCalls
        tags:
            - phpstan.rules.rule
        arguments:
            forbiddenCalls:
                -
                    method: 'PotentiallyDangerous\Logger::log()'
                    message: 'use our own logger instead'
                    allowIn:
                        - path/to/some/file-*.php
                        - tests/*.test.php
```

The paths in `allowIn` are relative to the config file location and support [fnmatch()](https://www.php.net/function.fnmatch) patterns.

Fixes #2