### PR TITLE
Method calls from child class are not detected

### DIFF
--- a/src/DisallowedHelper.php
+++ b/src/DisallowedHelper.php
@@ -5,13 +5,20 @@ namespace Spaze\PHPStan\Rules\Disallowed;
 
 use PhpParser\Node;
 use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
+use PHPStan\Broker\ClassNotFoundException;
 use PHPStan\File\FileHelper;
+use PHPStan\Reflection\MethodReflection;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\ConstantScalarType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\TypeWithClassName;
 
 class DisallowedHelper
 {
@@ -74,6 +81,7 @@ class DisallowedHelper
 	/**
 	 * @param array<array{function?:string, method?:string, message?:string, allowIn?:string[], allowParamsInAllowed?:array<integer, integer|boolean|string>, allowParamsAnywhere?:array<integer, integer|boolean|string>}> $config
 	 * @return DisallowedCall[]
+	 * @throws ShouldNotHappenException
 	 */
 	public function createCallsFromConfig(array $config): array
 	{
@@ -99,19 +107,60 @@ class DisallowedHelper
 	 * @param FuncCall|MethodCall|StaticCall $node
 	 * @param Scope $scope
 	 * @param string $name
+	 * @param string|null $displayName
 	 * @param DisallowedCall[] $disallowedCalls
 	 * @return string[]
 	 */
-	public function getDisallowedMessage(Node $node, Scope $scope, string $name, array $disallowedCalls): array
+	public function getDisallowedMessage(Node $node, Scope $scope, string $name, ?string $displayName, array $disallowedCalls): array
 	{
 		foreach ($disallowedCalls as $disallowedCall) {
 			if ($name === $disallowedCall->getCall() && !$this->isAllowed($scope, $node->args, $disallowedCall)) {
+				$call = ($displayName && $displayName !== $name ? "{$name} (as {$displayName})" : $name);
 				return [
-					sprintf('Calling %s is forbidden, %s', $name, $disallowedCall->getMessage()),
+					sprintf('Calling %s is forbidden, %s', $call, $disallowedCall->getMessage()),
 				];
 			}
 		}
 		return [];
+	}
+
+
+	/**
+	 * @param Name|Expr $class
+	 * @param Node $node
+	 * @param Scope $scope
+	 * @param DisallowedCall[] $disallowedCalls
+	 * @return string[]
+	 * @throws ClassNotFoundException
+	 */
+	public function getDisallowedMethodMessage($class, Node $node, Scope $scope, array $disallowedCalls): array
+	{
+		/** @var MethodCall|StaticCall $node */
+		if (!($node->name instanceof Identifier)) {
+			return [];
+		}
+
+		if ($class instanceof Name) {
+			$calledOnType = new ObjectType($scope->resolveName($class));
+		} else {
+			$calledOnType = $scope->getType($class);
+		}
+
+		if ($calledOnType->canCallMethods()->yes() && $calledOnType->hasMethod($node->name->name)->yes()) {
+			$method = $calledOnType->getMethod($node->name->name, $scope);
+			$declaredAs = $this->getFullyQualified($method->getDeclaringClass()->getDisplayName(), $method);
+			$calledAs = ($calledOnType instanceof TypeWithClassName ? $this->getFullyQualified($calledOnType->getClassName(), $method) : null);
+		} else {
+			return [];
+		}
+
+		return $this->getDisallowedMessage($node, $scope, $declaredAs, $calledAs, $disallowedCalls);
+	}
+
+
+	private function getFullyQualified(string $class, MethodReflection $method): string
+	{
+		return sprintf('%s::%s()', $class, $method->getName());
 	}
 
 }

--- a/src/FunctionCalls.php
+++ b/src/FunctionCalls.php
@@ -29,6 +29,7 @@ class FunctionCalls implements Rule
 	/**
 	 * @param DisallowedHelper $disallowedHelper
 	 * @param array<array{function?:string, method?:string, message?:string, allowIn?:string[], allowParamsInAllowed?:array<integer, integer|boolean|string>, allowParamsAnywhere?:array<integer, integer|boolean|string>}> $forbiddenCalls
+	 * @throws ShouldNotHappenException
 	 */
 	public function __construct(DisallowedHelper $disallowedHelper, array $forbiddenCalls)
 	{
@@ -47,7 +48,6 @@ class FunctionCalls implements Rule
 	 * @param Node $node
 	 * @param Scope $scope
 	 * @return string[]
-	 * @throws ShouldNotHappenException
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{
@@ -55,7 +55,7 @@ class FunctionCalls implements Rule
 		if (!($node->name instanceof Name)) {
 			return [];
 		}
-		return $this->disallowedHelper->getDisallowedMessage($node, $scope, $node->name . '()', $this->disallowedCalls);
+		return $this->disallowedHelper->getDisallowedMessage($node, $scope, $node->name . '()', null, $this->disallowedCalls);
 	}
 
 }

--- a/src/StaticCalls.php
+++ b/src/StaticCalls.php
@@ -4,15 +4,11 @@ declare(strict_types = 1);
 namespace Spaze\PHPStan\Rules\Disallowed;
 
 use PhpParser\Node;
-use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\StaticCall;
-use PhpParser\Node\Identifier;
-use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
 use PHPStan\Broker\ClassNotFoundException;
 use PHPStan\Rules\Rule;
 use PHPStan\ShouldNotHappenException;
-use PHPStan\Type\ObjectType;
 
 /**
  * Reports on statically calling a disallowed method or two.
@@ -35,6 +31,7 @@ class StaticCalls implements Rule
 	/**
 	 * @param DisallowedHelper $disallowedHelper
 	 * @param array<array{function?:string, method?:string, message?:string, allowIn?:string[], allowParamsInAllowed?:array<integer, integer|boolean|string>, allowParamsAnywhere?:array<integer, integer|boolean|string>}> $forbiddenCalls
+	 * @throws ShouldNotHappenException
 	 */
 	public function __construct(DisallowedHelper $disallowedHelper, array $forbiddenCalls)
 	{
@@ -53,45 +50,12 @@ class StaticCalls implements Rule
 	 * @param Node $node
 	 * @param Scope $scope
 	 * @return string[]
-	 * @throws ShouldNotHappenException
 	 * @throws ClassNotFoundException
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{
 		/** @var StaticCall $node */
-		if (!($node->name instanceof Identifier)) {
-			return [];
-		}
-
-		$fullyQualified = $this->getMethod($node->class, $node->name->name, $scope);
-		if (!$fullyQualified) {
-			return [];
-		}
-		return $this->disallowedHelper->getDisallowedMessage($node, $scope, $fullyQualified, $this->disallowedCalls);
-	}
-
-
-	/**
-	 * @param Name|Expr $class
-	 * @param string $methodName
-	 * @param Scope $scope
-	 * @return string|null
-	 * @throws ClassNotFoundException
-	 */
-	private function getMethod($class, string $methodName, Scope $scope): ?string
-	{
-		if ($class instanceof Name) {
-			$calledOnType = new ObjectType($scope->resolveName($class));
-		} else {
-			$calledOnType = $scope->getType($class);
-		}
-
-		if ($calledOnType->canCallMethods()->yes() && $calledOnType->hasMethod($methodName)->yes()) {
-			$method = $calledOnType->getMethod($methodName, $scope);
-			return sprintf('%s::%s()', $method->getDeclaringClass()->getDisplayName(), $method->getName());
-		}
-
-		return null;
+		return $this->disallowedHelper->getDisallowedMethodMessage($node->class, $node, $scope, $this->disallowedCalls);
 	}
 
 }

--- a/tests/MethodCallsTest.php
+++ b/tests/MethodCallsTest.php
@@ -13,7 +13,6 @@ class MethodCallsTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		return new MethodCalls(
-			$this->createBroker(),
 			new DisallowedHelper(new FileHelper(__DIR__)),
 			[
 				[
@@ -58,7 +57,7 @@ class MethodCallsTest extends RuleTestCase
 				36,
 			],
 			[
-				'Calling Inheritance\Sub::x() is forbidden, method Base::x() is dangerous',
+				'Calling Inheritance\Base::x() (as Inheritance\Sub::x()) is forbidden, method Base::x() is dangerous',
 				46,
 			],
 		]);

--- a/tests/MethodCallsTest.php
+++ b/tests/MethodCallsTest.php
@@ -29,6 +29,14 @@ class MethodCallsTest extends RuleTestCase
 						3 => '909',
 					],
 				],
+				[
+					'method' => 'Inheritance\Base::x()',
+					'message' => 'method Base::x() is dangerous',
+					'allowIn' => [
+						'data/*-allowed.php',
+						'data/*-allowed.*',
+					],
+				],
 			]
 		);
 	}
@@ -48,6 +56,10 @@ class MethodCallsTest extends RuleTestCase
 			[
 				"Calling Waldo\Quux\Blade::runner() is forbidden, I've seen tests you people wouldn't believe",
 				36,
+			],
+			[
+				'Calling Inheritance\Sub::x() is forbidden, method Base::x() is dangerous',
+				46,
 			],
 		]);
 		$this->analyse([__DIR__ . '/data/disallowed-calls-allowed.php'], [

--- a/tests/StaticCallsTest.php
+++ b/tests/StaticCallsTest.php
@@ -51,6 +51,14 @@ class StaticCallsTest extends RuleTestCase
 						3 => 4,
 					],
 				],
+				[
+					'method' => 'Inheritance\Base::woofer()',
+					'message' => 'method Base::woofer() is dangerous',
+					'allowIn' => [
+						'data/*-allowed.php',
+						'data/*-allowed.*',
+					],
+				],
 			]
 		);
 	}
@@ -82,6 +90,10 @@ class StaticCallsTest extends RuleTestCase
 			[
 				'Calling Fiction\Pulp\Royale::withoutCheese() is forbidden, a Quarter Pounder without Cheese?',
 				26,
+			],
+			[
+				'Calling Inheritance\Sub::woofer() is forbidden, method Base::woofer() is dangerous',
+				48,
 			],
 		]);
 		$this->analyse([__DIR__ . '/data/disallowed-calls-allowed.php'], [

--- a/tests/StaticCallsTest.php
+++ b/tests/StaticCallsTest.php
@@ -92,7 +92,7 @@ class StaticCallsTest extends RuleTestCase
 				26,
 			],
 			[
-				'Calling Inheritance\Sub::woofer() is forbidden, method Base::woofer() is dangerous',
+				'Calling Inheritance\Base::woofer() (as Inheritance\Sub::woofer()) is forbidden, method Base::woofer() is dangerous',
 				48,
 			],
 		]);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,3 +4,4 @@ declare(strict_types = 1);
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/data/Blade.php';
 require_once __DIR__ . '/data/Royale.php';
+require_once __DIR__ . '/data/Inheritance.php';

--- a/tests/data/Inheritance.php
+++ b/tests/data/Inheritance.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types = 1);
+
+namespace Inheritance;
+
+abstract class Base
+{
+
+	public function x(): void
+	{
+	}
+
+
+	public static function woofer(): void
+	{
+	}
+
+}
+
+
+final class Sub extends Base
+{
+}

--- a/tests/data/disallowed-calls-allowed.php
+++ b/tests/data/disallowed-calls-allowed.php
@@ -39,3 +39,11 @@ $blade->runner(42, true, '808');
 print_r('bar bar', true);
 print_r('bar bar baz', true, 303);
 print_r('bar bar was', false);
+
+
+use Inheritance\Sub;
+
+$sub = new Sub();
+$sub->x();
+
+Sub::woofer();

--- a/tests/data/disallowed-calls.php
+++ b/tests/data/disallowed-calls.php
@@ -38,3 +38,11 @@ $blade->runner(42, true, '808');
 print_r('bar bar', true);
 print_r('bar bar baz', true, 303);
 print_r('bar bar was', false);
+
+
+use Inheritance\Sub;
+
+$sub = new Sub();
+$sub->x();
+
+Sub::woofer();


### PR DESCRIPTION
Let's say I have code like this:

```php
abstract class A
{
	public function x(): void {}
}

final class B extends A
{
}

$b = new B();
$b->x();
```

And I want to disallow method `A::x()`. Currently this is not detected. Of course I don't want to list every class that extends A separately, someone could always implement a new one and forget to add it in the config.

I have no idea how to fix it but I'm trying to contribute by providing you with a failing test case.