### PR TITLE
Allow calls except when a params has a specified value

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,33 @@ With `allowParamsAnywhere`, calls are allowed when called with all parameters li
 - `log(..., true)` anywhere
 - `log('foo', true)` in `another/file.php` or `optional/path/to/log.tests.php`
 
+## Allow calls except when a param has a specified value
+
+Sometimes, it's handy to disallow a function or a method call only when a parameter matches but allow it otherwise. For example the `hash()` function, it's fine using it with algorithm families like SHA-2 & SHA-3 (not for passwords though) but you'd like PHPStan to report when it's used with MD5 like `hash('md5', ...)`.
+You can use `allowExceptParams` & `allowExceptCaseInsensitiveParams` config options to disallow only some calls:
+
+```neon
+parameters:
+    disallowedFunctionCalls:
+        -
+            function: 'hash()'
+            allowExceptCaseInsensitiveParams:
+            	1: 'md5'
+```
+
+This will disallow `hash()` call where the first parameter is `'md5'`. `allowExceptCaseInsensitiveParams` is used because the first parameter of `hash()` is case-insensitive (so you can also use `'MD5'`, or even `'Md5'` & `'mD5'` if you wish).
+To disallow only exact matches, use `allowExceptParams`:
+
+```neon
+parameters:
+    disallowedFunctionCalls:
+        -
+            function: 'foo()'
+            allowExceptParams:
+            	2: 'baz'
+```
+will disallow `foo('bar', 'baz')` but not `foo('bar', 'BAZ')`.
+
 ## Detect disallowed calls without any other PHPStan rules
 
 If you want to use this PHPStan extension without running any other PHPStan rules, you can use `phpstan.neon` config file that looks like this (the `customRulesetUsed: true` and the missing `level` key are the important bits):

--- a/extension.neon
+++ b/extension.neon
@@ -7,7 +7,7 @@ parameters:
 
 parametersSchema:
 	# These should be defined using `structure` with listed keys but it seems to me that PHPStan requires
-	# all keys to be present in a structure but `message`, `allowIn` & `allowParamsInAllowed` are optional.
+	# all keys to be present in a structure but `message` & `allow*` are optional.
 	disallowedNamespaces: listOf(
 		arrayOf(
 			anyOf(

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,7 +3,8 @@ parameters:
 		- src
 	level: max
 	typeAliases:
-		ForbiddenCallsConfig: 'array<array{function?:string, method?:string, message?:string, allowIn?:string[], allowParamsInAllowed?:array<integer, integer|boolean|string>, allowParamsAnywhere?:array<integer, integer|boolean|string>}>'
+		ForbiddenCallsConfig: 'array<array{function?:string, method?:string, message?:string, allowIn?:string[], allowParamsInAllowed?:array<integer, integer|boolean|string>, allowParamsAnywhere?:array<integer, integer|boolean|string>, allowExceptParams?:array<integer, integer|boolean|string>, allowExceptCaseInsensitiveParams?:array<integer, integer|boolean|string>}>'
+		ForbiddenCalls: 'PhpParser\Node\Expr\FuncCall|PhpParser\Node\Expr\MethodCall|PhpParser\Node\Expr\StaticCall'
 
 includes:
 	- vendor/phpstan/phpstan/conf/bleedingEdge.neon

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,7 +4,7 @@ parameters:
 	level: max
 	typeAliases:
 		ForbiddenCallsConfig: 'array<array{function?:string, method?:string, message?:string, allowIn?:string[], allowParamsInAllowed?:array<integer, integer|boolean|string>, allowParamsAnywhere?:array<integer, integer|boolean|string>, allowExceptParams?:array<integer, integer|boolean|string>, allowExceptCaseInsensitiveParams?:array<integer, integer|boolean|string>}>'
-		ForbiddenCalls: 'PhpParser\Node\Expr\FuncCall|PhpParser\Node\Expr\MethodCall|PhpParser\Node\Expr\StaticCall'
+		ForbiddenCalls: 'PhpParser\Node\Expr\FuncCall|PhpParser\Node\Expr\MethodCall|PhpParser\Node\Expr\StaticCall|PhpParser\Node\Expr\New_'
 
 includes:
 	- vendor/phpstan/phpstan/conf/bleedingEdge.neon

--- a/src/Calls/EchoCalls.php
+++ b/src/Calls/EchoCalls.php
@@ -48,7 +48,7 @@ class EchoCalls implements Rule
 
 
 	/**
-	 * @param Node $node
+	 * @param Echo_ $node
 	 * @param Scope $scope
 	 * @return string[]
 	 */

--- a/src/Calls/EmptyCalls.php
+++ b/src/Calls/EmptyCalls.php
@@ -48,7 +48,7 @@ class EmptyCalls implements Rule
 
 
 	/**
-	 * @param Node $node
+	 * @param Empty_ $node
 	 * @param Scope $scope
 	 * @return string[]
 	 */

--- a/src/Calls/EvalCalls.php
+++ b/src/Calls/EvalCalls.php
@@ -48,7 +48,7 @@ class EvalCalls implements Rule
 
 
 	/**
-	 * @param Node $node
+	 * @param Eval_ $node
 	 * @param Scope $scope
 	 * @return string[]
 	 */

--- a/src/Calls/ExitDieCalls.php
+++ b/src/Calls/ExitDieCalls.php
@@ -48,7 +48,7 @@ class ExitDieCalls implements Rule
 
 
 	/**
-	 * @param Node $node
+	 * @param Exit_ $node
 	 * @param Scope $scope
 	 * @return string[]
 	 */

--- a/src/Calls/FunctionCalls.php
+++ b/src/Calls/FunctionCalls.php
@@ -49,13 +49,12 @@ class FunctionCalls implements Rule
 
 
 	/**
-	 * @param Node $node
+	 * @param FuncCall $node
 	 * @param Scope $scope
 	 * @return string[]
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{
-		/** @var FuncCall $node */
 		if (!($node->name instanceof Name)) {
 			return [];
 		}

--- a/src/Calls/MethodCalls.php
+++ b/src/Calls/MethodCalls.php
@@ -51,14 +51,13 @@ class MethodCalls implements Rule
 
 
 	/**
-	 * @param Node $node
+	 * @param MethodCall $node
 	 * @param Scope $scope
 	 * @return string[]
 	 * @throws ClassNotFoundException
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{
-		/** @var MethodCall $node */
 		return $this->disallowedHelper->getDisallowedMethodMessage($node->var, $node, $scope, $this->disallowedCalls);
 	}
 

--- a/src/Calls/NewCalls.php
+++ b/src/Calls/NewCalls.php
@@ -64,7 +64,7 @@ class NewCalls implements Rule
 		} else {
 			return [];
 		}
-		return $this->disallowedHelper->getDisallowedMessage(null, $scope, $name, $name, $this->disallowedCalls);
+		return $this->disallowedHelper->getDisallowedMessage($node, $scope, $name, $name, $this->disallowedCalls);
 	}
 
 }

--- a/src/Calls/NewCalls.php
+++ b/src/Calls/NewCalls.php
@@ -51,13 +51,12 @@ class NewCalls implements Rule
 
 
 	/**
-	 * @param Node $node
+	 * @param New_ $node
 	 * @param Scope $scope
 	 * @return string[]
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{
-		/** @var New_ $node */
 		if ($node->class instanceof Name) {
 			$name = "{$node->class}::__construct";
 		} elseif ($node->class instanceof Expr && $scope->getType($node->class) instanceof ConstantScalarType) {

--- a/src/Calls/PrintCalls.php
+++ b/src/Calls/PrintCalls.php
@@ -48,7 +48,7 @@ class PrintCalls implements Rule
 
 
 	/**
-	 * @param Node $node
+	 * @param Print_ $node
 	 * @param Scope $scope
 	 * @return string[]
 	 */

--- a/src/Calls/ShellExecCalls.php
+++ b/src/Calls/ShellExecCalls.php
@@ -52,7 +52,7 @@ class ShellExecCalls implements Rule
 
 
 	/**
-	 * @param Node $node
+	 * @param ShellExec $node
 	 * @param Scope $scope
 	 * @return string[]
 	 */

--- a/src/Calls/StaticCalls.php
+++ b/src/Calls/StaticCalls.php
@@ -51,7 +51,7 @@ class StaticCalls implements Rule
 
 
 	/**
-	 * @param Node $node
+	 * @param StaticCall $node
 	 * @param Scope $scope
 	 * @return string[]
 	 * @throws ClassNotFoundException

--- a/src/DisallowedCall.php
+++ b/src/DisallowedCall.php
@@ -21,6 +21,12 @@ class DisallowedCall
 	/** @var array<integer, integer|boolean|string> */
 	private $allowParamsAnywhere;
 
+	/** @var array<integer, integer|boolean|string> */
+	private $allowExceptParams;
+
+	/** @var array<integer, integer|boolean|string> */
+	private $allowExceptCaseInsensitiveParams;
+
 
 	/**
 	 * DisallowedCall constructor.
@@ -30,8 +36,10 @@ class DisallowedCall
 	 * @param string[] $allowIn
 	 * @param array<integer, integer|boolean|string> $allowParamsInAllowed
 	 * @param array<integer, integer|boolean|string> $allowParamsAnywhere
+	 * @param array<integer, integer|boolean|string> $allowExceptParams
+	 * @param array<integer, integer|boolean|string> $allowExceptCaseInsensitiveParams
 	 */
-	public function __construct(string $call, ?string $message, array $allowIn, array $allowParamsInAllowed, array $allowParamsAnywhere)
+	public function __construct(string $call, ?string $message, array $allowIn, array $allowParamsInAllowed, array $allowParamsAnywhere, array $allowExceptParams, array $allowExceptCaseInsensitiveParams)
 	{
 		$call = substr($call, -2) === '()' ? substr($call, 0, -2) : $call;
 		$this->call = ltrim($call, '\\');
@@ -39,6 +47,8 @@ class DisallowedCall
 		$this->allowIn = $allowIn;
 		$this->allowParamsInAllowed = $allowParamsInAllowed;
 		$this->allowParamsAnywhere = $allowParamsAnywhere;
+		$this->allowExceptParams = $allowExceptParams;
+		$this->allowExceptCaseInsensitiveParams = $allowExceptCaseInsensitiveParams;
 	}
 
 
@@ -78,6 +88,32 @@ class DisallowedCall
 	public function getAllowParamsAnywhere(): array
 	{
 		return $this->allowParamsAnywhere;
+	}
+
+
+	/**
+	 * @return array<integer, integer|boolean|string>
+	 */
+	public function getAllowExceptParams(): array
+	{
+		return $this->allowExceptParams;
+	}
+
+
+	/**
+	 * @return array<integer, integer|boolean|string>
+	 */
+	public function getAllowExceptCaseInsensitiveParams(): array
+	{
+		return $this->allowExceptCaseInsensitiveParams;
+	}
+
+
+	public function getKey(): string
+	{
+		// The key consists of "initial" config values that would be overwritten with more specific details in a custom config.
+		// `allowIn` & `allowParams*` aren't included because these are set by the user in their config, not in the bundled files.
+		return serialize([$this->getCall(), $this->getAllowExceptParams(), $this->getAllowExceptCaseInsensitiveParams()]);
 	}
 
 }

--- a/src/DisallowedHelper.php
+++ b/src/DisallowedHelper.php
@@ -5,8 +5,6 @@ namespace Spaze\PHPStan\Rules\Disallowed;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr;
-use PhpParser\Node\Expr\MethodCall;
-use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
@@ -237,6 +235,8 @@ class DisallowedHelper
 	/**
 	 * @param Name|Expr $class
 	 * @param Node $node
+	 * @phpstan-param ForbiddenCalls $node
+	 * @noinspection PhpUndefinedClassInspection ForbiddenCalls is a type alias defined in PHPStan config
 	 * @param Scope $scope
 	 * @param DisallowedCall[] $disallowedCalls
 	 * @return string[]
@@ -244,8 +244,7 @@ class DisallowedHelper
 	 */
 	public function getDisallowedMethodMessage($class, Node $node, Scope $scope, array $disallowedCalls): array
 	{
-		/** @var MethodCall|StaticCall $node */
-		if (!($node->name instanceof Identifier)) {
+		if (!isset($node->name) || !($node->name instanceof Identifier)) {
 			return [];
 		}
 

--- a/src/Usages/ClassConstantUsages.php
+++ b/src/Usages/ClassConstantUsages.php
@@ -50,7 +50,7 @@ class ClassConstantUsages implements Rule
 
 
 	/**
-	 * @param Node $node
+	 * @param ClassConstFetch $node
 	 * @param Scope $scope
 	 * @return string[]
 	 * @throws ShouldNotHappenException

--- a/src/Usages/ConstantUsages.php
+++ b/src/Usages/ConstantUsages.php
@@ -46,7 +46,7 @@ class ConstantUsages implements Rule
 
 
 	/**
-	 * @param Node $node
+	 * @param ConstFetch $node
 	 * @param Scope $scope
 	 * @return string[]
 	 */

--- a/tests/Calls/FunctionCallsTest.php
+++ b/tests/Calls/FunctionCallsTest.php
@@ -69,6 +69,29 @@ class FunctionCallsTest extends RuleTestCase
 						'../src/*-allow/*.*',
 					],
 				],
+				// test disallowed param values
+				[
+					'function' => 'hash()',
+					'message' => 'MD4 very bad',
+					'allowIn' => [
+						'../src/disallowed-allowed/*.php',
+						'../src/*-allow/*.*',
+					],
+					'allowExceptParams' => [
+						1 => 'md4',
+					],
+				],
+				[
+					'function' => 'hash()',
+					'message' => 'MD5 bad',
+					'allowIn' => [
+						'../src/disallowed-allowed/*.php',
+						'../src/*-allow/*.*',
+					],
+					'allowExceptCaseInsensitiveParams' => [
+						1 => 'MD5',
+					],
+				],
 			]
 		);
 	}
@@ -111,6 +134,18 @@ class FunctionCallsTest extends RuleTestCase
 			[
 				'Calling print_r() is forbidden, nope',
 				25,
+			],
+			[
+				'Calling hash() is forbidden, MD4 very bad',
+				49,
+			],
+			[
+				'Calling hash() is forbidden, MD5 bad',
+				50,
+			],
+			[
+				'Calling hash() is forbidden, MD5 bad',
+				51,
 			],
 		]);
 		// Based on the configuration above, no errors in this file:

--- a/tests/Calls/MethodCallsTest.php
+++ b/tests/Calls/MethodCallsTest.php
@@ -70,6 +70,18 @@ class MethodCallsTest extends RuleTestCase
 						'../src/*-allow/*.*',
 					],
 				],
+				// test disallowed param values
+				[
+					'function' => 'DateTime::format()',
+					'message' => 'why too kay',
+					'allowIn' => [
+						'../src/disallowed-allowed/*.php',
+						'../src/*-allow/*.*',
+					],
+					'allowExceptParams' => [
+						1 => 'y',
+					],
+				],
 			]
 		);
 	}
@@ -116,6 +128,10 @@ class MethodCallsTest extends RuleTestCase
 			[
 				'Calling PhpOption\Some::getIterator() is forbidden, no PhpOption',
 				52,
+			],
+			[
+				'Calling DateTime::format() is forbidden, why too kay',
+				55,
 			],
 		]);
 		$this->analyse([__DIR__ . '/../src/disallowed-allow/methodCalls.php'], [

--- a/tests/Calls/NewCallsTest.php
+++ b/tests/Calls/NewCallsTest.php
@@ -33,6 +33,17 @@ class NewCallsTest extends RuleTestCase
 						'../src/*-allow/*.*',
 					],
 				],
+				[
+					'function' => 'DateTime::__construct()',
+					'message' => 'no future',
+					'allowIn' => [
+						'../src/disallowed-allowed/*.php',
+						'../src/*-allow/*.*',
+					],
+					'allowExceptCaseInsensitiveParams' => [
+						1 => 'tomorrow',
+					],
+				],
 			]
 		);
 	}
@@ -54,6 +65,10 @@ class NewCallsTest extends RuleTestCase
 				'Calling Constructor\ClassWithoutConstructor::__construct() is forbidden, class ClassWithoutConstructor should not be created',
 				36,
 			],
+			[
+				'Calling DateTime::__construct() is forbidden, no future',
+				57,
+			]
 		]);
 		// Based on the configuration above, no errors in this file:
 		$this->analyse([__DIR__ . '/../src/disallowed-allow/methodCalls.php'], []);

--- a/tests/src/disallowed-allow/functionCalls.php
+++ b/tests/src/disallowed-allow/functionCalls.php
@@ -44,3 +44,9 @@ print "hello";
 
 // backtick operator allowed by path
 `ls`;
+
+// disallowed value in an otherwise allowed param, allowed by path
+hash('md4', 'biiig nope');
+hash('md5', 'nope');
+hash('Md5', 'nOpE');
+hash('sha256', 'oh yeah but not for passwords tho');

--- a/tests/src/disallowed-allow/methodCalls.php
+++ b/tests/src/disallowed-allow/methodCalls.php
@@ -54,3 +54,4 @@ $some->getIterator();
 // disallowed value in an otherwise allowed param, allowed by path
 (new DateTime())->format('y');
 (new DateTime())->format('Y');
+new DateTime('tOmOrRoW');

--- a/tests/src/disallowed-allow/methodCalls.php
+++ b/tests/src/disallowed-allow/methodCalls.php
@@ -50,3 +50,7 @@ $none->getIterator();
  */
 $some = PhpOption\Some::create('value');
 $some->getIterator();
+
+// disallowed value in an otherwise allowed param, allowed by path
+(new DateTime())->format('y');
+(new DateTime())->format('Y');

--- a/tests/src/disallowed/functionCalls.php
+++ b/tests/src/disallowed/functionCalls.php
@@ -44,3 +44,9 @@ print "hello";
 
 // backtick operator disallowed when shell_exec() is disallowed
 `ls`;
+
+// disallowed value in an otherwise allowed param
+hash('md4', 'biiig nope');
+hash('md5', 'nope');
+hash('Md5', 'nOpE');
+hash('sha256', 'oh yeah but not for passwords tho');

--- a/tests/src/disallowed/methodCalls.php
+++ b/tests/src/disallowed/methodCalls.php
@@ -50,3 +50,7 @@ $none->getIterator();
  */
 $some = PhpOption\Some::create('value');
 $some->getIterator();
+
+// disallowed value in an otherwise allowed param
+(new DateTime())->format('y');
+(new DateTime())->format('Y');

--- a/tests/src/disallowed/methodCalls.php
+++ b/tests/src/disallowed/methodCalls.php
@@ -54,3 +54,4 @@ $some->getIterator();
 // disallowed value in an otherwise allowed param
 (new DateTime())->format('y');
 (new DateTime())->format('Y');
+new DateTime('tOmOrRoW');


### PR DESCRIPTION
Support `allowExceptParams` & `allowExceptCaseInsensitiveParams` config options to use when you need to disallow a function or a method only when a param has a specified value.

Close #62
