### PR TITLE
Trait methods are not detected

### DIFF
--- a/src/DisallowedHelper.php
+++ b/src/DisallowedHelper.php
@@ -148,12 +148,22 @@ class DisallowedHelper
 
 		if ($calledOnType->canCallMethods()->yes() && $calledOnType->hasMethod($node->name->name)->yes()) {
 			$method = $calledOnType->getMethod($node->name->name, $scope);
-			$declaredAs = $this->getFullyQualified($method->getDeclaringClass()->getDisplayName(), $method);
 			$calledAs = ($calledOnType instanceof TypeWithClassName ? $this->getFullyQualified($calledOnType->getClassName(), $method) : null);
+
+			foreach ($method->getDeclaringClass()->getTraits() as $trait) {
+				if ($trait->hasMethod($method->getName())) {
+					$declaredAs = $this->getFullyQualified($trait->getDisplayName(), $method);
+					$message = $this->getDisallowedMessage($node, $scope, $declaredAs, $calledAs, $disallowedCalls);
+					if ($message) {
+						return $message;
+					}
+				}
+			}
 		} else {
 			return [];
 		}
 
+		$declaredAs = $this->getFullyQualified($method->getDeclaringClass()->getDisplayName(), $method);
 		return $this->getDisallowedMessage($node, $scope, $declaredAs, $calledAs, $disallowedCalls);
 	}
 

--- a/tests/MethodCallsTest.php
+++ b/tests/MethodCallsTest.php
@@ -36,6 +36,22 @@ class MethodCallsTest extends RuleTestCase
 						'data/*-allowed.*',
 					],
 				],
+				[
+					'method' => 'Traits\TestTrait::x()',
+					'message' => 'method TestTrait::x() is dangerous',
+					'allowIn' => [
+						'data/*-allowed.php',
+						'data/*-allowed.*',
+					],
+				],
+				[
+					'method' => 'Traits\AnotherTestClass::y()',
+					'message' => 'method AnotherTestClass::y() is dangerous',
+					'allowIn' => [
+						'data/*-allowed.php',
+						'data/*-allowed.*',
+					],
+				],
 			]
 		);
 	}
@@ -59,6 +75,14 @@ class MethodCallsTest extends RuleTestCase
 			[
 				'Calling Inheritance\Base::x() (as Inheritance\Sub::x()) is forbidden, method Base::x() is dangerous',
 				46,
+			],
+			[
+				'Calling Traits\TestTrait::x() (as Traits\TestClass::x()) is forbidden, method TestTrait::x() is dangerous',
+				55,
+			],
+			[
+				'Calling Traits\AnotherTestClass::y() is forbidden, method AnotherTestClass::y() is dangerous',
+				57,
 			],
 		]);
 		$this->analyse([__DIR__ . '/data/disallowed-calls-allowed.php'], [

--- a/tests/StaticCallsTest.php
+++ b/tests/StaticCallsTest.php
@@ -59,6 +59,22 @@ class StaticCallsTest extends RuleTestCase
 						'data/*-allowed.*',
 					],
 				],
+				[
+					'method' => 'Traits\TestTrait::z()',
+					'message' => 'method TestTrait::z() is dangerous',
+					'allowIn' => [
+						'data/*-allowed.php',
+						'data/*-allowed.*',
+					],
+				],
+				[
+					'method' => 'Traits\AnotherTestClass::zz()',
+					'message' => 'method AnotherTestClass::zz() is dangerous',
+					'allowIn' => [
+						'data/*-allowed.php',
+						'data/*-allowed.*',
+					],
+				],
 			]
 		);
 	}
@@ -94,6 +110,14 @@ class StaticCallsTest extends RuleTestCase
 			[
 				'Calling Inheritance\Base::woofer() (as Inheritance\Sub::woofer()) is forbidden, method Base::woofer() is dangerous',
 				48,
+			],
+			[
+				'Calling Traits\TestTrait::z() (as Traits\TestClass::z()) is forbidden, method TestTrait::z() is dangerous',
+				59,
+			],
+			[
+				'Calling Traits\AnotherTestClass::zz() is forbidden, method AnotherTestClass::zz() is dangerous',
+				60,
 			],
 		]);
 		$this->analyse([__DIR__ . '/data/disallowed-calls-allowed.php'], [

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,3 +5,4 @@ require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/data/Blade.php';
 require_once __DIR__ . '/data/Royale.php';
 require_once __DIR__ . '/data/Inheritance.php';
+require_once __DIR__ . '/data/Traits.php';

--- a/tests/data/Traits.php
+++ b/tests/data/Traits.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types = 1);
+
+namespace Traits;
+
+trait TestTrait
+{
+
+	public function x(): void
+	{
+	}
+
+
+	public function y(): void
+	{
+	}
+
+
+	public static function z(): void
+	{
+	}
+
+
+	public static function zz(): void
+	{
+	}
+
+}
+
+
+trait AnotherTrait
+{
+}
+
+
+final class TestClass
+{
+	use TestTrait;
+	use AnotherTrait;
+}
+
+
+final class AnotherTestClass
+{
+	use TestTrait;
+	use AnotherTrait;
+}

--- a/tests/data/disallowed-calls-allowed.php
+++ b/tests/data/disallowed-calls-allowed.php
@@ -47,3 +47,15 @@ $sub = new Sub();
 $sub->x();
 
 Sub::woofer();
+
+
+use Traits\TestClass;
+use Traits\AnotherTestClass;
+
+$testClass = new TestClass();
+$testClass->x();
+$testClassToo = new AnotherTestClass();
+$testClassToo->y();
+
+TestClass::z();
+AnotherTestClass::zz();

--- a/tests/data/disallowed-calls.php
+++ b/tests/data/disallowed-calls.php
@@ -46,3 +46,15 @@ $sub = new Sub();
 $sub->x();
 
 Sub::woofer();
+
+
+use Traits\TestClass;
+use Traits\AnotherTestClass;
+
+$testClass = new TestClass();
+$testClass->x();
+$testClassToo = new AnotherTestClass();
+$testClassToo->y();
+
+TestClass::z();
+AnotherTestClass::zz();


### PR DESCRIPTION
How about a test for traits this time? Turns out a method defined in a trait can't be disallowed neither by using the trait name nor the class name. In my opinion both should work.

This method might be helpful for implementation:
https://github.com/nette/utils/blob/960bc900bd8a97d89feb8cbd1ae332e34a8adac3/src/Utils/Reflection.php#L146 