### PR TITLE
Split class constant usage definition to class & constant keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ There are four different disallowed types (and configuration keys) that can be d
 1. `disallowedMethodCalls` - for detecting `$object->method()` calls
 2. `disallowedStaticCalls` - for static calls `Class::method()`
 3. `disallowedFunctionCalls` - for functions like `function()`
-4. `disallowedConstants` - for constants like `DateTime::ISO8601` or `DATE_ISO8601`
+4. `disallowedConstants` - for constants like `DATE_ISO8601` or `DateTime::ISO8601` (which needs to be split to `class: DateTime` & `constant: ISO8601` in the configuration, see below)
 
 Use them to add rules to your `phpstan.neon` config file. I like to use a separate file (`disallowed-calls.neon`) for these which I'll include later on in the main `phpstan.neon` config file. Here's an example, update to your needs:
 
@@ -104,11 +104,23 @@ parameters:
             constant: 'DATE_ISO8601'
             message: 'use DATE_ATOM instead'
         -
-            constant: 'DateTimeInterface::ISO8601'
+            class: 'DateTimeInterface'
+            constant: 'ISO8601'
             message: 'use DateTimeInterface::ATOM instead'
 ```
 
-The `message` key is optional. Functions and methods can be specified with or without `()`.
+The `message` key is optional. Functions and methods can be specified with or without `()`. Omitting `()` is not recommended though to avoid confusing method calls with class constants.
+
+Class constants have to be specified using two keys: `class` and `constant`:
+```neon
+parameters:
+    disallowedConstants:
+        -
+            class: 'DateTimeInterface'
+            constant: 'ISO8601'
+            message: 'use DateTimeInterface::ATOM instead'
+```
+Using the fully-qualified name would result in the constant being replaced with its actual value. Otherwise, the extension would see `constant: "Y-m-d\TH:i:sO"` instead of `constant: DateTimeInterface::ISO8601` for example.
 
 Use wildcard (`*`) to ignore all functions or methods starting with a prefix, for example:
 ```neon

--- a/src/ClassConstantUsages.php
+++ b/src/ClassConstantUsages.php
@@ -31,7 +31,7 @@ class ClassConstantUsages implements Rule
 
 	/**
 	 * @param DisallowedHelper $disallowedHelper
-	 * @param array<array{function?:string, method?:string, message?:string, allowIn?:string[]}> $disallowedConstants
+	 * @param array<array{class?:string, constant?:string, message?:string, allowIn?:string[]}> $disallowedConstants
 	 * @throws ShouldNotHappenException
 	 */
 	public function __construct(DisallowedHelper $disallowedHelper, array $disallowedConstants)

--- a/src/ConstantUsages.php
+++ b/src/ConstantUsages.php
@@ -27,7 +27,7 @@ class ConstantUsages implements Rule
 
 	/**
 	 * @param DisallowedHelper $disallowedHelper
-	 * @param array<array{function?:string, method?:string, message?:string, allowIn?:string[]}> $disallowedConstants
+	 * @param array<array{constant?:string, message?:string, allowIn?:string[]}> $disallowedConstants
 	 * @throws ShouldNotHappenException
 	 */
 	public function __construct(DisallowedHelper $disallowedHelper, array $disallowedConstants)

--- a/src/DisallowedHelper.php
+++ b/src/DisallowedHelper.php
@@ -108,7 +108,7 @@ class DisallowedHelper
 
 
 	/**
-	 * @param array<array{constant?:string, message?:string, allowIn?:string[]}> $config
+	 * @param array<array{class?:string, constant?:string, message?:string, allowIn?:string[]}> $config
 	 * @return DisallowedConstant[]
 	 * @throws ShouldNotHappenException
 	 */
@@ -120,8 +120,9 @@ class DisallowedHelper
 			if (!$constant) {
 				throw new ShouldNotHappenException("'constant' must be set in configuration items");
 			}
+			$class = $disallowedConstant['class'] ?? null;
 			$disallowedConstant = new DisallowedConstant(
-				$constant,
+				$class ? "{$class}::{$constant}" : $constant,
 				$disallowedConstant['message'] ?? null,
 				$disallowedConstant['allowIn'] ?? []
 			);

--- a/tests/ClassConstantUsagesTest.php
+++ b/tests/ClassConstantUsagesTest.php
@@ -16,7 +16,8 @@ class ClassConstantUsagesTest extends RuleTestCase
 			new DisallowedHelper(new FileHelper(__DIR__)),
 			[
 				[
-					'constant' => '\Inheritance\Base::BELONG',
+					'class' => '\Inheritance\Base',
+					'constant' => 'BELONG',
 					'message' => 'belong to us',
 					'allowIn' => [
 						'src/disallowed-allowed/*.php',
@@ -24,7 +25,8 @@ class ClassConstantUsagesTest extends RuleTestCase
 					],
 				],
 				[
-					'constant' => 'Inheritance\Base::BELONG',
+					'class' => 'Inheritance\Base',
+					'constant' => 'BELONG',
 					'message' => 'belong to us',
 					'allowIn' => [
 						'src/disallowed-allowed/*.php',
@@ -32,7 +34,8 @@ class ClassConstantUsagesTest extends RuleTestCase
 					],
 				],
 				[
-					'constant' => '\Inheritance\Sub::BELONG',
+					'class' => '\Inheritance\Sub',
+					'constant' => 'BELONG',
 					'message' => 'belong to us',
 					'allowIn' => [
 						'src/disallowed-allowed/*.php',
@@ -40,7 +43,8 @@ class ClassConstantUsagesTest extends RuleTestCase
 					],
 				],
 				[
-					'constant' => 'Waldo\Quux\Blade::RUNNER',
+					'class' => 'Waldo\Quux\Blade',
+					'constant' => 'RUNNER',
 					'message' => 'not a replicant',
 					'allowIn' => [
 						'src/disallowed-allowed/*.php',
@@ -49,11 +53,13 @@ class ClassConstantUsagesTest extends RuleTestCase
 				],
 				// test param overwriting
 				[
-					'constant' => 'Waldo\Quux\Blade::DECKARD',
+					'class' => 'Waldo\Quux\Blade',
+					'constant' => 'DECKARD',
 					'message' => 'maybe a replicant',
 				],
 				[
-					'constant' => 'Waldo\Quux\Blade::DECKARD',
+					'class' => 'Waldo\Quux\Blade',
+					'constant' => 'DECKARD',
 					'message' => 'maybe a replicant',
 					'allowIn' => [
 						'src/disallowed-allowed/*.php',


### PR DESCRIPTION
Split class constant usage definition to class & constant keys to avoid replacing constant name with its actual value by Nette DI when used in services definitions.

Fix #48