### PR TITLE
Use update-alternatives to set PHP version to use in tests in Actions

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -21,16 +21,18 @@ jobs:
     - name: OS info
       run: cat /etc/os-release
 
+    - name: Set default PHP version
+      run: sudo update-alternatives --set php /usr/bin/php${{ matrix.php-version }}
+
     - name: PHP info
       run: |
-        php${{ matrix.php-version }} -v
-        php${{ matrix.php-version }} -m
-
+        php -v
+        php -m
     - name: Validate composer.json
-      run: php${{ matrix.php-version }} /usr/bin/composer validate --strict
+      run: composer validate --strict
 
     - name: Install dependencies
-      run: php${{ matrix.php-version }} /usr/bin/composer update --no-progress
+      run: composer update --no-progress
 
     - name: Run tests
-      run: php${{ matrix.php-version }} /usr/bin/composer test
+      run: composer test


### PR DESCRIPTION
This is much nicer than specifying the path akways, thanks @szepeviktor!

I've set it back to run on push only so I can merge PRs faster.