### PR TITLE
Detect eval()

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -45,6 +45,10 @@ services:
 		tags:
 			- phpstan.rules.rule
 	-
+		factory: Spaze\PHPStan\Rules\Disallowed\EvalCalls(forbiddenCalls: %disallowedFunctionCalls%)
+		tags:
+			- phpstan.rules.rule
+	-
 		factory: Spaze\PHPStan\Rules\Disallowed\FunctionCalls(forbiddenCalls: %disallowedFunctionCalls%)
 		tags:
 			- phpstan.rules.rule

--- a/src/EvalCalls.php
+++ b/src/EvalCalls.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Rules\Disallowed;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Eval_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\ShouldNotHappenException;
+
+/**
+ * Reports on dynamically calling eval().
+ *
+ * @package Spaze\PHPStan\Rules\Disallowed
+ * @implements Rule<Eval_>
+ */
+class EvalCalls implements Rule
+{
+
+	/** @var DisallowedHelper */
+	private $disallowedHelper;
+
+	/** @var DisallowedCall[] */
+	private $disallowedCalls;
+
+
+	/**
+	 * @param DisallowedHelper $disallowedHelper
+	 * @param array<array{function?:string, method?:string, message?:string, allowIn?:string[], allowParamsInAllowed?:array<integer, integer|boolean|string>, allowParamsAnywhere?:array<integer, integer|boolean|string>}> $forbiddenCalls
+	 * @throws ShouldNotHappenException
+	 */
+	public function __construct(DisallowedHelper $disallowedHelper, array $forbiddenCalls)
+	{
+		$this->disallowedHelper = $disallowedHelper;
+		$this->disallowedCalls = $this->disallowedHelper->createCallsFromConfig($forbiddenCalls);
+	}
+
+
+	public function getNodeType(): string
+	{
+		return Eval_::class;
+	}
+
+
+	/**
+	 * @param Node $node
+	 * @param Scope $scope
+	 * @return string[]
+	 */
+	public function processNode(Node $node, Scope $scope): array
+	{
+		return $this->disallowedHelper->getDisallowedMessage(null, $scope, 'eval', 'eval', $this->disallowedCalls);
+	}
+
+}

--- a/tests/EvalCallsTest.php
+++ b/tests/EvalCallsTest.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Rules\Disallowed;
+
+use PHPStan\File\FileHelper;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+class EvalCallsTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new EvalCalls(
+			new DisallowedHelper(new FileHelper(__DIR__)),
+			[
+				[
+					'function' => 'eval()',
+					'allowIn' => [
+						'src/disallowed-allowed/*.php',
+						'src/*-allow/*.*',
+					],
+				],
+			]
+		);
+	}
+
+
+	public function testRule(): void
+	{
+		// Based on the configuration above, in this file:
+		$this->analyse([__DIR__ . '/src/disallowed/functionCalls.php'], [
+			[
+				'Calling eval() is forbidden, because reasons',
+				28,
+			],
+		]);
+		// Based on the configuration above, no errors in this file:
+		$this->analyse([__DIR__ . '/src/disallowed-allow/functionCalls.php'], []);
+	}
+
+}

--- a/tests/src/disallowed-allow/functionCalls.php
+++ b/tests/src/disallowed-allow/functionCalls.php
@@ -23,3 +23,6 @@ print_r('bar bar baz', true, 303);
 
 // allowed by path
 print_r('bar bar was', false);
+
+// a language construct, allowed by path
+eval('$foo="bar";');

--- a/tests/src/disallowed/functionCalls.php
+++ b/tests/src/disallowed/functionCalls.php
@@ -23,3 +23,6 @@ print_r('bar bar baz', true, 303);
 
 // disallowed, param #2 is not true
 print_r('bar bar was', false);
+
+// a disallowed language construct
+eval('$foo="bar";');


### PR DESCRIPTION
`eval()` is not a function but a language construct so it wasn't detected in `FunctionCalls`. You still define the disallowed call in `disallowedFunctionCalls` config key though.