### PR TITLE
Allow previously forbidden call when a param with any value is present

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,29 @@ With `allowParamsAnywhere`, calls are allowed when called with all parameters li
 - `log(..., true)` anywhere
 - `log('foo', true)` in `another/file.php` or `optional/path/to/log.tests.php`
 
+Use `allowParamsInAllowedAnyValue` and `allowParamsAnywhereAnyValue` if you don't care about the parameter's value but want to make sure the parameter is passed.
+Following the previous example:
+
+```neon
+parameters:
+    disallowedMethodCalls:
+        -
+            method: 'PotentiallyDangerous\Logger::log()'
+            message: 'use our own logger instead'
+            allowIn:
+                - path/to/some/file-*.php
+                - tests/*.test.php
+            allowParamsInAllowedAnyValue:
+                - 2
+            allowParamsAnywhereAnyValue:
+                - 1
+```
+means that you should use (`...` means any value):
+- `log(...)` anywhere
+- `log(..., ...)` in `another/file.php` or `optional/path/to/log.tests.php`
+
+Such configuration only makes sense when both the parameters of `log()` are optional. If they are required, omitting them would result in an error already detected by PHPStan itself.
+
 ## Allow calls except when a param has a specified value
 
 Sometimes, it's handy to disallow a function or a method call only when a parameter matches but allow it otherwise. For example the `hash()` function, it's fine using it with algorithm families like SHA-2 & SHA-3 (not for passwords though) but you'd like PHPStan to report when it's used with MD5 like `hash('md5', ...)`.

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,7 +3,7 @@ parameters:
 		- src
 	level: max
 	typeAliases:
-		ForbiddenCallsConfig: 'array<array{function?:string, method?:string, message?:string, allowIn?:string[], allowParamsInAllowed?:array<integer, integer|boolean|string>, allowParamsAnywhere?:array<integer, integer|boolean|string>, allowExceptParams?:array<integer, integer|boolean|string>, allowExceptCaseInsensitiveParams?:array<integer, integer|boolean|string>}>'
+		ForbiddenCallsConfig: 'array<array{function?:string, method?:string, message?:string, allowIn?:string[], allowParamsInAllowed?:array<integer, integer|boolean|string>, allowParamsInAllowedAnyValue?:array<integer, integer>, allowParamsAnywhere?:array<integer, integer|boolean|string>, allowParamsAnywhereAnyValue?:array<integer, integer>, allowExceptParams?:array<integer, integer|boolean|string>, allowExceptCaseInsensitiveParams?:array<integer, integer|boolean|string>}>'
 		ForbiddenCalls: 'PhpParser\Node\Expr\FuncCall|PhpParser\Node\Expr\MethodCall|PhpParser\Node\Expr\StaticCall|PhpParser\Node\Expr\New_'
 
 includes:

--- a/src/DisallowedCallFactory.php
+++ b/src/DisallowedCallFactory.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 namespace Spaze\PHPStan\Rules\Disallowed;
 
 use PHPStan\ShouldNotHappenException;
+use Spaze\PHPStan\Rules\Disallowed\Params\DisallowedCallParamWithAnyValue;
 use Spaze\PHPStan\Rules\Disallowed\Params\DisallowedCallParamWithCaseInsensitiveValue;
 use Spaze\PHPStan\Rules\Disallowed\Params\DisallowedCallParamWithValue;
 
@@ -30,8 +31,14 @@ class DisallowedCallFactory
 			foreach ($disallowedCall['allowParamsInAllowed'] ?? [] as $param => $value) {
 				$allowParamsInAllowed[$param] = new DisallowedCallParamWithValue($value);
 			}
+			foreach ($disallowedCall['allowParamsInAllowedAnyValue'] ?? [] as $param) {
+				$allowParamsInAllowed[$param] = new DisallowedCallParamWithAnyValue();
+			}
 			foreach ($disallowedCall['allowParamsAnywhere'] ?? [] as $param => $value) {
 				$allowParamsAnywhere[$param] = new DisallowedCallParamWithValue($value);
+			}
+			foreach ($disallowedCall['allowParamsAnywhereAnyValue'] ?? [] as $param) {
+				$allowParamsAnywhere[$param] = new DisallowedCallParamWithAnyValue();
 			}
 			foreach ($disallowedCall['allowExceptParams'] ?? [] as $param => $value) {
 				$allowExceptParams[$param] = new DisallowedCallParamWithValue($value);

--- a/src/Params/DisallowedCallParamWithAnyValue.php
+++ b/src/Params/DisallowedCallParamWithAnyValue.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Rules\Disallowed\Params;
+
+use PHPStan\Type\ConstantScalarType;
+
+class DisallowedCallParamWithAnyValue implements DisallowedCallParam
+{
+
+	public function matches(ConstantScalarType $type): bool
+	{
+		return true;
+	}
+
+}

--- a/tests/Calls/FunctionCallsTest.php
+++ b/tests/Calls/FunctionCallsTest.php
@@ -94,6 +94,32 @@ class FunctionCallsTest extends RuleTestCase
 						1 => 'MD5',
 					],
 				],
+				[
+					'function' => 'setcookie()',
+					'allowIn' => [
+						'../src/disallowed-allowed/*.php',
+						'../src/*-allow/*.*',
+					],
+					'allowParamsAnywhere' => [
+						3 => 0,
+					],
+					'allowParamsInAllowed' => [
+						4 => '/',
+					],
+				],
+				[
+					'function' => 'header()',
+					'allowIn' => [
+						'../src/disallowed-allowed/*.php',
+						'../src/*-allow/*.*',
+					],
+					'allowParamsAnywhereAnyValue' => [
+						2,
+					],
+					'allowParamsInAllowedAnyValue' => [
+						3,
+					],
+				],
 			]
 		);
 	}
@@ -149,9 +175,34 @@ class FunctionCallsTest extends RuleTestCase
 				'Calling hash() is forbidden, MD5 bad',
 				51,
 			],
+			[
+				'Calling setcookie() is forbidden, because reasons',
+				55,
+			],
+			[
+				'Calling header() is forbidden, because reasons',
+				60,
+			],
 		]);
 		// Based on the configuration above, no errors in this file:
-		$this->analyse([__DIR__ . '/../src/disallowed-allow/functionCalls.php'], []);
+		$this->analyse([__DIR__ . '/../src/disallowed-allow/functionCalls.php'], [
+			[
+				'Calling setcookie() is forbidden, because reasons',
+				55,
+			],
+			[
+				'Calling setcookie() is forbidden, because reasons',
+				56,
+			],
+			[
+				'Calling header() is forbidden, because reasons',
+				60,
+			],
+			[
+				'Calling header() is forbidden, because reasons',
+				61,
+			],
+		]);
 	}
 
 }

--- a/tests/src/disallowed-allow/functionCalls.php
+++ b/tests/src/disallowed-allow/functionCalls.php
@@ -50,3 +50,13 @@ hash('md4', 'biiig nope');
 hash('md5', 'nope');
 hash('Md5', 'nOpE');
 hash('sha256', 'oh yeah but not for passwords tho');
+
+// third param needed
+setcookie('foo', 'bar');
+setcookie('foo', 'bar', 0);
+setcookie('foo', 'bar', 0, '/');
+
+// third param needed, any value
+header('foo: bar');
+header('foo: bar', true);
+header('foo: bar', false, 303);

--- a/tests/src/disallowed/functionCalls.php
+++ b/tests/src/disallowed/functionCalls.php
@@ -50,3 +50,13 @@ hash('md4', 'biiig nope');
 hash('md5', 'nope');
 hash('Md5', 'nOpE');
 hash('sha256', 'oh yeah but not for passwords tho');
+
+// second param needed
+setcookie('foo', 'bar');
+setcookie('foo', 'bar', 0);
+setcookie('foo', 'bar', 0, '/');
+
+// second param needed, any value
+header('foo: bar');
+header('foo: bar', true);
+header('foo: bar', false, 303);


### PR DESCRIPTION
Use `allowParamsInAllowedAnyValue` and `allowParamsAnywhereAnyValue` if you don't care about the parameter's value but want to make sure the parameter is passed.

Close #66