### PR TITLE
Move phpunit.xml to project root

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,4 +4,5 @@
 .gitignore export-ignore
 phpcs.xml export-ignore
 phpstan.neon export-ignore
+phpunit.xml export-ignore
 tests/ export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /composer.lock
 /vendor
 /tests/tmp
-/tests/.phpunit.result.cache
+/.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
 		"phpcs": "vendor/bin/phpcs src/ tests/",
 		"cs-fix": "vendor/bin/phpcbf src/ tests/",
 		"phpstan-dev": "vendor/bin/phpstan --ansi analyse --configuration phpstan.neon",
-		"phpunit-dev": "vendor/bin/phpunit --configuration tests/phpunit.xml --colors=always tests/",
+		"phpunit-dev": "vendor/bin/phpunit --colors=always",
 		"test": [
 			"@lint",
 			"@phpcs",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -2,7 +2,7 @@
 <phpunit
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
-		bootstrap="bootstrap.php"
+		bootstrap="tests/bootstrap.php"
 		colors="true"
 		backupGlobals="false"
 		backupStaticAttributes="false"
@@ -15,11 +15,16 @@
 >
 	<coverage>
 		<include>
-			<directory suffix=".php">../src</directory>
+			<directory suffix=".php">src</directory>
 		</include>
 		<report>
 			<html outputDirectory="tmp/report" lowUpperBound="35" highLowerBound="70"/>
 		</report>
 	</coverage>
+	<testsuites>
+		<testsuite name="main">
+			<directory>tests</directory>
+		</testsuite>
+	</testsuites>
 	<logging/>
 </phpunit>


### PR DESCRIPTION
Because every time I run tests it creates .phpunit.result.cache in the root directory instead of tests. I have to remove it before I commit. Therefore this should be ignored throughout the whole project.