### PR TITLE
Change PHPUnit fixtures visibility

### DIFF
--- a/tests/FileHelperTest.php
+++ b/tests/FileHelperTest.php
@@ -14,7 +14,7 @@ class FileHelperTest extends TestCase
 	private $fileHelper;
 
 
-	public function setUp(): void
+	protected function setUp(): void
 	{
 		$this->fileHelper = new FileHelper(new PHPStanFileHelper(__DIR__));
 	}


### PR DESCRIPTION
# Changed log

- According to the [PHPUnit doc](https://phpunit.readthedocs.io/en/9.5/fixtures.html#more-setup-than-teardown), it should be `protected function setUp` and `protected function tearDown` methods.