### PR TITLE
Use direct PHP8 support in GitHub Actions' ubuntu-latest

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -22,11 +22,8 @@ jobs:
     - name: OS info
       run: cat /etc/os-release
 
-    - name: "Install PHP"
-      uses: shivammathur/setup-php@v2
-      with:
-        coverage: "none"
-        php-version: "${{ matrix.php-version }}"
+    - name: Set default PHP version
+      run: sudo update-alternatives --set php /usr/bin/php${{ matrix.php-version }}
 
     - name: PHP info
       run: |


### PR DESCRIPTION
Can be merged once *ubuntu-latest* supports PHP 8 directly.

Try re-running the jobs to see if that's the case already.

This reverts commit 1976e72c3bb39040c5edf046af7ab8244fff9e02.