### PR TITLE
Don't crash on $string::constant

### DIFF
--- a/src/ClassConstantUsages.php
+++ b/src/ClassConstantUsages.php
@@ -11,6 +11,7 @@ use PHPStan\Rules\Rule;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\TypeWithClassName;
+use PHPStan\Type\VerbosityLevel;
 
 /**
  * Reports on class constant usage.
@@ -68,10 +69,21 @@ class ClassConstantUsages implements Rule
 		}
 
 		$displayName = ($usedOnType instanceof TypeWithClassName ? $this->getFullyQualified($usedOnType->getClassName(), $constant) : null);
-		$className = ($usedOnType instanceof ConstantStringType
-			? ltrim($usedOnType->getValue(), '\\')
-			: $usedOnType->getConstant($constant)->getDeclaringClass()->getDisplayName()
-		);
+		if ($usedOnType instanceof ConstantStringType) {
+			$className = ltrim($usedOnType->getValue(), '\\');
+		} else {
+			if ($usedOnType->hasConstant($constant)->yes()) {
+				$className = $usedOnType->getConstant($constant)->getDeclaringClass()->getDisplayName();
+			} else {
+				return [
+					sprintf(
+						'Cannot access constant %s on %s',
+						$constant,
+						$usedOnType->describe(VerbosityLevel::getRecommendedLevelByType($usedOnType))
+					),
+				];
+			}
+		}
 		$constant = $this->getFullyQualified($className, $constant);
 
 		return $this->disallowedHelper->getDisallowedConstantMessage($constant, $scope, $displayName, $this->disallowedConstants);

--- a/tests/ClassConstantInvalidUsagesTest.php
+++ b/tests/ClassConstantInvalidUsagesTest.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Rules\Disallowed;
+
+use PHPStan\File\FileHelper;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+class ClassConstantInvalidUsagesTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new ClassConstantUsages(new DisallowedHelper(new FileHelper(__DIR__)), []);
+	}
+
+
+	public function testRule(): void
+	{
+		// Based on the configuration above, in this file:
+		$this->analyse([__DIR__ . '/src/invalid/constantUsages.php'], [
+			[
+				// expect this error message:
+				'Cannot access constant GLITTER on string',
+				// on this line:
+				6,
+			],
+			[
+				'Cannot access constant COOKIE on string',
+				10,
+			],
+			[
+				'Cannot access constant COOKIE on class-string',
+				14,
+			],
+		]);
+	}
+
+}

--- a/tests/src/invalid/constantUsages.php
+++ b/tests/src/invalid/constantUsages.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types = 1);
+
+// invalid type
+/** @var string $cBeams */
+$cBeams::GLITTER;
+
+/** @var string $monster */
+$monster = DateTime::class;
+$monster::COOKIE;
+
+/** @var class-string $monster */
+$monster = DateTime::class;
+$monster::COOKIE;


### PR DESCRIPTION
Unfortunately, some valid use cases are not supported yet and an error will be thrown for cases like

```php
/** @var string $monster */
$monster = DateTime::class;
$monster::COOKIE;
```

```php
/** @var class-string $monster */
$monster = DateTime::class;
$monster::COOKIE;
```

If you hit those errors, you need to add them to `ignoreErrors` in your `phpstan.neon` config file. I hope to resolve the issue in a future release, contributions welcome.

Fix #42