### PR TITLE
Allow param overwriting

### DIFF
--- a/src/DisallowedHelper.php
+++ b/src/DisallowedHelper.php
@@ -94,15 +94,16 @@ class DisallowedHelper
 			if (!$call) {
 				throw new ShouldNotHappenException("Either 'method' or 'function' must be set in configuration items");
 			}
-			$calls[] = new DisallowedCall(
+			$disallowedCall = new DisallowedCall(
 				$call,
 				$disallowedCall['message'] ?? null,
 				$disallowedCall['allowIn'] ?? [],
 				$disallowedCall['allowParamsInAllowed'] ?? [],
 				$disallowedCall['allowParamsAnywhere'] ?? []
 			);
+			$calls[$disallowedCall->getCall()] = $disallowedCall;
 		}
-		return $calls;
+		return array_values($calls);
 	}
 
 
@@ -119,13 +120,14 @@ class DisallowedHelper
 			if (!$constant) {
 				throw new ShouldNotHappenException("'constant' must be set in configuration items");
 			}
-			$constants[] = new DisallowedConstant(
+			$disallowedConstant = new DisallowedConstant(
 				$constant,
 				$disallowedConstant['message'] ?? null,
 				$disallowedConstant['allowIn'] ?? []
 			);
+			$constants[$disallowedConstant->getConstant()] = $disallowedConstant;
 		}
-		return $constants;
+		return array_values($constants);
 	}
 
 

--- a/tests/ClassConstantUsagesTest.php
+++ b/tests/ClassConstantUsagesTest.php
@@ -47,6 +47,11 @@ class ClassConstantUsagesTest extends RuleTestCase
 						'src/*-allow/*.*',
 					],
 				],
+				// test param overwriting
+				[
+					'constant' => 'Waldo\Quux\Blade::DECKARD',
+					'message' => 'maybe a replicant',
+				],
 				[
 					'constant' => 'Waldo\Quux\Blade::DECKARD',
 					'message' => 'maybe a replicant',

--- a/tests/FunctionCallsTest.php
+++ b/tests/FunctionCallsTest.php
@@ -56,6 +56,10 @@ class FunctionCallsTest extends RuleTestCase
 						'src/*-allow/*.*',
 					],
 				],
+				// test param overwriting
+				[
+					'function' => 'exe*()',
+				],
 				[
 					'function' => 'exe*()',
 					'allowIn' => [


### PR DESCRIPTION
You can now include the bundled config file and then allow some calls in your local config.

Can only overwrite calls or constants using the same config key (`function`, `method`, `constant`) as the original disallowed call.