### PR TITLE
More dangerous calls in predefined config files

### DIFF
--- a/disallowed-dangerous-calls.neon
+++ b/disallowed-dangerous-calls.neon
@@ -1,16 +1,55 @@
 parameters:
 	disallowedFunctionCalls:
 		-
+			function: 'apache_setenv()'
+			message: 'might overwrite existing variables'
+		-
+			function: 'dl()'
+			message: 'removed from most SAPIs, might load untrusted code'
+		-
 			function: 'eval()'
 			message: 'eval is evil, please write more code and do not use eval()'
 		-
 			function: 'extract()'
 			message: 'do not use extract() and especially not on untrusted data'
 		-
+			function: 'posix_getpwuid()'
+			message: 'might reveal system user information'
+		-
+			function: 'posix_kill()'
+			message: 'do not send signals to processes from the script'
+		-
+			function: 'posix_mkfifo()'
+			message: 'do not create named pipes in the script'
+		-
+			function: 'posix_mknod()'
+			message: 'do not create special files in the script'
+		-
+			function: 'highlight_file()'
+			message: 'might reveal source code or config files'
+		-
+			function: 'show_source()'
+			message: 'might reveal source code or config files (alias of highlight_file())'
+		-
+			function: 'pfsockopen()'
+			message: 'use fsockopen() to create non-persistent socket connections'
+		-
 			function: 'print_r()'
 			message: 'use some logger instead'
 			allowParamsAnywhere:
 				2: true
+		-
+			function: 'proc_nice()'
+			message: 'changes the priority of the current process'
+		-
+			function: 'putenv()'
+			message: 'might overwrite existing variables'
+		-
+			function: 'socket_create_listen()'
+			message: 'do not accept new socket connections in the PHP script'
+		-
+			function: 'socket_listen()'
+			message: 'do not accept new socket connections in the PHP script'
 		-
 			function: 'var_dump()'
 			message: 'use some logger instead'

--- a/disallowed-execution-calls.neon
+++ b/disallowed-execution-calls.neon
@@ -14,3 +14,5 @@ parameters:
 		# Other functions
 		-
 			function: 'pcntl_exec()'
+		-
+			function: 'popen()'


### PR DESCRIPTION
New in `disallowed-dangerous-calls.neon`:
- `apache_setenv()`
- `dl()`
- `posix_getpwuid()`
- `posix_kill()`
- `posix_mkfifo()`
- `posix_mknod()`
- `highlight_file()` with its alias `show_source()`
- `pfsockopen()`
- `proc_nice()`
- `putenv()`
- `socket_create_listen()`
- `socket_listen()`

New in `disallowed-execution-calls.neon`:
- `popen()`