### PR TITLE
Do not absolutize path when path starts with wildcard

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -55,6 +55,7 @@ parametersSchema:
 	)
 
 services:
+	- Spaze\PHPStan\Rules\Disallowed\FileHelper
 	- Spaze\PHPStan\Rules\Disallowed\DisallowedHelper
 	- Spaze\PHPStan\Rules\Disallowed\DisallowedNamespaceHelper
 	-

--- a/src/DisallowedHelper.php
+++ b/src/DisallowedHelper.php
@@ -12,7 +12,6 @@ use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
 use PHPStan\Broker\ClassNotFoundException;
-use PHPStan\File\FileHelper;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\ConstantScalarType;

--- a/src/DisallowedNamespaceHelper.php
+++ b/src/DisallowedNamespaceHelper.php
@@ -4,7 +4,6 @@ declare(strict_types = 1);
 namespace Spaze\PHPStan\Rules\Disallowed;
 
 use PHPStan\Analyser\Scope;
-use PHPStan\File\FileHelper;
 
 class DisallowedNamespaceHelper
 {

--- a/src/FileHelper.php
+++ b/src/FileHelper.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Rules\Disallowed;
+
+use PHPStan\File\FileHelper as PHPStanFileHelper;
+
+class FileHelper
+{
+
+	/** @var PHPStanFileHelper */
+	private $fileHelper;
+
+
+	public function __construct(PHPStanFileHelper $fileHelper)
+	{
+		$this->fileHelper = $fileHelper;
+	}
+
+
+	/**
+	 * Make path absolute unless it starts with a wildcard, then return as is.
+	 *
+	 * @param string $path
+	 * @return string
+	 */
+	public function absolutizePath(string $path): string
+	{
+		if (strpos($path, '*') === 0) {
+			return $path;
+		}
+
+		return $this->fileHelper->absolutizePath($path);
+	}
+
+}

--- a/tests/ClassConstantInvalidUsagesTest.php
+++ b/tests/ClassConstantInvalidUsagesTest.php
@@ -3,7 +3,7 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Rules\Disallowed;
 
-use PHPStan\File\FileHelper;
+use PHPStan\File\FileHelper as PHPStanFileHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 
@@ -12,7 +12,7 @@ class ClassConstantInvalidUsagesTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
-		return new ClassConstantUsages(new DisallowedHelper(new FileHelper(__DIR__)), []);
+		return new ClassConstantUsages(new DisallowedHelper(new FileHelper(new PHPStanFileHelper(__DIR__))), []);
 	}
 
 

--- a/tests/ClassConstantUsagesTest.php
+++ b/tests/ClassConstantUsagesTest.php
@@ -3,7 +3,7 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Rules\Disallowed;
 
-use PHPStan\File\FileHelper;
+use PHPStan\File\FileHelper as PHPStanFileHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 
@@ -13,7 +13,7 @@ class ClassConstantUsagesTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		return new ClassConstantUsages(
-			new DisallowedHelper(new FileHelper(__DIR__)),
+			new DisallowedHelper(new FileHelper(new PHPStanFileHelper(__DIR__))),
 			[
 				[
 					'class' => '\Inheritance\Base',

--- a/tests/ConstantUsagesTest.php
+++ b/tests/ConstantUsagesTest.php
@@ -3,7 +3,7 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Rules\Disallowed;
 
-use PHPStan\File\FileHelper;
+use PHPStan\File\FileHelper as PHPStanFileHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 
@@ -13,7 +13,7 @@ class ConstantUsagesTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		return new ConstantUsages(
-			new DisallowedHelper(new FileHelper(__DIR__)),
+			new DisallowedHelper(new FileHelper(new PHPStanFileHelper(__DIR__))),
 			[
 				[
 					'constant' => 'FILTER_FLAG_NO_PRIV_RANGE',

--- a/tests/EvalCallsTest.php
+++ b/tests/EvalCallsTest.php
@@ -3,7 +3,7 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Rules\Disallowed;
 
-use PHPStan\File\FileHelper;
+use PHPStan\File\FileHelper as PHPStanFileHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 
@@ -13,7 +13,7 @@ class EvalCallsTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		return new EvalCalls(
-			new DisallowedHelper(new FileHelper(__DIR__)),
+			new DisallowedHelper(new FileHelper(new PHPStanFileHelper(__DIR__))),
 			[
 				[
 					'function' => 'eval()',

--- a/tests/FileHelperTest.php
+++ b/tests/FileHelperTest.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Rules\Disallowed;
+
+use Generator;
+use PHPUnit\Framework\TestCase;
+use PHPStan\File\FileHelper as PHPStanFileHelper;
+
+class FileHelperTest extends TestCase
+{
+
+	/** @var FileHelper */
+	private $fileHelper;
+
+
+	public function setUp(): void
+	{
+		$this->fileHelper = new FileHelper(new PHPStanFileHelper(__DIR__));
+	}
+
+
+	/**
+	 * @param string $input
+	 * @param string $output
+	 * @dataProvider pathProvider
+	 */
+	public function testAbsolutizePath(string $input, string $output): void
+	{
+		$this->assertSame($output, $this->fileHelper->absolutizePath($input));
+	}
+
+
+	public function pathProvider(): Generator
+	{
+		yield ['src', __DIR__ . '/src'];
+		yield ['src/*', __DIR__ . '/src/*'];
+		yield ['*/src', '*/src'];
+	}
+
+}

--- a/tests/FunctionCallsTest.php
+++ b/tests/FunctionCallsTest.php
@@ -3,7 +3,7 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Rules\Disallowed;
 
-use PHPStan\File\FileHelper;
+use PHPStan\File\FileHelper as PHPStanFileHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 
@@ -13,7 +13,7 @@ class FunctionCallsTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		return new FunctionCalls(
-			new DisallowedHelper(new FileHelper(__DIR__)),
+			new DisallowedHelper(new FileHelper(new PHPStanFileHelper(__DIR__))),
 			[
 				[
 					'function' => '\var_dump()',

--- a/tests/MethodCallsTest.php
+++ b/tests/MethodCallsTest.php
@@ -3,7 +3,7 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Rules\Disallowed;
 
-use PHPStan\File\FileHelper;
+use PHPStan\File\FileHelper as PHPStanFileHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 
@@ -13,7 +13,7 @@ class MethodCallsTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		return new MethodCalls(
-			new DisallowedHelper(new FileHelper(__DIR__)),
+			new DisallowedHelper(new FileHelper(new PHPStanFileHelper(__DIR__))),
 			[
 				[
 					'method' => 'Waldo\Quux\Blade::run*()',

--- a/tests/NamespaceUsagesTest.php
+++ b/tests/NamespaceUsagesTest.php
@@ -3,7 +3,7 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Rules\Disallowed;
 
-use PHPStan\File\FileHelper;
+use PHPStan\File\FileHelper as PHPStanFileHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 
@@ -13,7 +13,7 @@ class NamespaceUsagesTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		return new NamespaceUsages(
-			new DisallowedNamespaceHelper(new FileHelper(__DIR__)),
+			new DisallowedNamespaceHelper(new FileHelper(new PHPStanFileHelper(__DIR__))),
 			[
 				[
 					'namespace' => 'Framew*rk\Some*',

--- a/tests/NewCallsTest.php
+++ b/tests/NewCallsTest.php
@@ -3,7 +3,7 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Rules\Disallowed;
 
-use PHPStan\File\FileHelper;
+use PHPStan\File\FileHelper as PHPStanFileHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 
@@ -13,7 +13,7 @@ class NewCallsTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		return new NewCalls(
-			new DisallowedHelper(new FileHelper(__DIR__)),
+			new DisallowedHelper(new FileHelper(new PHPStanFileHelper(__DIR__))),
 			[
 				[
 					'method' => '\Constructor\ClassWithConstructor::__construct()',

--- a/tests/StaticCallsTest.php
+++ b/tests/StaticCallsTest.php
@@ -3,7 +3,7 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Rules\Disallowed;
 
-use PHPStan\File\FileHelper;
+use PHPStan\File\FileHelper as PHPStanFileHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 
@@ -13,7 +13,7 @@ class StaticCallsTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		return new StaticCalls(
-			new DisallowedHelper(new FileHelper(__DIR__)),
+			new DisallowedHelper(new FileHelper(new PHPStanFileHelper(__DIR__))),
 			[
 				[
 					'method' => 'Fiction\Pulp\Royale::withCheese()',


### PR DESCRIPTION
I'm using `allowIn` a lot to exclude certain directories from being disallowed.

I noticed that this library absolutizes all inputs making them relative to the current working directory.

That means that if i write:
```neon
allowIn:
  - tests
```
it becomes `/my/working/directory/tests`. And it also means that if I write
```neon
allowIn:
  - **/tests
```
it becomes `/my/working/directory/**/tests`.

I think it should not be done when the path starts with a wildcard.

PHPStorm has integration for PHPStan and I noticed that all my allowed paths were ignored by PHPStan when running in PHPStorm. Turns out, PHPStorm doesn't run PHPStan on the actual file, but instead copies the file to a temporary directory and then performs analysis on it.

So when you have `tests/MyTest.php` it will copy it to `/private/var/folders/m4/2_8czq_s1dbcfkm1yf8zjgg80000gn/T/PHPStantemp_folder7840/tests/MyTest.php` and then run it.

Because this library makes the allowed paths absolute to the working directory, the allowed path will never match that with the path from the temporary directory.

Current work around that I have is to use the following config:
```neon
allowIn:
  - tests/*
  - /private/var/**/PHPStantemp_folder*/tests/*
```

But by applying this change, I can write it like this:
```neon
allowIn:
  - **/tests/*
```

I checked how PHPStan deals with this. It does not absolutize paths when doing things like this:
```neon
parameters:
    ignoreErrors:
        -
            message: '#Dynamic call to static method PHPUnit\\.*#'
            paths:
                - **/tests/*
```

That means that the above example works fine, also in PHPStorm.

I also reported this to PHPStorm but I'm not sure if this will be fixed.
See https://youtrack.jetbrains.com/issue/WI-58890.
