### PR TITLE
Allow to use PHPStan's extension installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,57 +23,51 @@ composer require --dev spaze/phpstan-disallowed-calls
 
 [PHPStan](https://github.com/phpstan/phpstan), the PHP Static Analysis Tool, is a requirement.
 
+If you use [phpstan/extension-installer](https://github.com/phpstan/extension-installer), you are all set and can skip to configuration.
+
+For manual installation, add this to your `phpstan.neon`:
+
+```
+includes:
+    - vendor/spaze/phpstan-disallowed-calls/extension.neon
+```
+
+
 ## Configuration
 
-There are three different classes that can be used:
+There are three different disallowed types (and configuration keys) that can be disallowed:
 
-1. `MethodCalls` - for detecting `$object->method()` calls
-2. `StaticCalls` - for static calls `Class::method()`
-3. `FunctionCalls` - for functions like `function()`
+1. `disallowedMethodCalls` - for detecting `$object->method()` calls
+2. `disallowedStaticCalls` - for static calls `Class::method()`
+3. `disallowedFunctionCalls` - for functions like `function()`
 
-Use them to add rules to your `phpstan.neon` config file. Here's an example, update to your needs:
+Use them to add rules to your `phpstan.neon` config file. I like to use a separate file (`disallowed-calls.neon`) for these which I'll include later on in the main `phpstan.neon` config file. Here's an example, update to your needs:
 
 ```
-services:
-    - Spaze\PHPStan\Rules\Disallowed\DisallowedHelper
-    -
-        class: Spaze\PHPStan\Rules\Disallowed\MethodCalls
-        tags:
-            - phpstan.rules.rule
-        arguments:
-            forbiddenCalls:
-                -
-                    method: 'PotentiallyDangerous\Logger::log()'
-                    message: 'use our own logger instead'
-                -
-                    method: 'Redis::connect()'
-                    message: 'use our own Redis instead'
+parameters:
+    disallowedMethodCalls:
+        -
+            method: 'PotentiallyDangerous\Logger::log()'
+            message: 'use our own logger instead'
+        -
+            method: 'Redis::connect()'
+            message: 'use our own Redis instead'
 
-    -
-        class: Spaze\PHPStan\Rules\Disallowed\StaticCalls
-        tags:
-            - phpstan.rules.rule
-        arguments:
-            forbiddenCalls:
-                -
-                    method: 'PotentiallyDangerous\Debugger::log()'
-                    message: 'use our own logger instead'
+    disallowedStaticCalls:
+        -
+            method: 'PotentiallyDangerous\Debugger::log()'
+            message: 'use our own logger instead'
 
-    -
-        class: Spaze\PHPStan\Rules\Disallowed\FunctionCalls
-        tags:
-            - phpstan.rules.rule
-        arguments:
-            forbiddenCalls:
-                -
-                    function: 'var_dump()'
-                    message: 'use logger instead'
-                -
-                    function: 'print_r()'
-                    message: 'use logger instead'
+    disallowedFunctionCalls:
+        -
+            function: 'var_dump()'
+            message: 'use logger instead'
+        -
+            function: 'print_r()'
+            message: 'use logger instead'
 ```
 
-The `message` key is optional. Don't forget to add the `DisallowedHelper` service.
+The `message` key is optional.
 
 ## Example output
 
@@ -105,20 +99,14 @@ ignoreErrors:
 You can also allow some previously disallowed calls using the `allowIn` configuration key, for example:
 
 ```
-services:
-    - Spaze\PHPStan\Rules\Disallowed\DisallowedHelper
-    -
-        class: Spaze\PHPStan\Rules\Disallowed\MethodCalls
-        tags:
-            - phpstan.rules.rule
-        arguments:
-            forbiddenCalls:
-                -
-                    method: 'PotentiallyDangerous\Logger::log()'
-                    message: 'use our own logger instead'
-                    allowIn:
-                        - path/to/some/file-*.php
-                        - tests/*.test.php
+parameters:
+    disallowedMethodCalls:
+        -
+            method: 'PotentiallyDangerous\Logger::log()'
+            message: 'use our own logger instead'
+            allowIn:
+                - path/to/some/file-*.php
+                - tests/*.test.php
 ```
 
 The paths in `allowIn` are relative to the config file location and support [fnmatch()](https://www.php.net/function.fnmatch) patterns.
@@ -127,14 +115,14 @@ You can also narrow down the allowed items when called with some parameters. For
 This can be done with optional `allowParamsInAllowed` or `allowParamsAnywhere` configuration keys:
 
 ```
-arguments:
-    forbiddenCalls:
+parameters:
+    disallowedMethodCalls:
         -
-            method: 'Tracy\ILogger::log()'
+            method: 'PotentiallyDangerous\Logger::log()'
             message: 'use our own logger instead'
             allowIn:
-                - optional/path/to/*.tests.php
-                - another/file.php
+                - path/to/some/file-*.php
+                - tests/*.test.php
             allowParamsInAllowed:
                 1: 'foo'
                 2: true

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,13 @@
 			"email": "mail@michalspacek.cz"
 		}
 	],
+	"extra": {
+		"phpstan": {
+			"includes": [
+				"extension.neon"
+			]
+		}
+	},
 	"require": {
 		"php": "^7.1",
 		"phpstan/phpstan": "^0.12"

--- a/extension.neon
+++ b/extension.neon
@@ -1,0 +1,50 @@
+parameters:
+	disallowedMethodCalls: []
+	disallowedStaticCalls: []
+	disallowedFunctionCalls: []
+
+parametersSchema:
+	# These should be defined using `structure` with listed keys but it seems to me that PHPStan requires
+	# all keys to be present in a structure but `message`, `allowIn` & `allowParamsInAllowed` are optional.
+	disallowedMethodCalls: listOf(
+		arrayOf(
+			anyOf(
+				string(),
+				listOf(string()),
+				arrayOf(anyOf(int(), string(), bool()))
+			)
+		)
+	)
+	disallowedStaticCalls: listOf(
+		arrayOf(
+			anyOf(
+				string(),
+				listOf(string()),
+				arrayOf(anyOf(int(), string(), bool()))
+			)
+		)
+	)
+	disallowedFunctionCalls: listOf(
+		arrayOf(
+			anyOf(
+				string(),
+				listOf(string()),
+				arrayOf(anyOf(int(), string(), bool()))
+			)
+		)
+	)
+
+services:
+	- Spaze\PHPStan\Rules\Disallowed\DisallowedHelper
+	-
+		factory: Spaze\PHPStan\Rules\Disallowed\MethodCalls(forbiddenCalls: %disallowedMethodCalls%)
+		tags:
+			- phpstan.rules.rule
+	-
+		factory: Spaze\PHPStan\Rules\Disallowed\StaticCalls(forbiddenCalls: %disallowedStaticCalls%)
+		tags:
+			- phpstan.rules.rule
+	-
+		factory: Spaze\PHPStan\Rules\Disallowed\FunctionCalls(forbiddenCalls: %disallowedFunctionCalls%)
+		tags:
+			- phpstan.rules.rule

--- a/src/FunctionCalls.php
+++ b/src/FunctionCalls.php
@@ -10,27 +10,7 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 
 /**
- * Reports on dynamically calling a forbidden function.
- *
- * Specify required arguments in a config file, example:
- * <code>
- * arguments:
- *   forbiddenCalls:
- *     -
- *       function: 'var_dump()'
- *       message: 'use logger instead'
- *       allowIn:
- *         - optional/path/to/*.tests.php
- *         - another/file.php
- *       allowParamsInAllowed:
- *         1: 'foo'
- *         2: true
- *       allowParamsAnywhere:
- *         2: true
- *     -
- *       function: 'Foo\Bar\baz()'
- *       message: 'waldo instead'
- * </code>
+ * Reports on dynamically calling a disallowed function.
  *
  * @package spaze\PHPStan\Rules\Disallowed
  */

--- a/src/MethodCalls.php
+++ b/src/MethodCalls.php
@@ -13,29 +13,9 @@ use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Type\Type;
 
 /**
- * Reports on dynamically calling a forbidden method or two.
+ * Reports on dynamically calling a disallowed method or two.
  *
  * Static calls have a different rule, <code>StaticCalls</code>
- *
- * Specify required arguments in a config file, example:
- * <code>
- * arguments:
- *   forbiddenCalls:
- *     -
- *       method: 'Tracy\ILogger::log()'
- *       message: 'use our own logger instead'
- *       allowIn:
- *         - optional/path/to/*.tests.php
- *         - another/file.php
- *       allowParamsInAllowed:
- *         1: 'foo'
- *         2: true
- *       allowParamsAnywhere:
- *         2: true
- *     -
- *       method: 'Foo\Bar::baz()'
- *       message: 'waldo instead'
- * </code>
  *
  * @package spaze\PHPStan\Rules\Disallowed
  */

--- a/src/StaticCalls.php
+++ b/src/StaticCalls.php
@@ -10,29 +10,9 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 
 /**
- * Reports on statically calling a forbidden method or two.
+ * Reports on statically calling a disallowed method or two.
  *
  * Dynamic calls have a different rule, <code>MethodCalls</code>
- *
- * Specify required arguments in a config file, example:
- * <code>
- * arguments:
- *   forbiddenCalls:
- *     -
- *       method: 'Tracy\Debugger::log()'
- *       message: 'use our own logger instead'
- *       allowIn:
- *         - optional/path/to/*.tests.php
- *         - another/file.php
- *       allowParamsInAllowed:
- *         1: 'foo'
- *         2: true
- *       allowParamsAnywhere:
- *         2: true
- *     -
- *       method: 'Foo\Bar::baz()'
- *       message: 'waldo instead'
- * </code>
  *
  * @package spaze\PHPStan\Rules\Disallowed
  */


### PR DESCRIPTION
Those `parametersSchema` fields should really look like
```neon
	disallowedMethodCalls: listOf(structure([
		method: string()
		message: schema(string(), nullable())
		allowIn: listOf(string())
		allowParamsInAllowed: arrayOf(anyOf(int(), string(), bool()))
	]))
```
But PHPStan throws 

> The mandatory option 'parameters › disallowedMethodCalls › 0 › allowParamsInAllowed' is missing.

When for example `allowParamsInAllowed` is not specified (which is fine, the field is optional). I *think* PHPStan requires all the fields to be present in `structure`, even though the original nette/scheme library doesn't

Fix #9