### PR TITLE
Add support for disallowing namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,12 +67,13 @@ includes:
 
 ### Custom rules
 
-There are four different disallowed types (and configuration keys) that can be disallowed:
+There are five different disallowed types (and configuration keys) that can be disallowed:
 
 1. `disallowedMethodCalls` - for detecting `$object->method()` calls
 2. `disallowedStaticCalls` - for static calls `Class::method()`
 3. `disallowedFunctionCalls` - for functions like `function()`
 4. `disallowedConstants` - for constants like `DATE_ISO8601` or `DateTime::ISO8601` (which needs to be split to `class: DateTime` & `constant: ISO8601` in the configuration, see below)
+5. `disallowedNamespaces` - for usages of classes from a namespace
 
 Use them to add rules to your `phpstan.neon` config file. I like to use a separate file (`disallowed-calls.neon`) for these which I'll include later on in the main `phpstan.neon` config file. Here's an example, update to your needs:
 
@@ -107,6 +108,16 @@ parameters:
             class: 'DateTimeInterface'
             constant: 'ISO8601'
             message: 'use DateTimeInterface::ATOM instead'
+
+    disallowedNamespaces:
+        -
+            namespace: 'Symfony\Component\HttpFoundation\RequestStack'
+            message: 'pass Request via controller instead'
+            allowIn:
+                - tests/*
+        -
+            namespace: 'Assert\*'
+            message: 'use Webmozart\Assert instead'
 ```
 
 The `message` key is optional. Functions and methods can be specified with or without `()`. Omitting `()` is not recommended though to avoid confusing method calls with class constants.
@@ -122,7 +133,7 @@ parameters:
 ```
 Using the fully-qualified name would result in the constant being replaced with its actual value. Otherwise, the extension would see `constant: "Y-m-d\TH:i:sO"` instead of `constant: DateTimeInterface::ISO8601` for example.
 
-Use wildcard (`*`) to ignore all functions or methods starting with a prefix, for example:
+Use wildcard (`*`) to ignore all functions, methods, namespaces starting with a prefix, for example:
 ```neon
 parameters:
     disallowedFunctionCalls:

--- a/extension.neon
+++ b/extension.neon
@@ -1,4 +1,5 @@
 parameters:
+	disallowedNamespaces: []
 	disallowedMethodCalls: []
 	disallowedStaticCalls: []
 	disallowedFunctionCalls: []
@@ -7,6 +8,15 @@ parameters:
 parametersSchema:
 	# These should be defined using `structure` with listed keys but it seems to me that PHPStan requires
 	# all keys to be present in a structure but `message`, `allowIn` & `allowParamsInAllowed` are optional.
+	disallowedNamespaces: listOf(
+		arrayOf(
+			anyOf(
+				string(),
+				listOf(string()),
+				arrayOf(anyOf(int(), string(), bool()))
+			)
+		)
+	)
 	disallowedMethodCalls: listOf(
 		arrayOf(
 			anyOf(
@@ -46,6 +56,11 @@ parametersSchema:
 
 services:
 	- Spaze\PHPStan\Rules\Disallowed\DisallowedHelper
+	- Spaze\PHPStan\Rules\Disallowed\DisallowedNamespaceHelper
+	-
+		factory: Spaze\PHPStan\Rules\Disallowed\NamespaceUsages(forbiddenNamespaces: %disallowedNamespaces%)
+		tags:
+			- phpstan.rules.rule
 	-
 		factory: Spaze\PHPStan\Rules\Disallowed\MethodCalls(forbiddenCalls: %disallowedMethodCalls%)
 		tags:

--- a/src/DisallowedNamespace.php
+++ b/src/DisallowedNamespace.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Rules\Disallowed;
+
+class DisallowedNamespace
+{
+
+	/** @var string */
+	private $namespace;
+
+	/** @var string|null */
+	private $message;
+
+	/** @var string[] */
+	private $allowIn;
+
+
+	/**
+	 * @param string $namespace
+	 * @param string|null $message
+	 * @param string[] $allowIn
+	 */
+	public function __construct(string $namespace, ?string $message, array $allowIn)
+	{
+		$this->namespace = ltrim($namespace, '\\');
+		$this->message = $message;
+		$this->allowIn = $allowIn;
+	}
+
+
+	public function getNamespace(): string
+	{
+		return $this->namespace;
+	}
+
+
+	public function getMessage(): string
+	{
+		return $this->message ?? 'because reasons';
+	}
+
+
+	/**
+	 * @return string[]
+	 */
+	public function getAllowIn(): array
+	{
+		return $this->allowIn;
+	}
+
+}

--- a/src/DisallowedNamespaceHelper.php
+++ b/src/DisallowedNamespaceHelper.php
@@ -1,0 +1,102 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Rules\Disallowed;
+
+use PHPStan\Analyser\Scope;
+use PHPStan\File\FileHelper;
+
+class DisallowedNamespaceHelper
+{
+
+	/** @var FileHelper */
+	private $fileHelper;
+
+
+	public function __construct(FileHelper $fileHelper)
+	{
+		$this->fileHelper = $fileHelper;
+	}
+
+
+	/**
+	 * @param Scope $scope
+	 * @param DisallowedNamespace $disallowedNamespace
+	 * @return boolean
+	 */
+	private function isAllowed(Scope $scope, DisallowedNamespace $disallowedNamespace): bool
+	{
+		foreach ($disallowedNamespace->getAllowIn() as $allowedPath) {
+			$match = fnmatch($this->fileHelper->absolutizePath($allowedPath), $scope->getFile());
+			if ($match) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+
+	/**
+	 * @param array<array{namespace:string, message?:string, allowIn?:string[], allowParamsInAllowed?:array<integer, integer|boolean|string>, allowParamsAnywhere?:array<integer, integer|boolean|string>}> $config
+	 * @return DisallowedNamespace[]
+	 */
+	public function createDisallowedNamespacesFromConfig(array $config): array
+	{
+		$disallowedNamespaces = [];
+		foreach ($config as $disallowed) {
+			$disallowed = new DisallowedNamespace(
+				$disallowed['namespace'],
+				$disallowed['message'] ?? null,
+				$disallowed['allowIn'] ?? []
+			);
+			$disallowedNamespaces[$disallowed->getNamespace()] = $disallowed;
+		}
+		return array_values($disallowedNamespaces);
+	}
+
+
+	/**
+	 * @param string $namespace
+	 * @param Scope $scope
+	 * @param DisallowedNamespace[] $disallowedNamespaces
+	 * @return string[]
+	 */
+	public function getDisallowedMessage(string $namespace, Scope $scope, array $disallowedNamespaces): array
+	{
+		foreach ($disallowedNamespaces as $disallowedNamespace) {
+			if ($this->isAllowed($scope, $disallowedNamespace)) {
+				continue;
+			}
+
+			if (!$this->matchesNamespace($disallowedNamespace->getNamespace(), $namespace)) {
+				continue;
+			}
+
+			return [
+				sprintf(
+					'Namespace %s is forbidden, %s%s',
+					$namespace,
+					$disallowedNamespace->getMessage(),
+					$disallowedNamespace->getNamespace() !== $namespace ? " [{$namespace} matches {$disallowedNamespace->getNamespace()}]" : ''
+				),
+			];
+		}
+
+		return [];
+	}
+
+
+	private function matchesNamespace(string $pattern, string $value): bool
+	{
+		if ($pattern === $value) {
+			return true;
+		}
+
+		if (fnmatch($pattern, $value, FNM_NOESCAPE)) {
+			return true;
+		}
+
+		return false;
+	}
+
+}

--- a/src/NamespaceUsages.php
+++ b/src/NamespaceUsages.php
@@ -1,0 +1,93 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Rules\Disallowed;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Name;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\TraitUse;
+use PhpParser\Node\Stmt\UseUse;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+
+/**
+ * @implements Rule<Node>
+ */
+class NamespaceUsages implements Rule
+{
+
+	/** @var DisallowedNamespaceHelper */
+	private $disallowedHelper;
+
+	/** @var DisallowedNamespace[] */
+	private $disallowedNamespace;
+
+
+	/**
+	 * @param DisallowedNamespaceHelper $disallowedNamespaceHelper
+	 * @param array<array{namespace:string, message?:string, allowIn?:string[]}> $forbiddenNamespaces
+	 */
+	public function __construct(DisallowedNamespaceHelper $disallowedNamespaceHelper, array $forbiddenNamespaces)
+	{
+		$this->disallowedHelper  = $disallowedNamespaceHelper;
+		$this->disallowedNamespace = $this->disallowedHelper->createDisallowedNamespacesFromConfig($forbiddenNamespaces);
+	}
+
+
+	public function getNodeType(): string
+	{
+		return Node::class;
+	}
+
+
+	/**
+	 * @param Node $node
+	 * @param Scope $scope
+	 * @return string[]
+	 */
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if ($node instanceof FullyQualified) {
+			$namespaces = [$node->toString()];
+		} elseif ($node instanceof UseUse) {
+			$namespaces = [$node->name->toString()];
+		} elseif ($node instanceof StaticCall && $node->class instanceof Name) {
+			$namespaces = [$node->class->toString()];
+		} elseif ($node instanceof ClassConstFetch && $node->class instanceof Name) {
+			$namespaces = [$node->class->toString()];
+		} elseif ($node instanceof Class_ && ($node->extends !== null || count($node->implements) > 0)) {
+			$namespaces = [];
+
+			if ($node->extends !== null) {
+				$namespaces[] = $node->extends->toString();
+			}
+
+			foreach ($node->implements as $implement) {
+				$namespaces[] = $implement->toString();
+			}
+		} elseif ($node instanceof TraitUse) {
+			$namespaces = [];
+
+			foreach ($node->traits as $trait) {
+				$namespaces[] = $trait->toString();
+			}
+		} else {
+			return [];
+		}
+
+		$errors = [];
+		foreach ($namespaces as $namespace) {
+			$errors = array_merge(
+				$errors,
+				$this->disallowedHelper->getDisallowedMessage(ltrim($namespace, '\\'), $scope, $this->disallowedNamespace)
+			);
+		}
+
+		return $errors;
+	}
+
+}

--- a/tests/NamespaceUsagesTest.php
+++ b/tests/NamespaceUsagesTest.php
@@ -1,0 +1,129 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Rules\Disallowed;
+
+use PHPStan\File\FileHelper;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+class NamespaceUsagesTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new NamespaceUsages(
+			new DisallowedNamespaceHelper(new FileHelper(__DIR__)),
+			[
+				[
+					'namespace' => 'Framew*rk\Some*',
+					'message' => 'no framework some',
+					'allowIn' => [
+						'src/disallowed-allowed/*.php',
+						'src/*-allow/*.*',
+					],
+				],
+				[
+					'namespace' => 'Inheritance\Base',
+					'message' => 'no inheritance Base',
+					'allowIn' => [
+						'src/disallowed-allowed/*.php',
+						'src/*-allow/*.*',
+					],
+				],
+				[
+					'namespace' => 'Inheritance\Sub',
+					'message' => 'no sub',
+					'allowIn' => [
+						'src/disallowed-allowed/*.php',
+						'src/*-allow/*.*',
+					],
+				],
+				[
+					'namespace' => 'Waldo\Quux\Blade',
+					'message' => 'no blade',
+					'allowIn' => [
+						'src/disallowed-allowed/*.php',
+						'src/*-allow/*.*',
+					],
+				],
+				[
+					'namespace' => 'Waldo\Foo\Bar',
+					'message' => 'no FooBar',
+					'allowIn' => [
+						'src/disallowed-allowed/*.php',
+						'src/*-allow/*.*',
+					],
+				],
+				[
+					'namespace' => 'Traits\TestTrait',
+					'message' => 'no TestTrait',
+					'allowIn' => [
+						'src/disallowed-allowed/*.php',
+						'src/*-allow/*.*',
+					],
+				],
+			]
+		);
+	}
+
+
+	public function testRule(): void
+	{
+		// Based on the configuration above, in this file:
+		$this->analyse([__DIR__ . '/src/disallowed/namespaceUsages.php'], [
+			[
+				// Based on the configuration above, in this file:
+				'Namespace Framework\SomeInterface is forbidden, no framework some [Framework\SomeInterface matches Framew*rk\Some*]',
+				// on this line:
+				6,
+			],
+			[
+				'Namespace Inheritance\Base is forbidden, no inheritance Base',
+				7,
+			],
+			[
+				'Namespace Inheritance\Sub is forbidden, no sub',
+				8,
+			],
+			[
+				'Namespace Traits\TestTrait is forbidden, no TestTrait',
+				9,
+			],
+			[
+				'Namespace Waldo\Quux\Blade is forbidden, no blade',
+				10,
+			],
+			[
+				'Namespace Waldo\Foo\Bar is forbidden, no FooBar',
+				11,
+			],
+			[
+				'Namespace Inheritance\Base is forbidden, no inheritance Base',
+				13,
+			],
+			[
+				'Namespace Framework\SomeInterface is forbidden, no framework some [Framework\SomeInterface matches Framew*rk\Some*]',
+				13,
+			],
+			[
+				'Namespace Traits\TestTrait is forbidden, no TestTrait',
+				17,
+			],
+			[
+				'Namespace Waldo\Quux\Blade is forbidden, no blade',
+				20,
+			],
+			[
+				'Namespace Inheritance\Sub is forbidden, no sub',
+				28,
+			],
+			[
+				'Namespace Waldo\Foo\Bar is forbidden, no FooBar',
+				34,
+			],
+		]);
+		$this->analyse([__DIR__ . '/src/disallowed-allow/namespaceUsages.php'], []);
+	}
+
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,9 +2,11 @@
 declare(strict_types = 1);
 
 require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/libs/Bar.php';
 require_once __DIR__ . '/libs/Blade.php';
-require_once __DIR__ . '/libs/Royale.php';
+require_once __DIR__ . '/libs/Constructor.php';
 require_once __DIR__ . '/libs/Inheritance.php';
+require_once __DIR__ . '/libs/Royale.php';
+require_once __DIR__ . '/libs/SomeInterface.php';
 require_once __DIR__ . '/libs/Option.php';
 require_once __DIR__ . '/libs/Traits.php';
-require_once __DIR__ . '/libs/Constructor.php';

--- a/tests/libs/Bar.php
+++ b/tests/libs/Bar.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types = 1);
+
+namespace Waldo\Foo;
+
+class Bar
+{
+
+	public const NAME = 'Bar';
+
+}

--- a/tests/libs/SomeInterface.php
+++ b/tests/libs/SomeInterface.php
@@ -1,0 +1,8 @@
+<?php
+declare(strict_types = 1);
+
+namespace Framework;
+
+interface SomeInterface
+{
+}

--- a/tests/src/disallowed-allow/namespaceUsages.php
+++ b/tests/src/disallowed-allow/namespaceUsages.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types = 1);
+
+namespace Whatever;
+
+use Framework\SomeInterface;
+use Inheritance\Base;
+use Inheritance\Sub;
+use Traits\TestTrait;
+use Waldo\Quux\Blade;
+use Waldo\Foo\Bar;
+
+class Service extends Base implements SomeInterface
+{
+	private $blade;
+
+	use TestTrait;
+
+
+	public function __construct(Blade $blade)
+	{
+		$this->blade = $blade;
+	}
+
+
+	public static function callSub()
+	{
+		Sub::woofer();
+	}
+
+
+	public function callConstant()
+	{
+		return Bar::NAME;
+	}
+
+}

--- a/tests/src/disallowed/namespaceUsages.php
+++ b/tests/src/disallowed/namespaceUsages.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types = 1);
+
+namespace Whatever;
+
+use Framework\SomeInterface;
+use Inheritance\Base;
+use Inheritance\Sub;
+use Traits\TestTrait;
+use Waldo\Quux\Blade;
+use Waldo\Foo\Bar;
+
+class Service extends Base implements SomeInterface
+{
+	private $blade;
+
+	use TestTrait;
+
+
+	public function __construct(Blade $blade)
+	{
+		$this->blade = $blade;
+	}
+
+
+	public static function callSub()
+	{
+		Sub::woofer();
+	}
+
+
+	public function callConstant()
+	{
+		return Bar::NAME;
+	}
+
+}


### PR DESCRIPTION
See #50 

Currently it only triggers on `FullyQualified` nodes. 

```neon
    disallowedNamespaces:
        -
            namespace: 'Symfony\Component\HttpFoundation\RequestStack'
            message: 'pass Request via controller instead'
            allowIn:
                - tests/*
        -
            namespace: 'Assert\*'
            message: 'use Webmozart\Assert instead'
```
