### PR TITLE
PHPStan level over 9000

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,4 @@
 parameters:
 	paths:
 		- src
-	level: 1
+	level: 6

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,3 +2,6 @@ parameters:
 	paths:
 		- src
 	level: max
+
+includes:
+	- vendor/phpstan/phpstan/conf/bleedingEdge.neon

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,4 @@
 parameters:
 	paths:
 		- src
-	level: 6
+	level: max

--- a/src/DisallowedCall.php
+++ b/src/DisallowedCall.php
@@ -1,0 +1,82 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Rules\Disallowed;
+
+class DisallowedCall
+{
+
+	/** @var string */
+	private $call;
+
+	/** @var string|null */
+	private $message;
+
+	/** @var string[] */
+	private $allowIn;
+
+	/** @var array<integer, integer|boolean|string> */
+	private $allowParamsInAllowed;
+
+	/** @var array<integer, integer|boolean|string> */
+	private $allowParamsAnywhere;
+
+
+	/**
+	 * DisallowedCall constructor.
+	 *
+	 * @param string $call
+	 * @param string|null $message
+	 * @param string[] $allowIn
+	 * @param array<integer, integer|boolean|string> $allowParamsInAllowed
+	 * @param array<integer, integer|boolean|string> $allowParamsAnywhere
+	 */
+	public function __construct(string $call, ?string $message, array $allowIn, array $allowParamsInAllowed, array $allowParamsAnywhere)
+	{
+		$this->call = $call;
+		$this->message = $message;
+		$this->allowIn = $allowIn;
+		$this->allowParamsInAllowed = $allowParamsInAllowed;
+		$this->allowParamsAnywhere = $allowParamsAnywhere;
+	}
+
+
+	public function getCall(): string
+	{
+		return $this->call;
+	}
+
+
+	public function getMessage(): string
+	{
+		return $this->message ?? 'because reasons';
+	}
+
+
+	/**
+	 * @return string[]
+	 */
+	public function getAllowIn(): array
+	{
+		return $this->allowIn;
+	}
+
+
+	/**
+	 * @return array<integer, integer|boolean|string>
+	 */
+	public function getAllowParamsInAllowed(): array
+	{
+		return $this->allowParamsInAllowed;
+	}
+
+
+	/**
+	 * @return array<integer, integer|boolean|string>
+	 */
+	public function getAllowParamsAnywhere(): array
+	{
+		return $this->allowParamsAnywhere;
+	}
+
+}

--- a/src/DisallowedHelper.php
+++ b/src/DisallowedHelper.php
@@ -30,27 +30,28 @@ class DisallowedHelper
 	public function isAllowed(Scope $scope, array $args, array $config): bool
 	{
 		foreach (($config['allowIn'] ?? []) as $allowedPath) {
-			if (fnmatch($this->fileHelper->absolutizePath($allowedPath), $scope->getFile()) && $this->hasAllowedParams($scope, $args, $config, 'allowParamsInAllowed', true)) {
+			if (fnmatch($this->fileHelper->absolutizePath($allowedPath), $scope->getFile())
+				&& $this->hasAllowedParams($scope, $args, $config['allowParamsInAllowed'] ?? null, true)
+			) {
 				return true;
 			}
 		}
-		return $this->hasAllowedParams($scope, $args, $config, 'allowParamsAnywhere', false);
+		return $this->hasAllowedParams($scope, $args, $config['allowParamsAnywhere'] ?? null, false);
 	}
 
 
 	/**
 	 * @param Scope $scope
 	 * @param Arg[] $args
-	 * @param array{function?:string, method?:string, message?:string, allowIn?:string[], allowParamsInAllowed?:array<integer, integer|boolean|string>} $config
-	 * @param string $configKey
+	 * @param array<integer, integer|boolean|string>|null $allowConfig
 	 * @param boolean $default
 	 * @return boolean
 	 */
-	private function hasAllowedParams(Scope $scope, array $args, array $config, string $configKey, bool $default): bool
+	private function hasAllowedParams(Scope $scope, array $args, ?array $allowConfig, bool $default): bool
 	{
-		if (isset($config[$configKey]) && is_array($config[$configKey])) {
+		if ($allowConfig !== null) {
 			$disallowed = false;
-			foreach ($config[$configKey] as $param => $value) {
+			foreach ($allowConfig as $param => $value) {
 				$arg = $args[$param - 1] ?? null;
 				$type = $arg ? $scope->getType($arg->value) : null;
 				if ($arg && $type instanceof ConstantScalarType) {
@@ -59,7 +60,7 @@ class DisallowedHelper
 					$disallowed = true;
 				}
 			}
-			if (count($config[$configKey]) > 0) {
+			if (count($allowConfig) > 0) {
 				return !$disallowed;
 			}
 		}

--- a/src/DisallowedHelper.php
+++ b/src/DisallowedHelper.php
@@ -3,9 +3,14 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Rules\Disallowed;
 
+use PhpParser\Node;
 use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\File\FileHelper;
+use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\ConstantScalarType;
 
 class DisallowedHelper
@@ -24,47 +29,89 @@ class DisallowedHelper
 	/**
 	 * @param Scope $scope
 	 * @param Arg[] $args
-	 * @param array{function?:string, method?:string, message?:string, allowIn?:string[], allowParamsInAllowed?:array<integer, integer|boolean|string>} $config
+	 * @param DisallowedCall $disallowedCall
 	 * @return boolean
 	 */
-	public function isAllowed(Scope $scope, array $args, array $config): bool
+	public function isAllowed(Scope $scope, array $args, DisallowedCall $disallowedCall): bool
 	{
-		foreach (($config['allowIn'] ?? []) as $allowedPath) {
+		foreach ($disallowedCall->getAllowIn() as $allowedPath) {
 			if (fnmatch($this->fileHelper->absolutizePath($allowedPath), $scope->getFile())
-				&& $this->hasAllowedParams($scope, $args, $config['allowParamsInAllowed'] ?? null, true)
+				&& $this->hasAllowedParams($scope, $args, $disallowedCall->getAllowParamsInAllowed(), true)
 			) {
 				return true;
 			}
 		}
-		return $this->hasAllowedParams($scope, $args, $config['allowParamsAnywhere'] ?? null, false);
+		return $this->hasAllowedParams($scope, $args, $disallowedCall->getAllowParamsAnywhere(), false);
 	}
 
 
 	/**
 	 * @param Scope $scope
 	 * @param Arg[] $args
-	 * @param array<integer, integer|boolean|string>|null $allowConfig
+	 * @param array<integer, integer|boolean|string> $allowConfig
 	 * @param boolean $default
 	 * @return boolean
 	 */
-	private function hasAllowedParams(Scope $scope, array $args, ?array $allowConfig, bool $default): bool
+	private function hasAllowedParams(Scope $scope, array $args, array $allowConfig, bool $default): bool
 	{
-		if ($allowConfig !== null) {
-			$disallowed = false;
-			foreach ($allowConfig as $param => $value) {
-				$arg = $args[$param - 1] ?? null;
-				$type = $arg ? $scope->getType($arg->value) : null;
-				if ($arg && $type instanceof ConstantScalarType) {
-					$disallowed = $disallowed || ($value !== $type->getValue());
-				} else {
-					$disallowed = true;
-				}
-			}
-			if (count($allowConfig) > 0) {
-				return !$disallowed;
+		$disallowed = false;
+		foreach ($allowConfig as $param => $value) {
+			$arg = $args[$param - 1] ?? null;
+			$type = $arg ? $scope->getType($arg->value) : null;
+			if ($arg && $type instanceof ConstantScalarType) {
+				$disallowed = $disallowed || ($value !== $type->getValue());
+			} else {
+				$disallowed = true;
 			}
 		}
+		if (count($allowConfig) > 0) {
+			return !$disallowed;
+		}
 		return $default;
+	}
+
+
+	/**
+	 * @param array<array{function?:string, method?:string, message?:string, allowIn?:string[], allowParamsInAllowed?:array<integer, integer|boolean|string>, allowParamsAnywhere?:array<integer, integer|boolean|string>}> $config
+	 * @return DisallowedCall[]
+	 */
+	public function createCallsFromConfig(array $config): array
+	{
+		$calls = [];
+		foreach ($config as $disallowedCall) {
+			$call = $disallowedCall['function'] ?? $disallowedCall['method'] ?? null;
+			if (!$call) {
+				throw new ShouldNotHappenException("Either 'method' or 'function' must be set in configuration items");
+			}
+			$calls[] = new DisallowedCall(
+				$call,
+				$disallowedCall['message'] ?? null,
+				$disallowedCall['allowIn'] ?? [],
+				$disallowedCall['allowParamsInAllowed'] ?? [],
+				$disallowedCall['allowParamsAnywhere'] ?? []
+			);
+		}
+		return $calls;
+	}
+
+
+	/**
+	 * @param FuncCall|MethodCall|StaticCall $node
+	 * @param Scope $scope
+	 * @param string $name
+	 * @param DisallowedCall[] $disallowedCalls
+	 * @return string[]
+	 */
+	public function getDisallowedMessage(Node $node, Scope $scope, string $name, array $disallowedCalls): array
+	{
+		foreach ($disallowedCalls as $disallowedCall) {
+			if ($name === $disallowedCall->getCall() && !$this->isAllowed($scope, $node->args, $disallowedCall)) {
+				return [
+					sprintf('Calling %s is forbidden, %s', $name, $disallowedCall->getMessage()),
+				];
+			}
+		}
+		return [];
 	}
 
 }

--- a/src/DisallowedHelper.php
+++ b/src/DisallowedHelper.php
@@ -4,8 +4,9 @@ declare(strict_types = 1);
 namespace Spaze\PHPStan\Rules\Disallowed;
 
 use PhpParser\Node\Arg;
-use PhpParser\Node\Scalar;
+use PHPStan\Analyser\Scope;
 use PHPStan\File\FileHelper;
+use PHPStan\Type\ConstantScalarType;
 
 class DisallowedHelper
 {
@@ -21,37 +22,39 @@ class DisallowedHelper
 
 
 	/**
-	 * @param string $file
+	 * @param Scope $scope
 	 * @param Arg[] $args
 	 * @param string[] $config
 	 * @return boolean
 	 */
-	public function isAllowed(string $file, array $args, array $config): bool
+	public function isAllowed(Scope $scope, array $args, array $config): bool
 	{
 		foreach (($config['allowIn'] ?? []) as $allowedPath) {
-			if (fnmatch($this->fileHelper->absolutizePath($allowedPath), $file) && $this->hasAllowedParams($config, $args, 'allowParamsInAllowed', true)) {
+			if (fnmatch($this->fileHelper->absolutizePath($allowedPath), $scope->getFile()) && $this->hasAllowedParams($scope, $args, $config, 'allowParamsInAllowed', true)) {
 				return true;
 			}
 		}
-		return $this->hasAllowedParams($config, $args, 'allowParamsAnywhere', false);
+		return $this->hasAllowedParams($scope, $args, $config, 'allowParamsAnywhere', false);
 	}
 
 
 	/**
-	 * @param string[] $config
+	 * @param Scope $scope
 	 * @param Arg[] $args
+	 * @param string[] $config
 	 * @param string $configKey
 	 * @param boolean $default
 	 * @return boolean
 	 */
-	private function hasAllowedParams(array $config, array $args, string $configKey, bool $default): bool
+	private function hasAllowedParams(Scope $scope, array $args, array $config, string $configKey, bool $default): bool
 	{
 		if (isset($config[$configKey]) && is_array($config[$configKey])) {
 			$disallowed = false;
 			foreach ($config[$configKey] as $param => $value) {
-				if (isset($args[$param - 1])) {
-					$arg = $args[$param - 1];
-					$disallowed = $disallowed || $this->isDisallowedParam($value, $arg);
+				$arg = $args[$param - 1] ?? null;
+				$type = $arg ? $scope->getType($arg->value) : null;
+				if ($arg && $type instanceof ConstantScalarType) {
+					$disallowed = $disallowed || ($value !== $type->getValue());
 				} else {
 					$disallowed = true;
 				}
@@ -61,23 +64,6 @@ class DisallowedHelper
 			}
 		}
 		return $default;
-	}
-
-
-	/**
-	 * @param mixed $value
-	 * @param Arg $arg
-	 * @return boolean
-	 */
-	private function isDisallowedParam($value, Arg $arg): bool
-	{
-		// 2nd param in print_r(..., true) is returned as Node\Expr\ConstFetch by the parser and I can't find a way to
-		// get it as a bool, only as a string. So to support booleans in the .neon config file we have to convert to a string manually.
-		if (is_bool($value)) {
-			return $this->isDisallowedParam($value ? 'true' : 'false', $arg);
-		} else {
-			return ($value !== ($arg->value instanceof Scalar ? $arg->value->value : (string)$arg->value->name));
-		}
 	}
 
 }

--- a/src/DisallowedHelper.php
+++ b/src/DisallowedHelper.php
@@ -24,7 +24,7 @@ class DisallowedHelper
 	/**
 	 * @param Scope $scope
 	 * @param Arg[] $args
-	 * @param string[] $config
+	 * @param array{function?:string, method?:string, message?:string, allowIn?:string[], allowParamsInAllowed?:array<integer, integer|boolean|string>} $config
 	 * @return boolean
 	 */
 	public function isAllowed(Scope $scope, array $args, array $config): bool
@@ -41,7 +41,7 @@ class DisallowedHelper
 	/**
 	 * @param Scope $scope
 	 * @param Arg[] $args
-	 * @param string[] $config
+	 * @param array{function?:string, method?:string, message?:string, allowIn?:string[], allowParamsInAllowed?:array<integer, integer|boolean|string>} $config
 	 * @param string $configKey
 	 * @param boolean $default
 	 * @return boolean

--- a/src/FunctionCalls.php
+++ b/src/FunctionCalls.php
@@ -12,7 +12,8 @@ use PHPStan\Rules\Rule;
 /**
  * Reports on dynamically calling a disallowed function.
  *
- * @package spaze\PHPStan\Rules\Disallowed
+ * @package Spaze\PHPStan\Rules\Disallowed
+ * @implements Rule<FuncCall>
  */
 class FunctionCalls implements Rule
 {
@@ -20,10 +21,14 @@ class FunctionCalls implements Rule
 	/** @var DisallowedHelper */
 	private $disallowedHelper;
 
-	/** @var string[][] */
+	/** @var array{function?:string, method?:string, message?:string, allowIn?:string[], allowParamsInAllowed?:array<integer, integer|boolean|string>}[] */
 	private $forbiddenCalls;
 
 
+	/**
+	 * @param DisallowedHelper $disallowedHelper
+	 * @param array{function?:string, method?:string, message?:string, allowIn?:string[], allowParamsInAllowed?:array<integer, integer|boolean|string>}[] $forbiddenCalls
+	 */
 	public function __construct(DisallowedHelper $disallowedHelper, array $forbiddenCalls)
 	{
 		$this->disallowedHelper = $disallowedHelper;

--- a/src/FunctionCalls.php
+++ b/src/FunctionCalls.php
@@ -22,18 +22,18 @@ class FunctionCalls implements Rule
 	/** @var DisallowedHelper */
 	private $disallowedHelper;
 
-	/** @var array{function?:string, method?:string, message?:string, allowIn?:string[], allowParamsInAllowed?:array<integer, integer|boolean|string>}[] */
-	private $forbiddenCalls;
+	/** @var DisallowedCall[] */
+	private $disallowedCalls;
 
 
 	/**
 	 * @param DisallowedHelper $disallowedHelper
-	 * @param array{function?:string, method?:string, message?:string, allowIn?:string[], allowParamsInAllowed?:array<integer, integer|boolean|string>}[] $forbiddenCalls
+	 * @param array<array{function?:string, method?:string, message?:string, allowIn?:string[], allowParamsInAllowed?:array<integer, integer|boolean|string>, allowParamsAnywhere?:array<integer, integer|boolean|string>}> $forbiddenCalls
 	 */
 	public function __construct(DisallowedHelper $disallowedHelper, array $forbiddenCalls)
 	{
 		$this->disallowedHelper = $disallowedHelper;
-		$this->forbiddenCalls = $forbiddenCalls;
+		$this->disallowedCalls = $this->disallowedHelper->createCallsFromConfig($forbiddenCalls);
 	}
 
 
@@ -55,19 +55,7 @@ class FunctionCalls implements Rule
 		if (!($node->name instanceof Name)) {
 			return [];
 		}
-
-		$name = $node->name . '()';
-		foreach ($this->forbiddenCalls as $forbiddenCall) {
-			if (!isset($forbiddenCall['function'])) {
-				throw new ShouldNotHappenException("Key 'function' missing in disallowedFunctionCalls configuration");
-			}
-			if ($name === $forbiddenCall['function'] && !$this->disallowedHelper->isAllowed($scope, $node->args, $forbiddenCall)) {
-				return [
-					sprintf('Calling %s is forbidden, %s', $name, $forbiddenCall['message'] ?? 'because reasons'),
-				];
-			}
-		}
-
-		return [];
+		return $this->disallowedHelper->getDisallowedMessage($node, $scope, $node->name . '()', $this->disallowedCalls);
 	}
+
 }

--- a/src/FunctionCalls.php
+++ b/src/FunctionCalls.php
@@ -50,7 +50,7 @@ class FunctionCalls implements Rule
 
 		$name = $node->name . '()';
 		foreach ($this->forbiddenCalls as $forbiddenCall) {
-			if ($name === $forbiddenCall['function'] && !$this->disallowedHelper->isAllowed($scope->getFile(), $node->args, $forbiddenCall)) {
+			if ($name === $forbiddenCall['function'] && !$this->disallowedHelper->isAllowed($scope, $node->args, $forbiddenCall)) {
 				return [
 					sprintf('Calling %s is forbidden, %s', $name, $forbiddenCall['message'] ?? 'because reasons'),
 				];

--- a/src/MethodCalls.php
+++ b/src/MethodCalls.php
@@ -71,7 +71,7 @@ class MethodCalls implements Rule
 		foreach ($typeResult->getReferencedClasses() as $referencedClass) {
 			$fullyQualified = current($typeResult->getReferencedClasses()) . "::{$name}()";
 			foreach ($this->forbiddenCalls as $forbiddenCall) {
-				if ($fullyQualified === $forbiddenCall['method'] && !$this->disallowedHelper->isAllowed($scope->getFile(), $node->args, $forbiddenCall)) {
+				if ($fullyQualified === $forbiddenCall['method'] && !$this->disallowedHelper->isAllowed($scope, $node->args, $forbiddenCall)) {
 					return [
 						sprintf('Calling %s is forbidden, %s', $fullyQualified, $forbiddenCall['message'] ?? 'because reasons'),
 					];

--- a/src/MethodCalls.php
+++ b/src/MethodCalls.php
@@ -17,7 +17,8 @@ use PHPStan\Type\Type;
  *
  * Static calls have a different rule, <code>StaticCalls</code>
  *
- * @package spaze\PHPStan\Rules\Disallowed
+ * @package Spaze\PHPStan\Rules\Disallowed
+ * @implements Rule<MethodCall>
  */
 class MethodCalls implements Rule
 {
@@ -28,10 +29,15 @@ class MethodCalls implements Rule
 	/** @var DisallowedHelper */
 	private $disallowedHelper;
 
-	/** @var string[][] */
+	/** @var array{function?:string, method?:string, message?:string, allowIn?:string[], allowParamsInAllowed?:array<integer, integer|boolean|string>}[] */
 	private $forbiddenCalls;
 
 
+	/**
+	 * @param Broker $broker
+	 * @param DisallowedHelper $disallowedHelper
+	 * @param array{function?:string, method?:string, message?:string, allowIn?:string[], allowParamsInAllowed?:array<integer, integer|boolean|string>}[] $forbiddenCalls
+	 */
 	public function __construct(Broker $broker, DisallowedHelper $disallowedHelper, array $forbiddenCalls)
 	{
 		$this->ruleLevelHelper = new RuleLevelHelper($broker, true, false, true);

--- a/src/StaticCalls.php
+++ b/src/StaticCalls.php
@@ -54,7 +54,7 @@ class StaticCalls implements Rule
 		$name = $node->name->name;
 		$fullyQualified = "{$node->class}::{$name}()";
 		foreach ($this->forbiddenCalls as $forbiddenCall) {
-			if ($fullyQualified === $forbiddenCall['method'] && !$this->disallowedHelper->isAllowed($scope->getFile(), $node->args, $forbiddenCall)) {
+			if ($fullyQualified === $forbiddenCall['method'] && !$this->disallowedHelper->isAllowed($scope, $node->args, $forbiddenCall)) {
 				return [
 					sprintf('Calling %s is forbidden, %s', $fullyQualified, $forbiddenCall['message'] ?? 'because reasons'),
 				];

--- a/src/StaticCalls.php
+++ b/src/StaticCalls.php
@@ -14,7 +14,8 @@ use PHPStan\Rules\Rule;
  *
  * Dynamic calls have a different rule, <code>MethodCalls</code>
  *
- * @package spaze\PHPStan\Rules\Disallowed
+ * @package Spaze\PHPStan\Rules\Disallowed
+ * @implements Rule<StaticCall>
  */
 class StaticCalls implements Rule
 {
@@ -22,10 +23,14 @@ class StaticCalls implements Rule
 	/** @var DisallowedHelper */
 	private $disallowedHelper;
 
-	/** @var string[][] */
+	/** @var array{function?:string, method?:string, message?:string, allowIn?:string[], allowParamsInAllowed?:array<integer, integer|boolean|string>}[] */
 	private $forbiddenCalls;
 
 
+	/**
+	 * @param DisallowedHelper $disallowedHelper
+	 * @param array{function?:string, method?:string, message?:string, allowIn?:string[], allowParamsInAllowed?:array<integer, integer|boolean|string>}[] $forbiddenCalls
+	 */
 	public function __construct(DisallowedHelper $disallowedHelper, array $forbiddenCalls)
 	{
 		$this->disallowedHelper = $disallowedHelper;

--- a/tests/FunctionCallsTest.php
+++ b/tests/FunctionCallsTest.php
@@ -79,7 +79,7 @@ class FunctionCallsTest extends RuleTestCase
 			],
 			[
 				'Calling print_r() is forbidden, nope',
-				35,
+				39,
 			],
 		]);
 		$this->analyse([__DIR__ . '/data/disallowed-calls-allowed.php'], []);

--- a/tests/MethodCallsTest.php
+++ b/tests/MethodCallsTest.php
@@ -39,25 +39,25 @@ class MethodCallsTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/disallowed-calls.php'], [
 			[
 				"Calling Waldo\Quux\Blade::runner() is forbidden, I've seen tests you people wouldn't believe",
-				28,
+				32,
 			],
 			[
 				"Calling Waldo\Quux\Blade::runner() is forbidden, I've seen tests you people wouldn't believe",
-				30,
+				34,
 			],
 			[
 				"Calling Waldo\Quux\Blade::runner() is forbidden, I've seen tests you people wouldn't believe",
-				31,
+				35,
 			],
 		]);
 		$this->analyse([__DIR__ . '/data/disallowed-calls-allowed.php'], [
 			[
 				"Calling Waldo\Quux\Blade::runner() is forbidden, I've seen tests you people wouldn't believe",
-				29,
+				33,
 			],
 			[
 				"Calling Waldo\Quux\Blade::runner() is forbidden, I've seen tests you people wouldn't believe",
-				32,
+				36,
 			],
 		]);
 	}

--- a/tests/StaticCallsTest.php
+++ b/tests/StaticCallsTest.php
@@ -75,8 +75,21 @@ class StaticCallsTest extends RuleTestCase
 				'Calling Fiction\Pulp\Royale::withoutCheese() is forbidden, a Quarter Pounder without Cheese?',
 				21,
 			],
+			[
+				'Calling Fiction\Pulp\Royale::withoutCheese() is forbidden, a Quarter Pounder without Cheese?',
+				23,
+			],
+			[
+				'Calling Fiction\Pulp\Royale::withoutCheese() is forbidden, a Quarter Pounder without Cheese?',
+				26,
+			],
 		]);
-		$this->analyse([__DIR__ . '/data/disallowed-calls-allowed.php'], []);
+		$this->analyse([__DIR__ . '/data/disallowed-calls-allowed.php'], [
+			[
+				'Calling Fiction\Pulp\Royale::withoutCheese() is forbidden, a Quarter Pounder without Cheese?',
+				27,
+			],
+		]);
 	}
 
 }

--- a/tests/StaticCallsTest.php
+++ b/tests/StaticCallsTest.php
@@ -31,7 +31,7 @@ class StaticCallsTest extends RuleTestCase
 						'data/*-allowed.php',
 						'data/*-allowed.*',
 					],
-					'allowParamsInAllowed' => '',
+					'allowParamsInAllowed' => [],
 				],
 				[
 					'method' => 'Fiction\Pulp\Royale::withoutCheese()',

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,3 +3,4 @@ declare(strict_types = 1);
 
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/data/Blade.php';
+require_once __DIR__ . '/data/Royale.php';

--- a/tests/data/Royale.php
+++ b/tests/data/Royale.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types = 1);
+
+namespace Fiction\Pulp;
+
+class Royale
+{
+
+	public static function leBigMac(): void
+	{
+	}
+
+
+	public static function withCheese(): void
+	{
+	}
+
+
+	public static function withBadCheese(): void
+	{
+	}
+
+
+	public static function withoutCheese(int $patty, int $bun, int $tomato): void
+	{
+	}
+
+}

--- a/tests/data/disallowed-calls-allowed.php
+++ b/tests/data/disallowed-calls-allowed.php
@@ -20,7 +20,11 @@ Pulp\Royale::withCheese();
 Pulp\Royale::leBigMac();
 Pulp\Royale::withBadCheese();
 Pulp\Royale::withoutCheese(1, 2, 3);
+$a = 3;
+Pulp\Royale::withoutCheese(1, 2, $a);
 Pulp\Royale::withoutCheese(1, 2, 4);
+$a = 5;
+Pulp\Royale::withoutCheese(1, 2, $a);
 
 
 use Waldo\Quux;

--- a/tests/data/disallowed-calls.php
+++ b/tests/data/disallowed-calls.php
@@ -19,7 +19,11 @@ Pulp\Royale::withCheese();
 Pulp\Royale::leBigMac();
 Pulp\Royale::withBadCheese();
 Pulp\Royale::withoutCheese(1, 2, 3);
+$a = 3;
+Pulp\Royale::withoutCheese(1, 2, $a);
 Pulp\Royale::withoutCheese(1, 2, 4);
+$a = 5;
+Pulp\Royale::withoutCheese(1, 2, $a);
 
 
 use Waldo\Quux;


### PR DESCRIPTION
A few internal changes (no new features or userland changes):
- Use PHPStan's `Scope` (i.e. `MutatingScope`) class to get function param values
- Use array of data objects (`DisallowedCall[]`) to store config instead of config arrays

All this to get PHPStan's level to
![Over_9000!](https://user-images.githubusercontent.com/1966648/91676268-8c727600-eb3f-11ea-901e-8db63178ad98.png)

(It's actually only *8*, the current *max*, plus *Bleeding edge* rules)