### PR TITLE
Detect constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ The wildcard must be the leftmost character of the function or method name, opti
 
 You can treat `eval()` as a function (although it's a language construct) and disallow it in `disallowedFunctionCalls`.
 
+To disallow naive object creation (`new ClassName()`), disallow `NameSpace\ClassName::__construct` in `disallowedMethodCalls`. Works even when there's no constructor defined in that class.
+
 ## Example output
 
 ```

--- a/src/NewCalls.php
+++ b/src/NewCalls.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Rules\Disallowed;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\ShouldNotHappenException;
+
+/**
+ * Reports on creating objects (calling constructors).
+ *
+ * @package Spaze\PHPStan\Rules\Disallowed
+ * @implements Rule<New_>
+ */
+class NewCalls implements Rule
+{
+
+	/** @var DisallowedHelper */
+	private $disallowedHelper;
+
+	/** @var DisallowedCall[] */
+	private $disallowedCalls;
+
+
+	/**
+	 * @param DisallowedHelper $disallowedHelper
+	 * @param array<array{function?:string, method?:string, message?:string, allowIn?:string[], allowParamsInAllowed?:array<integer, integer|boolean|string>, allowParamsAnywhere?:array<integer, integer|boolean|string>}> $forbiddenCalls
+	 * @throws ShouldNotHappenException
+	 */
+	public function __construct(DisallowedHelper $disallowedHelper, array $forbiddenCalls)
+	{
+		$this->disallowedHelper = $disallowedHelper;
+		$this->disallowedCalls = $this->disallowedHelper->createCallsFromConfig($forbiddenCalls);
+	}
+
+
+	public function getNodeType(): string
+	{
+		return New_::class;
+	}
+
+
+	/**
+	 * @param Node $node
+	 * @param Scope $scope
+	 * @return string[]
+	 */
+	public function processNode(Node $node, Scope $scope): array
+	{
+		/** @var New_ $node */
+		if (!($node->class instanceof Name)) {
+			return [];
+		}
+		$name = "{$node->class}::__construct";
+		return $this->disallowedHelper->getDisallowedMessage(null, $scope, $name, $name, $this->disallowedCalls);
+	}
+
+}

--- a/tests/MethodCallsTest.php
+++ b/tests/MethodCallsTest.php
@@ -52,22 +52,6 @@ class MethodCallsTest extends RuleTestCase
 						'src/*-allow/*.*',
 					],
 				],
-				[
-					'method' => 'Constructor\ClassWithConstructor::__construct()',
-					'message' => 'Class ClassWithConstructor should not be created',
-					'allowIn' => [
-						'data/*-allowed.php',
-						'data/*-allowed.*',
-					],
-				],
-				[
-					'method' => 'Constructor\ClassWithoutConstructor::__construct()',
-					'message' => 'Class ClassWithoutConstructor should not be created',
-					'allowIn' => [
-						'data/*-allowed.php',
-						'data/*-allowed.*',
-					],
-				],
 			]
 		);
 	}
@@ -81,49 +65,41 @@ class MethodCallsTest extends RuleTestCase
 				// expect this error message:
 				"Calling Waldo\Quux\Blade::runner() is forbidden, I've seen tests you people wouldn't believe [Waldo\Quux\Blade::runner() matches Waldo\Quux\Blade::run*()]",
 				// on this line:
-				9,
-			],
-			[
-				"Calling Waldo\Quux\Blade::runner() is forbidden, I've seen tests you people wouldn't believe [Waldo\Quux\Blade::runner() matches Waldo\Quux\Blade::run*()]",
 				10,
 			],
 			[
 				"Calling Waldo\Quux\Blade::runner() is forbidden, I've seen tests you people wouldn't believe [Waldo\Quux\Blade::runner() matches Waldo\Quux\Blade::run*()]",
-				13,
+				11,
+			],
+			[
+				"Calling Waldo\Quux\Blade::runner() is forbidden, I've seen tests you people wouldn't believe [Waldo\Quux\Blade::runner() matches Waldo\Quux\Blade::run*()]",
+				14,
 			],
 			[
 				'Calling Inheritance\Base::x() (as Inheritance\Sub::x()) is forbidden, Base::x*() methods are dangerous [Inheritance\Base::x() matches Inheritance\Base::x*()]',
-				21,
+				22,
 			],
 			[
 				'Calling Traits\TestTrait::x() (as Traits\TestClass::x()) is forbidden, all TestTrait methods are dangerous [Traits\TestTrait::x() matches Traits\TestTrait::*()]',
-				25,
+				26,
 			],
 			[
 				'Calling Traits\TestTrait::y() (as Traits\AnotherTestClass::y()) is forbidden, all TestTrait methods are dangerous [Traits\TestTrait::y() matches Traits\TestTrait::*()]',
-				27,
-			],
-			[
-				'Calling Traits\AnotherTestClass::zzTop() is forbidden, method AnotherTestClass::zzTop() is dangerous',
 				28,
 			],
 			[
-				'Calling Constructor\ClassWithConstructor::__construct() is forbidden, Class ClassWithConstructor should not be created',
-				66,
-			],
-			[
-				'Calling Constructor\ClassWithoutConstructor::__construct() is forbidden, Class ClassWithoutConstructor should not be created',
-				67,
+				'Calling Traits\AnotherTestClass::zzTop() is forbidden, method AnotherTestClass::zzTop() is dangerous',
+				29,
 			],
 		]);
 		$this->analyse([__DIR__ . '/src/disallowed-allow/methodCalls.php'], [
 			[
 				"Calling Waldo\Quux\Blade::runner() is forbidden, I've seen tests you people wouldn't believe [Waldo\Quux\Blade::runner() matches Waldo\Quux\Blade::run*()]",
-				9,
+				10,
 			],
 			[
 				"Calling Waldo\Quux\Blade::runner() is forbidden, I've seen tests you people wouldn't believe [Waldo\Quux\Blade::runner() matches Waldo\Quux\Blade::run*()]",
-				10,
+				11,
 			],
 		]);
 	}

--- a/tests/MethodCallsTest.php
+++ b/tests/MethodCallsTest.php
@@ -52,6 +52,22 @@ class MethodCallsTest extends RuleTestCase
 						'src/*-allow/*.*',
 					],
 				],
+				[
+					'method' => 'Constructor\ClassWithConstructor::__construct()',
+					'message' => 'Class ClassWithConstructor should not be created',
+					'allowIn' => [
+						'data/*-allowed.php',
+						'data/*-allowed.*',
+					],
+				],
+				[
+					'method' => 'Constructor\ClassWithoutConstructor::__construct()',
+					'message' => 'Class ClassWithoutConstructor should not be created',
+					'allowIn' => [
+						'data/*-allowed.php',
+						'data/*-allowed.*',
+					],
+				],
 			]
 		);
 	}
@@ -90,6 +106,14 @@ class MethodCallsTest extends RuleTestCase
 			[
 				'Calling Traits\AnotherTestClass::zzTop() is forbidden, method AnotherTestClass::zzTop() is dangerous',
 				28,
+			],
+			[
+				'Calling Constructor\ClassWithConstructor::__construct() is forbidden, Class ClassWithConstructor should not be created',
+				66,
+			],
+			[
+				'Calling Constructor\ClassWithoutConstructor::__construct() is forbidden, Class ClassWithoutConstructor should not be created',
+				67,
 			],
 		]);
 		$this->analyse([__DIR__ . '/src/disallowed-allow/methodCalls.php'], [

--- a/tests/NewCallsTest.php
+++ b/tests/NewCallsTest.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Rules\Disallowed;
+
+use PHPStan\File\FileHelper;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+class NewCallsTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new NewCalls(
+			new DisallowedHelper(new FileHelper(__DIR__)),
+			[
+				[
+					'method' => 'Constructor\ClassWithConstructor::__construct()',
+					'message' => 'class ClassWithConstructor should not be created',
+					'allowIn' => [
+						'data/*-allowed.php',
+						'data/*-allowed.*',
+					],
+				],
+				[
+					'method' => 'Constructor\ClassWithoutConstructor::__construct()',
+					'message' => 'class ClassWithoutConstructor should not be created',
+					'allowIn' => [
+						'data/*-allowed.php',
+						'data/*-allowed.*',
+					],
+				],
+			]
+		);
+	}
+
+
+	public function testRule(): void
+	{
+		// Based on the configuration above, in this file:
+		$this->analyse([__DIR__ . '/src/disallowed/methodCalls.php'], [
+			[
+				'Calling Constructor\ClassWithConstructor::__construct() is forbidden, class ClassWithConstructor should not be created',
+				32,
+			],
+			[
+				'Calling Constructor\ClassWithoutConstructor::__construct() is forbidden, class ClassWithoutConstructor should not be created',
+				34,
+			],
+		]);
+		// Based on the configuration above, no errors in this file:
+		$this->analyse([__DIR__ . '/src/disallowed-allow/functionCalls.php'], []);
+	}
+
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,3 +6,4 @@ require_once __DIR__ . '/libs/Blade.php';
 require_once __DIR__ . '/libs/Royale.php';
 require_once __DIR__ . '/libs/Inheritance.php';
 require_once __DIR__ . '/libs/Traits.php';
+require_once __DIR__ . '/libs/Constructor.php';

--- a/tests/libs/Constructor.php
+++ b/tests/libs/Constructor.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types = 1);
+
+namespace Constructor;
+
+class ClassWithConstructor
+{
+	public function __construct()
+	{
+	}
+}
+
+class ClassWithoutConstructor
+{
+}

--- a/tests/src/disallowed-allow/methodCalls.php
+++ b/tests/src/disallowed-allow/methodCalls.php
@@ -26,3 +26,10 @@ $testClass->x();
 $testClassToo = new Traits\AnotherTestClass();
 $testClassToo->y();
 $testClassToo->zzTop();
+
+// instantiation allowed by path
+use Constructor\ClassWithConstructor;
+use Constructor\ClassWithoutConstructor;
+
+new ClassWithConstructor();
+new ClassWithoutConstructor();

--- a/tests/src/disallowed-allow/methodCalls.php
+++ b/tests/src/disallowed-allow/methodCalls.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types = 1);
 
+use Constructor\ClassWithConstructor;
 use Waldo\Quux;
 
 $blade = new Quux\Blade();
@@ -27,9 +28,10 @@ $testClassToo = new Traits\AnotherTestClass();
 $testClassToo->y();
 $testClassToo->zzTop();
 
-// instantiation allowed by path
-use Constructor\ClassWithConstructor;
-use Constructor\ClassWithoutConstructor;
-
+// object creation allowed by path
 new ClassWithConstructor();
-new ClassWithoutConstructor();
+// phpcs:ignore PSR12.Classes.ClassInstantiation.MissingParentheses, SlevomatCodingStandard.ControlStructures.NewWithParentheses.MissingParentheses
+new Constructor\ClassWithoutConstructor;
+
+// allowed object creation
+new stdClass();

--- a/tests/src/disallowed/methodCalls.php
+++ b/tests/src/disallowed/methodCalls.php
@@ -26,3 +26,10 @@ $testClass->x();
 $testClassToo = new Traits\AnotherTestClass();
 $testClassToo->y();
 $testClassToo->zzTop();
+
+// disallowed instantiation
+use Constructor\ClassWithConstructor;
+use Constructor\ClassWithoutConstructor;
+
+new ClassWithConstructor();
+new ClassWithoutConstructor();

--- a/tests/src/disallowed/methodCalls.php
+++ b/tests/src/disallowed/methodCalls.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types = 1);
 
+use Constructor\ClassWithConstructor;
 use Waldo\Quux;
 
 $blade = new Quux\Blade();
@@ -27,9 +28,10 @@ $testClassToo = new Traits\AnotherTestClass();
 $testClassToo->y();
 $testClassToo->zzTop();
 
-// disallowed instantiation
-use Constructor\ClassWithConstructor;
-use Constructor\ClassWithoutConstructor;
-
+// disallowed object creation
 new ClassWithConstructor();
-new ClassWithoutConstructor();
+// phpcs:ignore PSR12.Classes.ClassInstantiation.MissingParentheses, SlevomatCodingStandard.ControlStructures.NewWithParentheses.MissingParentheses
+new Constructor\ClassWithoutConstructor;
+
+// allowed object creation
+new stdClass();


### PR DESCRIPTION
Can disallow object creation `new ClassName()`
Will not detect `$a = 'Foo'; new $a;` though.

Fix #30