### PR TITLE
`allowExceptParamsInAllowed` config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ Such configuration only makes sense when both the parameters of `log()` are opti
 ## Allow calls except when a param has a specified value
 
 Sometimes, it's handy to disallow a function or a method call only when a parameter matches but allow it otherwise. For example the `hash()` function, it's fine using it with algorithm families like SHA-2 & SHA-3 (not for passwords though) but you'd like PHPStan to report when it's used with MD5 like `hash('md5', ...)`.
-You can use `allowExceptParams` & `allowExceptCaseInsensitiveParams` config options to disallow only some calls:
+You can use `allowExceptParams`, `allowExceptCaseInsensitiveParams`, `allowExceptParamsInAllowed` config options to disallow only some calls:
 
 ```neon
 parameters:
@@ -302,6 +302,23 @@ parameters:
             	2: 'baz'
 ```
 will disallow `foo('bar', 'baz')` but not `foo('bar', 'BAZ')`.
+
+It's also possible to disallow functions and methods previously allowed by path (using `allowIn`) or by function/method name (`allowInMethods`) when they're called with specified parameters, and allow when called with any other parameter. This is done using the `allowExceptParamsInAllowed` config option.
+
+Take this example configuration:
+
+```neon
+parameters:
+    disallowedFunctionCalls:
+        -
+            function: 'waldo()'
+            allowIn:
+                - 'views/*'
+            allowExceptParamsInAllowed:
+                2: 'quux'
+```
+
+Calling `waldo()` is disallowed, and allowed back again only when the file is in the `views/` subdirectory **and** `waldo()` is called in the file with a 2nd parameter being the string `quux`.
 
 ## Detect disallowed calls without any other PHPStan rules
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,7 +3,7 @@ parameters:
 		- src
 	level: max
 	typeAliases:
-		ForbiddenCallsConfig: 'array<array{function?:string, method?:string, message?:string, allowIn?:string[], allowInFunctions?:string[], allowInMethods?:string[], allowParamsInAllowed?:array<integer, integer|boolean|string>, allowParamsInAllowedAnyValue?:array<integer, integer>, allowParamsAnywhere?:array<integer, integer|boolean|string>, allowParamsAnywhereAnyValue?:array<integer, integer>, allowExceptParams?:array<integer, integer|boolean|string>, allowExceptCaseInsensitiveParams?:array<integer, integer|boolean|string>}>'
+		ForbiddenCallsConfig: 'array<array{function?:string, method?:string, message?:string, allowIn?:string[], allowInFunctions?:string[], allowInMethods?:string[], allowParamsInAllowed?:array<integer, integer|boolean|string>, allowParamsInAllowedAnyValue?:array<integer, integer>, allowParamsAnywhere?:array<integer, integer|boolean|string>, allowParamsAnywhereAnyValue?:array<integer, integer>, allowExceptParamsInAllowed?:array<integer, integer|boolean|string>, allowExceptParams?:array<integer, integer|boolean|string>, allowExceptCaseInsensitiveParams?:array<integer, integer|boolean|string>}>'
 		ForbiddenCalls: 'PhpParser\Node\Expr\FuncCall|PhpParser\Node\Expr\MethodCall|PhpParser\Node\Expr\StaticCall|PhpParser\Node\Expr\New_'
 
 includes:

--- a/src/DisallowedCall.php
+++ b/src/DisallowedCall.php
@@ -27,6 +27,9 @@ class DisallowedCall
 	private $allowParamsAnywhere;
 
 	/** @var array<integer, DisallowedCallParam> */
+	private $allowExceptParamsInAllowed;
+
+	/** @var array<integer, DisallowedCallParam> */
 	private $allowExceptParams;
 
 
@@ -39,9 +42,10 @@ class DisallowedCall
 	 * @param string[] $allowInCalls
 	 * @param array<integer, DisallowedCallParam> $allowParamsInAllowed
 	 * @param array<integer, DisallowedCallParam> $allowParamsAnywhere
+	 * @param array<integer, DisallowedCallParam> $allowExceptParamsInAllowed
 	 * @param array<integer, DisallowedCallParam> $allowExceptParams
 	 */
-	public function __construct(string $call, ?string $message, array $allowIn, array $allowInCalls, array $allowParamsInAllowed, array $allowParamsAnywhere, array $allowExceptParams)
+	public function __construct(string $call, ?string $message, array $allowIn, array $allowInCalls, array $allowParamsInAllowed, array $allowParamsAnywhere, array $allowExceptParamsInAllowed, array $allowExceptParams)
 	{
 		$this->call = $call;
 		$this->message = $message;
@@ -49,6 +53,7 @@ class DisallowedCall
 		$this->allowInCalls = $allowInCalls;
 		$this->allowParamsInAllowed = $allowParamsInAllowed;
 		$this->allowParamsAnywhere = $allowParamsAnywhere;
+		$this->allowExceptParamsInAllowed = $allowExceptParamsInAllowed;
 		$this->allowExceptParams = $allowExceptParams;
 	}
 
@@ -104,6 +109,15 @@ class DisallowedCall
 	/**
 	 * @return array<integer, DisallowedCallParam>
 	 */
+	public function getAllowExceptParamsInAllowed(): array
+	{
+		return $this->allowExceptParamsInAllowed;
+	}
+
+
+	/**
+	 * @return array<integer, DisallowedCallParam>
+	 */
 	public function getAllowExceptParams(): array
 	{
 		return $this->allowExceptParams;
@@ -113,7 +127,7 @@ class DisallowedCall
 	public function getKey(): string
 	{
 		// The key consists of "initial" config values that would be overwritten with more specific details in a custom config.
-		// `allowIn` & `allowParams*` aren't included because these are set by the user in their config, not in the bundled files.
+		// `allowIn` & `allowParams*` & few others aren't included because these are set by the user in their config, not in the bundled files.
 		return serialize([$this->getCall(), $this->getAllowExceptParams()]);
 	}
 

--- a/src/DisallowedCallFactory.php
+++ b/src/DisallowedCallFactory.php
@@ -4,8 +4,9 @@ declare(strict_types = 1);
 namespace Spaze\PHPStan\Rules\Disallowed;
 
 use PHPStan\ShouldNotHappenException;
+use Spaze\PHPStan\Rules\Disallowed\Params\DisallowedCallParamExceptCaseInsensitiveValue;
+use Spaze\PHPStan\Rules\Disallowed\Params\DisallowedCallParamExceptValue;
 use Spaze\PHPStan\Rules\Disallowed\Params\DisallowedCallParamWithAnyValue;
-use Spaze\PHPStan\Rules\Disallowed\Params\DisallowedCallParamWithCaseInsensitiveValue;
 use Spaze\PHPStan\Rules\Disallowed\Params\DisallowedCallParamWithValue;
 
 class DisallowedCallFactory
@@ -27,7 +28,7 @@ class DisallowedCallFactory
 				throw new ShouldNotHappenException("Either 'method' or 'function' must be set in configuration items");
 			}
 
-			$allowInCalls = $allowParamsInAllowed = $allowParamsAnywhere = $allowExceptParams = [];
+			$allowInCalls = $allowParamsInAllowed = $allowParamsAnywhere = $allowExceptParamsInAllowed = $allowExceptParams = [];
 			foreach ($disallowedCall['allowInFunctions'] ?? $disallowedCall['allowInMethods'] ?? [] as $allowedCall) {
 				$allowInCalls[] = $this->normalizeCall($allowedCall);
 			}
@@ -43,11 +44,14 @@ class DisallowedCallFactory
 			foreach ($disallowedCall['allowParamsAnywhereAnyValue'] ?? [] as $param) {
 				$allowParamsAnywhere[$param] = new DisallowedCallParamWithAnyValue();
 			}
+			foreach ($disallowedCall['allowExceptParamsInAllowed'] ?? [] as $param => $value) {
+				$allowExceptParamsInAllowed[$param] = new DisallowedCallParamExceptValue($value);
+			}
 			foreach ($disallowedCall['allowExceptParams'] ?? [] as $param => $value) {
-				$allowExceptParams[$param] = new DisallowedCallParamWithValue($value);
+				$allowExceptParams[$param] = new DisallowedCallParamExceptValue($value);
 			}
 			foreach ($disallowedCall['allowExceptCaseInsensitiveParams'] ?? [] as $param => $value) {
-				$allowExceptParams[$param] = new DisallowedCallParamWithCaseInsensitiveValue($value);
+				$allowExceptParams[$param] = new DisallowedCallParamExceptCaseInsensitiveValue($value);
 			}
 			$disallowedCall = new DisallowedCall(
 				$this->normalizeCall($call),
@@ -56,6 +60,7 @@ class DisallowedCallFactory
 				$allowInCalls,
 				$allowParamsInAllowed,
 				$allowParamsAnywhere,
+				$allowExceptParamsInAllowed,
 				$allowExceptParams
 			);
 			$calls[$disallowedCall->getKey()] = $disallowedCall;

--- a/src/Params/DisallowedCallParamExceptCaseInsensitiveValue.php
+++ b/src/Params/DisallowedCallParamExceptCaseInsensitiveValue.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Rules\Disallowed\Params;
+
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\ConstantScalarType;
+
+class DisallowedCallParamExceptCaseInsensitiveValue implements DisallowedCallParam
+{
+
+	/** @var integer|boolean|string */
+	private $value;
+
+
+	/**
+	 * @param integer|boolean|string $value
+	 */
+	public function __construct($value)
+	{
+		$this->value = $value;
+	}
+
+
+	public function matches(ConstantScalarType $type): bool
+	{
+		$a = is_string($this->value) ? strtolower($this->value) : $this->value;
+		$b = $type instanceof ConstantStringType ? strtolower($type->getValue()) : $type->getValue();
+		return $a !== $b;
+	}
+
+
+	/**
+	 * @return integer|boolean|string
+	 */
+	public function getValue()
+	{
+		return $this->value;
+	}
+
+}

--- a/src/Params/DisallowedCallParamExceptValue.php
+++ b/src/Params/DisallowedCallParamExceptValue.php
@@ -3,10 +3,9 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Rules\Disallowed\Params;
 
-use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\ConstantScalarType;
 
-class DisallowedCallParamWithCaseInsensitiveValue implements DisallowedCallParam
+class DisallowedCallParamExceptValue implements DisallowedCallParam
 {
 
 	/** @var integer|boolean|string */
@@ -24,9 +23,7 @@ class DisallowedCallParamWithCaseInsensitiveValue implements DisallowedCallParam
 
 	public function matches(ConstantScalarType $type): bool
 	{
-		$a = is_string($this->value) ? strtolower($this->value) : $this->value;
-		$b = $type instanceof ConstantStringType ? strtolower($type->getValue()) : $type->getValue();
-		return $a === $b;
+		return $this->value !== $type->getValue();
 	}
 
 

--- a/tests/Calls/FunctionCallsTest.php
+++ b/tests/Calls/FunctionCallsTest.php
@@ -52,6 +52,9 @@ class FunctionCallsTest extends RuleTestCase
 						'../src/disallowed-allowed/*.php',
 						'../src/*-allow/*.*',
 					],
+					'allowExceptParamsInAllowed' => [
+						1 => 123,
+					],
 				],
 				[
 					'function' => 'shell_*',
@@ -216,6 +219,10 @@ class FunctionCallsTest extends RuleTestCase
 		]);
 		// Based on the configuration above, no errors in this file:
 		$this->analyse([__DIR__ . '/../src/disallowed-allow/functionCalls.php'], [
+			[
+				'Calling Foo\Bar\waldo() is forbidden, whoa, a namespace',
+				11,
+			],
 			[
 				'Calling setcookie() is forbidden, because reasons',
 				57,

--- a/tests/src/disallowed-allow/functionCalls.php
+++ b/tests/src/disallowed-allow/functionCalls.php
@@ -8,7 +8,7 @@ var_dump('foo', true);
 print_r('bar');
 \printf('foobar');
 \Foo\Bar\waldo();
-waldo();
+waldo(123);
 shell_exec('foo --bar');
 exec('bar --foo');
 

--- a/tests/src/disallowed/functionCalls.php
+++ b/tests/src/disallowed/functionCalls.php
@@ -8,7 +8,7 @@ var_dump('foo', true);
 print_r('bar');
 \printf('foobar');
 \Foo\Bar\waldo();
-waldo();
+waldo(123);
 shell_exec('foo --bar');
 exec('bar --foo');
 


### PR DESCRIPTION
When you want to allow the call in allowed paths/calls only when it's not using those params