### PR TITLE
Put `tmp` dir back to tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /composer.lock
 /vendor
 /tests/tmp
-/tmp
 /.phpunit.result.cache

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -18,7 +18,7 @@
 			<directory suffix=".php">src</directory>
 		</include>
 		<report>
-			<html outputDirectory="tmp/report" lowUpperBound="35" highLowerBound="70"/>
+			<html outputDirectory="tests/tmp/report" lowUpperBound="35" highLowerBound="70"/>
 		</report>
 	</coverage>
 	<testsuites>


### PR DESCRIPTION
Revert "Also ignore /tmp as it sometimes contains coverage report too"

This reverts commit f358d1a25993c283563d1e813f3b55c8cb218d3e.

Follow-up to #54