### PR TITLE
Forbid backtick operator when `shell_exec()` is forbidden

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ includes:
 `disallowed-dangerous-calls.neon` can also serve as a template when you'd like to extend the configuration to disallow some other functions or methods, copy it and modify to your needs.
 You can also allow a previously disallowed dangerous call in a defined path (see below) in your own config by using the same `call` or `method` key.
 
-If you want to disable program execution functions (`exec()`, `shell_exec()` & friends), include `disallowed-execution-calls.neon`:
+If you want to disallow program execution functions (`exec()`, `shell_exec()` & friends) including the backtick operator (`` `...` ``, disallowed when `shell_exec()` is disallowed), include `disallowed-execution-calls.neon`:
 
 ```neon
 includes:

--- a/disallowed-execution-calls.neon
+++ b/disallowed-execution-calls.neon
@@ -8,7 +8,7 @@ parameters:
 		-
 			function: 'proc_open()'
 		-
-			function: 'shell_exec()'
+			function: 'shell_exec()'  # also disallows the backtick operator `...`
 		-
 			function: 'system()'
 		# Other functions

--- a/extension.neon
+++ b/extension.neon
@@ -99,6 +99,10 @@ services:
 		tags:
 			- phpstan.rules.rule
 	-
+		factory: Spaze\PHPStan\Rules\Disallowed\Calls\ShellExecCalls(forbiddenCalls: %disallowedFunctionCalls%)
+		tags:
+			- phpstan.rules.rule
+	-
 		factory: Spaze\PHPStan\Rules\Disallowed\Usages\ConstantUsages(disallowedConstants: %disallowedConstants%)
 		tags:
 			- phpstan.rules.rule

--- a/src/Calls/ShellExecCalls.php
+++ b/src/Calls/ShellExecCalls.php
@@ -1,0 +1,71 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Rules\Disallowed\Calls;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\ShellExec;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\ShouldNotHappenException;
+use Spaze\PHPStan\Rules\Disallowed\DisallowedCall;
+use Spaze\PHPStan\Rules\Disallowed\DisallowedHelper;
+
+/**
+ * Reports on dynamically using the execution backtick operator (<code>`ls`</code>).
+ *
+ * This class is in the Calls namespace because according to the docs,
+ * "Use of the backtick operator is identical to shell_exec()"
+ * https://www.php.net/operators.execution
+ *
+ * @package Spaze\PHPStan\Rules\Disallowed
+ * @implements Rule<ShellExec>
+ */
+class ShellExecCalls implements Rule
+{
+
+	/** @var DisallowedHelper */
+	private $disallowedHelper;
+
+	/** @var DisallowedCall[] */
+	private $disallowedCalls;
+
+
+	/**
+	 * @param DisallowedHelper $disallowedHelper
+	 * @param array $forbiddenCalls
+	 * @phpstan-param ForbiddenCallsConfig $forbiddenCalls
+	 * @noinspection PhpUndefinedClassInspection ForbiddenCallsConfig is a type alias defined in PHPStan config
+	 * @throws ShouldNotHappenException
+	 */
+	public function __construct(DisallowedHelper $disallowedHelper, array $forbiddenCalls)
+	{
+		$this->disallowedHelper = $disallowedHelper;
+		$this->disallowedCalls = $this->disallowedHelper->createCallsFromConfig($forbiddenCalls);
+	}
+
+
+	public function getNodeType(): string
+	{
+		return ShellExec::class;
+	}
+
+
+	/**
+	 * @param Node $node
+	 * @param Scope $scope
+	 * @return string[]
+	 */
+	public function processNode(Node $node, Scope $scope): array
+	{
+		return $this->disallowedHelper->getDisallowedMessage(
+			null,
+			$scope,
+			'shell_exec',
+			null,
+			$this->disallowedCalls,
+			'Using the backtick operator (`...`) is forbidden because shell_exec() is forbidden, %2$s%3$s'
+		);
+	}
+
+}

--- a/src/DisallowedHelper.php
+++ b/src/DisallowedHelper.php
@@ -137,15 +137,16 @@ class DisallowedHelper
 	 * @param string $name
 	 * @param string|null $displayName
 	 * @param DisallowedCall[] $disallowedCalls
+	 * @param string|null $message
 	 * @return string[]
 	 */
-	public function getDisallowedMessage(?Node $node, Scope $scope, string $name, ?string $displayName, array $disallowedCalls): array
+	public function getDisallowedMessage(?Node $node, Scope $scope, string $name, ?string $displayName, array $disallowedCalls, ?string $message = null): array
 	{
 		foreach ($disallowedCalls as $disallowedCall) {
 			if ($this->callMatches($disallowedCall, $name) && !$this->isAllowed($scope, $node, $disallowedCall)) {
 				return [
 					sprintf(
-						'Calling %s is forbidden, %s%s',
+						$message ?? 'Calling %s is forbidden, %s%s',
 						($displayName && $displayName !== $name) ? "{$name}() (as {$displayName}())" : "{$name}()",
 						$disallowedCall->getMessage(),
 						$disallowedCall->getCall() !== $name ? " [{$name}() matches {$disallowedCall->getCall()}()]" : ''

--- a/tests/Calls/ShellExecCallsTest.php
+++ b/tests/Calls/ShellExecCallsTest.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Rules\Disallowed\Calls;
+
+use PHPStan\File\FileHelper as PHPStanFileHelper;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use Spaze\PHPStan\Rules\Disallowed\DisallowedHelper;
+use Spaze\PHPStan\Rules\Disallowed\FileHelper;
+
+class ShellExecCallsTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new ShellExecCalls(
+			new DisallowedHelper(new FileHelper(new PHPStanFileHelper(__DIR__))),
+			[
+				[
+					'function' => 'shell_*()',
+					'allowIn' => [
+						'../src/disallowed-allowed/*.php',
+						'../src/*-allow/*.*',
+					],
+				],
+			]
+		);
+	}
+
+
+	public function testRule(): void
+	{
+		// Based on the configuration above, in this file:
+		$this->analyse([__DIR__ . '/../src/disallowed/functionCalls.php'], [
+			[
+				'Using the backtick operator (`...`) is forbidden because shell_exec() is forbidden, because reasons [shell_exec() matches shell_*()]',
+				46,
+			],
+		]);
+		// Based on the configuration above, no errors in this file:
+		$this->analyse([__DIR__ . '/../src/disallowed-allow/functionCalls.php'], []);
+	}
+
+}

--- a/tests/src/disallowed-allow/functionCalls.php
+++ b/tests/src/disallowed-allow/functionCalls.php
@@ -41,3 +41,6 @@ if (random_int(0, 1) === 1) {
 empty($bottle);
 echo "hello";
 print "hello";
+
+// backtick operator allowed by path
+`ls`;

--- a/tests/src/disallowed/functionCalls.php
+++ b/tests/src/disallowed/functionCalls.php
@@ -41,3 +41,6 @@ if (random_int(0, 1) === 1) {
 empty($bottle);
 echo "hello";
 print "hello";
+
+// backtick operator disallowed when shell_exec() is disallowed
+`ls`;


### PR DESCRIPTION
According to the [docs](https://www.php.net/operators.execution), "Use of the backtick operator is identical to shell_exec()" which is also the reason why the class is called `ShellExecCalls` and is in the `Calls` namespace.