### PR TITLE
More language constructs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /composer.lock
 /vendor
 /tests/tmp
+/tmp
 /.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -131,7 +131,10 @@ parameters:
 ```
 The wildcard makes most sense when used as the rightmost character of the function or method name, optionally followed by `()`, but you can use it anywhere for example to disallow all functions that end with `y`: `function: '*y()'`. The matching is powered by [`fnmatch`](https://www.php.net/function.fnmatch) so you can use even multiple wildcards if you wish because w*y n*t.
 
-You can treat `eval()` as a function (although it's a language construct) and disallow it in `disallowedFunctionCalls`.
+You can treat some language constructs as functions and disallow it in `disallowedFunctionCalls`. Currently detected language constructs are:
+- `die()`
+- `eval()`
+- `exit()`
 
 To disallow naive object creation (`new ClassName()` or `new $classname`), disallow `NameSpace\ClassName::__construct` in `disallowedMethodCalls`. Works even when there's no constructor defined in that class.
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ The wildcard makes most sense when used as the rightmost character of the functi
 
 You can treat some language constructs as functions and disallow it in `disallowedFunctionCalls`. Currently detected language constructs are:
 - `die()`
+- `empty()`
 - `eval()`
 - `exit()`
 

--- a/extension.neon
+++ b/extension.neon
@@ -79,6 +79,10 @@ services:
 		tags:
 			- phpstan.rules.rule
 	-
+		factory: Spaze\PHPStan\Rules\Disallowed\EmptyCalls(forbiddenCalls: %disallowedFunctionCalls%)
+		tags:
+			- phpstan.rules.rule
+	-
 		factory: Spaze\PHPStan\Rules\Disallowed\ExitDieCalls(forbiddenCalls: %disallowedFunctionCalls%)
 		tags:
 			- phpstan.rules.rule

--- a/extension.neon
+++ b/extension.neon
@@ -79,6 +79,10 @@ services:
 		tags:
 			- phpstan.rules.rule
 	-
+		factory: Spaze\PHPStan\Rules\Disallowed\ExitDieCalls(forbiddenCalls: %disallowedFunctionCalls%)
+		tags:
+			- phpstan.rules.rule
+	-
 		factory: Spaze\PHPStan\Rules\Disallowed\FunctionCalls(forbiddenCalls: %disallowedFunctionCalls%)
 		tags:
 			- phpstan.rules.rule

--- a/src/EmptyCalls.php
+++ b/src/EmptyCalls.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Rules\Disallowed;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Empty_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\ShouldNotHappenException;
+
+/**
+ * Reports on dynamically calling empty().
+ *
+ * @package Spaze\PHPStan\Rules\Disallowed
+ * @implements Rule<Empty_>
+ */
+class EmptyCalls implements Rule
+{
+
+	/** @var DisallowedHelper */
+	private $disallowedHelper;
+
+	/** @var DisallowedCall[] */
+	private $disallowedCalls;
+
+
+	/**
+	 * @param DisallowedHelper $disallowedHelper
+	 * @param array<array{function?:string, method?:string, message?:string, allowIn?:string[], allowParamsInAllowed?:array<integer, integer|boolean|string>, allowParamsAnywhere?:array<integer, integer|boolean|string>}> $forbiddenCalls
+	 * @throws ShouldNotHappenException
+	 */
+	public function __construct(DisallowedHelper $disallowedHelper, array $forbiddenCalls)
+	{
+		$this->disallowedHelper = $disallowedHelper;
+		$this->disallowedCalls = $this->disallowedHelper->createCallsFromConfig($forbiddenCalls);
+	}
+
+
+	public function getNodeType(): string
+	{
+		return Empty_::class;
+	}
+
+
+	/**
+	 * @param Node $node
+	 * @param Scope $scope
+	 * @return string[]
+	 */
+	public function processNode(Node $node, Scope $scope): array
+	{
+		return $this->disallowedHelper->getDisallowedMessage(null, $scope, 'empty', 'empty', $this->disallowedCalls);
+	}
+
+}

--- a/src/ExitDieCalls.php
+++ b/src/ExitDieCalls.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Rules\Disallowed;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Exit_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\ShouldNotHappenException;
+
+/**
+ * Reports on dynamically calling exit() & die().
+ *
+ * @package Spaze\PHPStan\Rules\Disallowed
+ * @implements Rule<Exit_>
+ */
+class ExitDieCalls implements Rule
+{
+
+	/** @var DisallowedHelper */
+	private $disallowedHelper;
+
+	/** @var DisallowedCall[] */
+	private $disallowedCalls;
+
+
+	/**
+	 * @param DisallowedHelper $disallowedHelper
+	 * @param array<array{function?:string, method?:string, message?:string, allowIn?:string[], allowParamsInAllowed?:array<integer, integer|boolean|string>, allowParamsAnywhere?:array<integer, integer|boolean|string>}> $forbiddenCalls
+	 * @throws ShouldNotHappenException
+	 */
+	public function __construct(DisallowedHelper $disallowedHelper, array $forbiddenCalls)
+	{
+		$this->disallowedHelper = $disallowedHelper;
+		$this->disallowedCalls = $this->disallowedHelper->createCallsFromConfig($forbiddenCalls);
+	}
+
+
+	public function getNodeType(): string
+	{
+		return Exit_::class;
+	}
+
+
+	/**
+	 * @param Node $node
+	 * @param Scope $scope
+	 * @return string[]
+	 */
+	public function processNode(Node $node, Scope $scope): array
+	{
+		$kind = $node->getAttribute('kind', Exit_::KIND_DIE) === Exit_::KIND_EXIT ? 'exit' : 'die';
+		return $this->disallowedHelper->getDisallowedMessage(null, $scope, $kind, $kind, $this->disallowedCalls);
+	}
+
+}

--- a/tests/EmptyCallsTest.php
+++ b/tests/EmptyCallsTest.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Rules\Disallowed;
+
+use PHPStan\File\FileHelper as PHPStanFileHelper;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+class EmptyCallsTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new EmptyCalls(
+			new DisallowedHelper(new FileHelper(new PHPStanFileHelper(__DIR__))),
+			[
+				[
+					'function' => 'empty()',
+					'allowIn' => [
+						'src/disallowed-allowed/*.php',
+						'src/*-allow/*.*',
+					],
+				],
+			]
+		);
+	}
+
+
+	public function testRule(): void
+	{
+		// Based on the configuration above, in this file:
+		$this->analyse([__DIR__ . '/src/disallowed/functionCalls.php'], [
+			[
+				'Calling empty() is forbidden, because reasons',
+				41,
+			],
+		]);
+		// Based on the configuration above, no errors in this file:
+		$this->analyse([__DIR__ . '/src/disallowed-allow/functionCalls.php'], []);
+	}
+
+}

--- a/tests/ExitDieCallsTest.php
+++ b/tests/ExitDieCallsTest.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Rules\Disallowed;
+
+use PHPStan\File\FileHelper as PHPStanFileHelper;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+class ExitDieCallsTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new ExitDieCalls(
+			new DisallowedHelper(new FileHelper(new PHPStanFileHelper(__DIR__))),
+			[
+				[
+					'function' => 'die()',
+					'allowIn' => [
+						'src/disallowed-allowed/*.php',
+						'src/*-allow/*.*',
+					],
+				],
+				[
+					'function' => 'exit()',
+					'allowIn' => [
+						'src/disallowed-allowed/*.php',
+						'src/*-allow/*.*',
+					],
+				],
+			]
+		);
+	}
+
+
+	public function testRule(): void
+	{
+		// Based on the configuration above, in this file:
+		$this->analyse([__DIR__ . '/src/disallowed/functionCalls.php'], [
+			[
+				'Calling die() is forbidden, because reasons',
+				30,
+			],
+			[
+				'Calling die() is forbidden, because reasons',
+				33,
+			],
+			[
+				'Calling exit() is forbidden, because reasons',
+				36,
+			],
+			[
+				'Calling exit() is forbidden, because reasons',
+				39,
+			],
+		]);
+		// Based on the configuration above, no errors in this file:
+		$this->analyse([__DIR__ . '/src/disallowed-allow/functionCalls.php'], []);
+	}
+
+}

--- a/tests/src/disallowed-allow/functionCalls.php
+++ b/tests/src/disallowed-allow/functionCalls.php
@@ -38,3 +38,4 @@ if (random_int(0, 1) === 1) {
 if (random_int(0, 1) === 1) {
 	exit;
 }
+empty($bottle);

--- a/tests/src/disallowed-allow/functionCalls.php
+++ b/tests/src/disallowed-allow/functionCalls.php
@@ -26,3 +26,15 @@ print_r('bar bar was', false);
 
 // a language construct, allowed by path
 eval('$foo="bar";');
+if (random_int(0, 1) === 1) {
+	die('hard');
+}
+if (random_int(0, 1) === 1) {
+	die;
+}
+if (random_int(0, 1) === 1) {
+	exit('through the gift shop');
+}
+if (random_int(0, 1) === 1) {
+	exit;
+}

--- a/tests/src/disallowed/functionCalls.php
+++ b/tests/src/disallowed/functionCalls.php
@@ -26,3 +26,15 @@ print_r('bar bar was', false);
 
 // a disallowed language construct
 eval('$foo="bar";');
+if (random_int(0, 1) === 1) {
+	die('hard');
+}
+if (random_int(0, 1) === 1) {
+	die;
+}
+if (random_int(0, 1) === 1) {
+	exit('through the gift shop');
+}
+if (random_int(0, 1) === 1) {
+	exit;
+}

--- a/tests/src/disallowed/functionCalls.php
+++ b/tests/src/disallowed/functionCalls.php
@@ -38,3 +38,4 @@ if (random_int(0, 1) === 1) {
 if (random_int(0, 1) === 1) {
 	exit;
 }
+empty($bottle);


### PR DESCRIPTION
Add support for `die`, `exit`, `empty` language constructs

Fix #69