### PR TITLE
Check called on type instead of declaring type too

### DIFF
--- a/src/ConstantUsages.php
+++ b/src/ConstantUsages.php
@@ -51,7 +51,7 @@ class ConstantUsages implements Rule
 	public function processNode(Node $node, Scope $scope): array
 	{
 		/** @var ConstFetch $node */
-		return $this->disallowedHelper->getDisallowedConstantMessage((string)$node->name, $scope, null, $this->disallowedConstants);
+		return $this->disallowedHelper->getDisallowedConstantMessage((string)$node->name, $scope, (string)$node->name, $this->disallowedConstants);
 	}
 
 }

--- a/src/DisallowedHelper.php
+++ b/src/DisallowedHelper.php
@@ -143,7 +143,7 @@ class DisallowedHelper
 	public function getDisallowedMessage(?Node $node, Scope $scope, string $name, ?string $displayName, array $disallowedCalls): array
 	{
 		foreach ($disallowedCalls as $disallowedCall) {
-			if ($this->callMatches($disallowedCall, $name) && !$this->isAllowed($scope, $node, $disallowedCall)) {
+			if ($this->matches($disallowedCall->getCall(), $name) && !$this->isAllowed($scope, $node, $disallowedCall)) {
 				return [
 					sprintf(
 						'Calling %s is forbidden, %s%s',
@@ -158,13 +158,13 @@ class DisallowedHelper
 	}
 
 
-	private function callMatches(DisallowedCall $disallowedCall, string $name): bool
+	private function matches(string $expected, string $actual): bool
 	{
-		if ($name === $disallowedCall->getCall()) {
+		if ($expected === $actual) {
 			return true;
 		}
 
-		if (fnmatch($disallowedCall->getCall(), $name, FNM_NOESCAPE)) {
+		if (fnmatch($expected, $actual, FNM_NOESCAPE)) {
 			return true;
 		}
 

--- a/src/DisallowedHelper.php
+++ b/src/DisallowedHelper.php
@@ -253,7 +253,7 @@ class DisallowedHelper
 	public function getDisallowedConstantMessage(string $constant, Scope $scope, ?string $displayName, array $disallowedConstants): array
 	{
 		foreach ($disallowedConstants as $disallowedConstant) {
-			if ($disallowedConstant->getConstant() === $constant && !$this->isAllowedPath($scope, $disallowedConstant)) {
+			if ($this->matches($disallowedConstant->getConstant(), $constant) && !$this->isAllowedPath($scope, $disallowedConstant)) {
 				return [
 					sprintf(
 						'Using %s%s is forbidden, %s',

--- a/tests/ClassConstantUsagesTest.php
+++ b/tests/ClassConstantUsagesTest.php
@@ -3,6 +3,8 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Rules\Disallowed;
 
+use DateTime;
+use DateTimeInterface;
 use PHPStan\File\FileHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
@@ -75,6 +77,24 @@ class ClassConstantUsagesTest extends RuleTestCase
 						'src/*-allow/*.*',
 					],
 				],
+				[
+					'class' => 'DateTime*',
+					'constant' => 'ISO8601',
+					'message' => 'use DateTimeInterface::ATOM instead',
+					'allowIn' => [
+						'src/disallowed-allowed/*.php',
+						'src/*-allow/*.*',
+					],
+				],
+				[
+					'class' => 'DateTimeInterface',
+					'constant' => 'RFC*',
+					'message' => 'no RFC',
+					'allowIn' => [
+						'src/disallowed-allowed/*.php',
+						'src/*-allow/*.*',
+					],
+				],
 			]
 		);
 	}
@@ -117,6 +137,26 @@ class ClassConstantUsagesTest extends RuleTestCase
 			[
 				'Using PhpOption\Option::NAME is forbidden, no PhpOption',
 				35,
+			],
+			[
+				'Using DateTime*::ISO8601 (as DateTime::ISO8601) is forbidden, use DateTimeInterface::ATOM instead',
+				38,
+			],
+			[
+				'Using DateTime*::ISO8601 (as DateTimeImmutable::ISO8601) is forbidden, use DateTimeInterface::ATOM instead',
+				39,
+			],
+			[
+				'Using DateTime*::ISO8601 (as DateTimeInterface::ISO8601) is forbidden, use DateTimeInterface::ATOM instead',
+				40,
+			],
+			[
+				'Using DateTimeInterface::RFC* (as DateTimeInterface::RFC1123) is forbidden, no RFC',
+				43,
+			],
+			[
+				'Using DateTimeInterface::RFC* (as DateTimeInterface::RFC3339) is forbidden, no RFC',
+				44,
 			],
 		]);
 		$this->analyse([__DIR__ . '/src/disallowed-allow/constantUsages.php'], []);

--- a/tests/ClassConstantUsagesTest.php
+++ b/tests/ClassConstantUsagesTest.php
@@ -95,6 +95,15 @@ class ClassConstantUsagesTest extends RuleTestCase
 						'src/*-allow/*.*',
 					],
 				],
+				[
+					'class' => 'DateTime',
+					'constant' => 'RSS',
+					'message' => 'no RSS',
+					'allowIn' => [
+						'src/disallowed-allowed/*.php',
+						'src/*-allow/*.*',
+					],
+				],
 			]
 		);
 	}
@@ -172,6 +181,10 @@ class ClassConstantUsagesTest extends RuleTestCase
 			[
 				'Using DateTimeInterface::RFC* (as DateTimeInterface::RFC3339) is forbidden, no RFC',
 				11,
+			],
+			[
+				'Using DateTime::RSS is forbidden, no RSS',
+				16,
 			],
 		]);
 	}

--- a/tests/ClassConstantUsagesTest.php
+++ b/tests/ClassConstantUsagesTest.php
@@ -138,28 +138,42 @@ class ClassConstantUsagesTest extends RuleTestCase
 				'Using PhpOption\Option::NAME is forbidden, no PhpOption',
 				35,
 			],
+		]);
+		$this->analyse([__DIR__ . '/src/disallowed-allow/constantUsages.php'], []);
+	}
+
+
+	public function testRulePHP72AndHigher(): void
+	{
+		if (!version_compare(PHP_VERSION, '7.2', '>=')) {
+			$this->markTestSkipped('These tests require PHP 7.2');
+		}
+
+		// Based on the configuration above, in this file:
+		$this->analyse([__DIR__ . '/src/disallowed/constantUsagesPHP72.php'], [
 			[
+				// expect this error message:
 				'Using DateTime*::ISO8601 (as DateTime::ISO8601) is forbidden, use DateTimeInterface::ATOM instead',
-				38,
+				// on this line:
+				5,
 			],
 			[
 				'Using DateTime*::ISO8601 (as DateTimeImmutable::ISO8601) is forbidden, use DateTimeInterface::ATOM instead',
-				39,
+				6,
 			],
 			[
 				'Using DateTime*::ISO8601 (as DateTimeInterface::ISO8601) is forbidden, use DateTimeInterface::ATOM instead',
-				40,
+				7,
 			],
 			[
 				'Using DateTimeInterface::RFC* (as DateTimeInterface::RFC1123) is forbidden, no RFC',
-				43,
+				10,
 			],
 			[
 				'Using DateTimeInterface::RFC* (as DateTimeInterface::RFC3339) is forbidden, no RFC',
-				44,
+				11,
 			],
 		]);
-		$this->analyse([__DIR__ . '/src/disallowed-allow/constantUsages.php'], []);
 	}
 
 }

--- a/tests/ConstantUsagesTest.php
+++ b/tests/ConstantUsagesTest.php
@@ -60,7 +60,7 @@ class ConstantUsagesTest extends RuleTestCase
 			],
 			[
 				'Using FILTER_FLAG_*_FRACTION (as FILTER_FLAG_ALLOW_FRACTION) is forbidden, the cake is a lie',
-				47,
+				38,
 			],
 		]);
 		$this->analyse([__DIR__ . '/src/disallowed-allow/constantUsages.php'], []);

--- a/tests/ConstantUsagesTest.php
+++ b/tests/ConstantUsagesTest.php
@@ -31,6 +31,14 @@ class ConstantUsagesTest extends RuleTestCase
 						'src/*-allow/*.*',
 					],
 				],
+				[
+					'constant' => 'FILTER_FLAG_*_FRACTION',
+					'message' => 'the cake is a lie',
+					'allowIn' => [
+						'src/disallowed-allowed/*.php',
+						'src/*-allow/*.*',
+					],
+				],
 			]
 		);
 	}
@@ -49,6 +57,10 @@ class ConstantUsagesTest extends RuleTestCase
 			[
 				'Using FILTER_FLAG_NO_PRIV_RANGE is forbidden, the cake is a lie',
 				9,
+			],
+			[
+				'Using FILTER_FLAG_*_FRACTION (as FILTER_FLAG_ALLOW_FRACTION) is forbidden, the cake is a lie',
+				47,
 			],
 		]);
 		$this->analyse([__DIR__ . '/src/disallowed-allow/constantUsages.php'], []);

--- a/tests/src/disallowed/constantUsages.php
+++ b/tests/src/disallowed/constantUsages.php
@@ -33,3 +33,15 @@ Base::class;
  */
 $none = PhpOption\None::create();
 $none::NAME;
+
+// disallowed constants with class wildcard
+echo DateTime::ISO8601;
+echo DateTimeImmutable::ISO8601;
+echo DateTimeInterface::ISO8601;
+
+// disallowed class constants with wildcard in constant
+echo DateTimeInterface::RFC1123;
+echo DateTimeInterface::RFC3339;
+
+// global constant wildcard
+echo FILTER_FLAG_ALLOW_FRACTION;

--- a/tests/src/disallowed/constantUsages.php
+++ b/tests/src/disallowed/constantUsages.php
@@ -34,14 +34,5 @@ Base::class;
 $none = PhpOption\None::create();
 $none::NAME;
 
-// disallowed constants with class wildcard
-echo DateTime::ISO8601;
-echo DateTimeImmutable::ISO8601;
-echo DateTimeInterface::ISO8601;
-
-// disallowed class constants with wildcard in constant
-echo DateTimeInterface::RFC1123;
-echo DateTimeInterface::RFC3339;
-
 // global constant wildcard
 echo FILTER_FLAG_ALLOW_FRACTION;

--- a/tests/src/disallowed/constantUsagesPHP72.php
+++ b/tests/src/disallowed/constantUsagesPHP72.php
@@ -9,3 +9,8 @@ echo DateTimeInterface::ISO8601;
 // disallowed class constants with wildcard in constant
 echo DateTimeInterface::RFC1123;
 echo DateTimeInterface::RFC3339;
+
+// These constants are declared on the DateTimeInterface that is implemented by DateTime.
+// But `ClassConstantUsages` would resolve this to the declaring class (DateTimeInterface::RSS).
+// When disallowing `DateTime:RSS` it would never match.
+echo DateTime::RSS;

--- a/tests/src/disallowed/constantUsagesPHP72.php
+++ b/tests/src/disallowed/constantUsagesPHP72.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types = 1);
+
+// disallowed constants with class wildcard
+echo DateTime::ISO8601;
+echo DateTimeImmutable::ISO8601;
+echo DateTimeInterface::ISO8601;
+
+// disallowed class constants with wildcard in constant
+echo DateTimeInterface::RFC1123;
+echo DateTimeInterface::RFC3339;


### PR DESCRIPTION
:warning: This is based on the commits from https://github.com/spaze/phpstan-disallowed-calls/pull/56 because I needed it. When https://github.com/spaze/phpstan-disallowed-calls/pull/56 is merged, I'll rebase this PR so that it's easier to review. Basically, you should only look at the last commit.

## What has been done and why?
I noticed that disallowing `DateTime::RSS` doesn't work.

This is because `DateTime` extends `DateTimeInterface` and the `RSS` constant is defined on that interface.

`ClassConstantUsages` resolves the constant fetches to the declaring classes. That means that it would check if `DateTimeInterface::RSS` is allowed or not. That would never match.

To me this is a hidden concern that is not really what you expect as an end user.

To solve the problem, `ClassConstantUsages` now first checks the declaring constant (old behavior). If that doesn't give any errors, it checks the called on type for errors.