### PR TITLE
Support leading backslash in namespaces in definitions

### DIFF
--- a/src/DisallowedCall.php
+++ b/src/DisallowedCall.php
@@ -33,7 +33,8 @@ class DisallowedCall
 	 */
 	public function __construct(string $call, ?string $message, array $allowIn, array $allowParamsInAllowed, array $allowParamsAnywhere)
 	{
-		$this->call = (substr($call, -2) === '()' ? substr($call, 0, -2) : $call);
+		$call = substr($call, -2) === '()' ? substr($call, 0, -2) : $call;
+		$this->call = ltrim($call, '\\');
 		$this->message = $message;
 		$this->allowIn = $allowIn;
 		$this->allowParamsInAllowed = $allowParamsInAllowed;

--- a/tests/FunctionCallsTest.php
+++ b/tests/FunctionCallsTest.php
@@ -16,7 +16,7 @@ class FunctionCallsTest extends RuleTestCase
 			new DisallowedHelper(new FileHelper(__DIR__)),
 			[
 				[
-					'function' => 'var_dump()',
+					'function' => '\var_dump()',
 					'message' => 'use logger instead',
 					'allowIn' => [
 						'src/disallowed-allowed/*.php',
@@ -42,7 +42,7 @@ class FunctionCallsTest extends RuleTestCase
 					],
 				],
 				[
-					'function' => 'Foo\Bar\waldo()',
+					'function' => '\Foo\Bar\waldo()',
 					'message' => 'whoa, a namespace',
 					'allowIn' => [
 						'src/disallowed-allowed/*.php',

--- a/tests/NewCallsTest.php
+++ b/tests/NewCallsTest.php
@@ -16,7 +16,7 @@ class NewCallsTest extends RuleTestCase
 			new DisallowedHelper(new FileHelper(__DIR__)),
 			[
 				[
-					'method' => 'Constructor\ClassWithConstructor::__construct()',
+					'method' => '\Constructor\ClassWithConstructor::__construct()',
 					'message' => 'class ClassWithConstructor should not be created',
 					'allowIn' => [
 						'data/*-allowed.php',

--- a/tests/StaticCallsTest.php
+++ b/tests/StaticCallsTest.php
@@ -25,7 +25,7 @@ class StaticCallsTest extends RuleTestCase
 					'allowParamsInAllowed' => [],
 				],
 				[
-					'method' => 'Fiction\Pulp\Royale::withBad*()',
+					'method' => '\Fiction\Pulp\Royale::withBad*()',
 					'message' => 'a Quarter Pounder with Cheese?',
 					'allowIn' => [
 						'src/disallowed-allowed/*.php',


### PR DESCRIPTION
Configuration can now contain leading backslashes in (root) namespaces like

```
method: '\Foo\Bar::baz()'
```

or

```
function: '\print_r()'
```
