### PR TITLE
Make parentheses optional in disallowed calls definition

### DIFF
--- a/src/DisallowedCall.php
+++ b/src/DisallowedCall.php
@@ -33,7 +33,7 @@ class DisallowedCall
 	 */
 	public function __construct(string $call, ?string $message, array $allowIn, array $allowParamsInAllowed, array $allowParamsAnywhere)
 	{
-		$this->call = $call;
+		$this->call = (substr($call, -2) === '()' ? $call : $call . '()');
 		$this->message = $message;
 		$this->allowIn = $allowIn;
 		$this->allowParamsInAllowed = $allowParamsInAllowed;

--- a/tests/FunctionCallsTest.php
+++ b/tests/FunctionCallsTest.php
@@ -35,7 +35,7 @@ class FunctionCallsTest extends RuleTestCase
 					]
 				],
 				[
-					'function' => 'printf()',
+					'function' => 'printf',
 					'allowIn' => [
 						'src/disallowed-allowed/*.php',
 						'src/*-allow/*.*',

--- a/tests/MethodCallsTest.php
+++ b/tests/MethodCallsTest.php
@@ -37,7 +37,7 @@ class MethodCallsTest extends RuleTestCase
 					],
 				],
 				[
-					'method' => 'Traits\TestTrait::x()',
+					'method' => 'Traits\TestTrait::x',
 					'message' => 'method TestTrait::x() is dangerous',
 					'allowIn' => [
 						'src/disallowed-allowed/*.php',

--- a/tests/StaticCallsTest.php
+++ b/tests/StaticCallsTest.php
@@ -34,7 +34,7 @@ class StaticCallsTest extends RuleTestCase
 					'allowParamsInAllowed' => [],
 				],
 				[
-					'method' => 'Fiction\Pulp\Royale::withoutCheese()',
+					'method' => 'Fiction\Pulp\Royale::withoutCheese',
 					'message' => 'a Quarter Pounder without Cheese?',
 					'allowIn' => [
 						'src/disallowed-allowed/*.php',


### PR DESCRIPTION
Fix #33