### PR TITLE
Support generic types

### DIFF
--- a/src/DisallowedHelper.php
+++ b/src/DisallowedHelper.php
@@ -205,7 +205,7 @@ class DisallowedHelper
 			return [];
 		}
 
-		$declaredAs = $this->getFullyQualified($method->getDeclaringClass()->getDisplayName(), $method);
+		$declaredAs = $this->getFullyQualified($method->getDeclaringClass()->getDisplayName(false), $method);
 		return $this->getDisallowedMessage($node, $scope, $declaredAs, $calledAs, $disallowedCalls);
 	}
 

--- a/tests/ClassConstantUsagesTest.php
+++ b/tests/ClassConstantUsagesTest.php
@@ -66,6 +66,15 @@ class ClassConstantUsagesTest extends RuleTestCase
 						'src/*-allow/*.*',
 					],
 				],
+				[
+					'class' => 'PhpOption\Option',
+					'constant' => 'NAME',
+					'message' => 'no PhpOption',
+					'allowIn' => [
+						'src/disallowed-allowed/*.php',
+						'src/*-allow/*.*',
+					],
+				],
 			]
 		);
 	}
@@ -104,6 +113,10 @@ class ClassConstantUsagesTest extends RuleTestCase
 			[
 				'Using Waldo\Quux\Blade::DECKARD is forbidden, maybe a replicant',
 				21,
+			],
+			[
+				'Using PhpOption\Option::NAME is forbidden, no PhpOption',
+				35,
 			],
 		]);
 		$this->analyse([__DIR__ . '/src/disallowed-allow/constantUsages.php'], []);

--- a/tests/MethodCallsTest.php
+++ b/tests/MethodCallsTest.php
@@ -52,6 +52,22 @@ class MethodCallsTest extends RuleTestCase
 						'src/*-allow/*.*',
 					],
 				],
+				[
+					'method' => 'PhpOption\None::getIterator()',
+					'message' => 'no PhpOption',
+					'allowIn' => [
+						'src/disallowed-allowed/*.php',
+						'src/*-allow/*.*',
+					],
+				],
+				[
+					'method' => 'PhpOption\Some::getIterator()',
+					'message' => 'no PhpOption',
+					'allowIn' => [
+						'src/disallowed-allowed/*.php',
+						'src/*-allow/*.*',
+					],
+				],
 			]
 		);
 	}
@@ -90,6 +106,14 @@ class MethodCallsTest extends RuleTestCase
 			[
 				'Calling Traits\AnotherTestClass::zzTop() is forbidden, method AnotherTestClass::zzTop() is dangerous',
 				29,
+			],
+			[
+				'Calling PhpOption\None::getIterator() is forbidden, no PhpOption',
+				46,
+			],
+			[
+				'Calling PhpOption\Some::getIterator() is forbidden, no PhpOption',
+				52,
 			],
 		]);
 		$this->analyse([__DIR__ . '/src/disallowed-allow/methodCalls.php'], [

--- a/tests/StaticCallsTest.php
+++ b/tests/StaticCallsTest.php
@@ -75,6 +75,30 @@ class StaticCallsTest extends RuleTestCase
 						'src/*-allow/*.*',
 					],
 				],
+				[
+					'method' => 'PhpOption\Option::*()',
+					'message' => 'do not use PhpOption',
+					'allowIn' => [
+						'src/disallowed-allowed/*.php',
+						'src/*-allow/*.*',
+					],
+				],
+				[
+					'method' => 'PhpOption\Some::create()',
+					'message' => 'do not use PhpOption',
+					'allowIn' => [
+						'src/disallowed-allowed/*.php',
+						'src/*-allow/*.*',
+					],
+				],
+				[
+					'method' => 'PhpOption\None::*()',
+					'message' => 'do not use PhpOption',
+					'allowIn' => [
+						'src/disallowed-allowed/*.php',
+						'src/*-allow/*.*',
+					],
+				],
 			]
 		);
 	}
@@ -121,6 +145,18 @@ class StaticCallsTest extends RuleTestCase
 			[
 				'Calling Traits\AnotherTestClass::zz() is forbidden, method AnotherTestClass::zz() is dangerous',
 				32,
+			],
+			[
+				'Calling PhpOption\Option::fromArraysValue() is forbidden, do not use PhpOption [PhpOption\Option::fromArraysValue() matches PhpOption\Option::*()]',
+				35,
+			],
+			[
+				'Calling PhpOption\None::create() is forbidden, do not use PhpOption [PhpOption\None::create() matches PhpOption\None::*()]',
+				36,
+			],
+			[
+				'Calling PhpOption\Some::create() is forbidden, do not use PhpOption',
+				37,
 			],
 		]);
 		$this->analyse([__DIR__ . '/src/disallowed-allow/staticCalls.php'], [

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,5 +5,6 @@ require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/libs/Blade.php';
 require_once __DIR__ . '/libs/Royale.php';
 require_once __DIR__ . '/libs/Inheritance.php';
+require_once __DIR__ . '/libs/Option.php';
 require_once __DIR__ . '/libs/Traits.php';
 require_once __DIR__ . '/libs/Constructor.php';

--- a/tests/libs/Option.php
+++ b/tests/libs/Option.php
@@ -1,0 +1,111 @@
+<?php
+declare(strict_types = 1);
+
+namespace PhpOption;
+
+use ArrayAccess;
+use EmptyIterator;
+use IteratorAggregate;
+use ArrayIterator;
+
+/**
+ * @template T
+ *
+ * @implements IteratorAggregate<T>
+ */
+abstract class Option implements IteratorAggregate
+{
+	public const NAME = 'Option';
+
+	/**
+	 * Creates an option from an array's value.
+	 *
+	 * If the key does not exist in the array, the array is not actually an
+	 * array, or the array's value at the given key is null, None is returned.
+	 * Otherwise, Some is returned wrapping the value at the given key.
+	 *
+	 * @template S
+	 *
+	 * @param array<string|int,S>|ArrayAccess<string|int,S>|null $array A potential array or \ArrayAccess value.
+	 * @param string                                             $key   The key to check.
+	 *
+	 * @return Option<S>
+	 */
+	public static function fromArraysValue($array, $key)
+	{
+		if (!(is_array($array) || $array instanceof ArrayAccess) || !isset($array[$key])) {
+			return None::create();
+		}
+
+		return new Some($array[$key]);
+	}
+}
+
+
+/**
+ * @extends Option<mixed>
+ */
+final class None extends Option
+{
+	/** @var None|null */
+	private static $instance;
+
+	/**
+	 * @return None
+	 */
+	public static function create()
+	{
+		if (null === self::$instance) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	public function getIterator()
+	{
+		return new EmptyIterator();
+	}
+}
+
+
+
+
+/**
+ * @template T
+ *
+ * @extends  Option<T>
+ */
+final class Some extends Option
+{
+	/** @var T */
+	private $value;
+
+
+	/**
+	 * @param T $value
+	 */
+	public function __construct($value)
+	{
+		$this->value = $value;
+	}
+
+
+	/**
+	 * @template U
+	 *
+	 * @param U $value
+	 *
+	 * @return Some<U>
+	 */
+	public static function create($value)
+	{
+		return new self($value);
+	}
+
+
+	public function getIterator()
+	{
+		return new ArrayIterator([$this->value]);
+	}
+}

--- a/tests/src/disallowed/constantUsages.php
+++ b/tests/src/disallowed/constantUsages.php
@@ -26,3 +26,10 @@ Base::ALL;
 // not a constant
 Base::class;
 \Constructor\ClassWithConstructor::class;
+
+// types that support generics
+/**
+ * @var PhpOption\None<string> $none
+ */
+$none = PhpOption\None::create();
+$none::NAME;

--- a/tests/src/disallowed/methodCalls.php
+++ b/tests/src/disallowed/methodCalls.php
@@ -37,3 +37,16 @@ new $classname();
 
 // allowed object creation
 new stdClass();
+
+// types that support generics
+/**
+ * @var PhpOption\None<string> $none
+ */
+$none = PhpOption\None::create();
+$none->getIterator();
+
+/**
+ * @var PhpOption\Some<string> $some
+ */
+$some = PhpOption\Some::create('value');
+$some->getIterator();

--- a/tests/src/disallowed/staticCalls.php
+++ b/tests/src/disallowed/staticCalls.php
@@ -30,3 +30,8 @@ Inheritance\Sub::woofer();
 // disallowed trait method
 Traits\TestClass::z();
 Traits\AnotherTestClass::zz();
+
+// types that support generics
+PhpOption\Option::fromArraysValue([]);
+PhpOption\None::create();
+PhpOption\Some::create('value');


### PR DESCRIPTION
I was trying to prevent the usage of `PhpOption` and noticed it didn't work properly.

Did some debugging and found the issue.

The rule uses `$method->getDeclaringClass()->getDisplayName()` to find the name of the class.

But since `PhpOption` uses generic types (`@template)` it would return `PhpOption\Option<mixed>`.

That doesn't match with my rule: `PhpOption\Option::*()`.

Passing `false` to `getDisplayName()` solves this.

Added a bunch of tests to guard it for other scenario's too (didn't fail there).