### PR TITLE
Use fnmatch for callMatches

### DIFF
--- a/src/DisallowedHelper.php
+++ b/src/DisallowedHelper.php
@@ -160,11 +160,15 @@ class DisallowedHelper
 
 	private function callMatches(DisallowedCall $disallowedCall, string $name): bool
 	{
-		if ($disallowedCall->getCall()[-1] === '*') {
-			return strpos($name, trim($disallowedCall->getCall(), '*')) === 0;
-		} else {
-			return $name === $disallowedCall->getCall();
+		if ($name === $disallowedCall->getCall()) {
+			return true;
 		}
+
+		if (fnmatch($disallowedCall->getCall(), $name)) {
+			return true;
+		}
+
+		return false;
 	}
 
 

--- a/src/DisallowedHelper.php
+++ b/src/DisallowedHelper.php
@@ -164,7 +164,7 @@ class DisallowedHelper
 			return true;
 		}
 
-		if (fnmatch($disallowedCall->getCall(), $name)) {
+		if (fnmatch($disallowedCall->getCall(), $name, FNM_NOESCAPE)) {
 			return true;
 		}
 

--- a/tests/StaticCallsTest.php
+++ b/tests/StaticCallsTest.php
@@ -25,7 +25,7 @@ class StaticCallsTest extends RuleTestCase
 					'allowParamsInAllowed' => [],
 				],
 				[
-					'method' => '\Fiction\Pulp\Royale::withBad*()',
+					'method' => '\Fiction\Pulp\*::withBad*()',
 					'message' => 'a Quarter Pounder with Cheese?',
 					'allowIn' => [
 						'src/disallowed-allowed/*.php',
@@ -52,7 +52,7 @@ class StaticCallsTest extends RuleTestCase
 					],
 				],
 				[
-					'method' => 'Inheritance\Base::woofer()',
+					'method' => 'Inheritance\Base::w*f*r()',
 					'message' => 'method Base::woofer() is dangerous',
 					'allowIn' => [
 						'src/disallowed-allowed/*.php',
@@ -95,7 +95,7 @@ class StaticCallsTest extends RuleTestCase
 				8,
 			],
 			[
-				'Calling Fiction\Pulp\Royale::withBadCheese() is forbidden, a Quarter Pounder with Cheese? [Fiction\Pulp\Royale::withBadCheese() matches Fiction\Pulp\Royale::withBad*()]',
+				'Calling Fiction\Pulp\Royale::withBadCheese() is forbidden, a Quarter Pounder with Cheese? [Fiction\Pulp\Royale::withBadCheese() matches Fiction\Pulp\*::withBad*()]',
 				9,
 			],
 			[
@@ -111,7 +111,7 @@ class StaticCallsTest extends RuleTestCase
 				18,
 			],
 			[
-				'Calling Inheritance\Base::woofer() (as Inheritance\Sub::woofer()) is forbidden, method Base::woofer() is dangerous',
+				'Calling Inheritance\Base::woofer() (as Inheritance\Sub::woofer()) is forbidden, method Base::woofer() is dangerous [Inheritance\Base::woofer() matches Inheritance\Base::w*f*r()]',
 				28,
 			],
 			[


### PR DESCRIPTION
I think it's good to always use `fnmatch` instead of doing strpos * trick.