### PR TITLE
Use `CallLike->getArgs()` to support PHP 8.1's first-class callable in PHP Parser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 	},
 	"require": {
 		"php": "^7.1 || ^8.0",
-		"phpstan/phpstan": "^0.12"
+		"phpstan/phpstan": "^1.0"
 	},
 	"require-dev": {
 		"nette/neon": "^3.2",
@@ -29,6 +29,8 @@
 		"php-parallel-lint/php-console-highlighter": "^0.5.0",
 		"spaze/coding-standard": "^0.0"
 	},
+	"minimum-stability": "dev",
+	"prefer-stable": true,
 	"autoload": {
 		"psr-4": {"Spaze\\PHPStan\\Rules\\Disallowed\\": "src"}
 	},

--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,6 @@
 		"php-parallel-lint/php-console-highlighter": "^0.5.0",
 		"spaze/coding-standard": "^0.0"
 	},
-	"minimum-stability": "dev",
-	"prefer-stable": true,
 	"autoload": {
 		"psr-4": {"Spaze\\PHPStan\\Rules\\Disallowed\\": "src"}
 	},

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 	},
 	"require-dev": {
 		"nette/neon": "^3.2",
-		"nikic/php-parser": "~4.12.0",
+		"nikic/php-parser": "^4.13",
 		"phpunit/phpunit": "^7.0 || ^9.4.2",
 		"php-parallel-lint/php-parallel-lint": "^1.2",
 		"php-parallel-lint/php-console-highlighter": "^0.5.0",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,7 +4,6 @@ parameters:
 	level: max
 	typeAliases:
 		ForbiddenCallsConfig: 'array<array{function?:string, method?:string, message?:string, allowIn?:string[], allowInFunctions?:string[], allowInMethods?:string[], allowParamsInAllowed?:array<integer, integer|boolean|string>, allowParamsInAllowedAnyValue?:array<integer, integer>, allowParamsAnywhere?:array<integer, integer|boolean|string>, allowParamsAnywhereAnyValue?:array<integer, integer>, allowExceptParamsInAllowed?:array<integer, integer|boolean|string>, allowExceptParams?:array<integer, integer|boolean|string>, allowExceptCaseInsensitiveParams?:array<integer, integer|boolean|string>}>'
-		ForbiddenCalls: 'PhpParser\Node\Expr\FuncCall|PhpParser\Node\Expr\MethodCall|PhpParser\Node\Expr\StaticCall|PhpParser\Node\Expr\New_'
 
 includes:
 	- vendor/phpstan/phpstan/conf/bleedingEdge.neon

--- a/src/DisallowedHelper.php
+++ b/src/DisallowedHelper.php
@@ -5,6 +5,7 @@ namespace Spaze\PHPStan\Rules\Disallowed;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\CallLike;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
@@ -116,16 +117,16 @@ class DisallowedHelper
 
 
 	/**
-	 * @param Expr $node
+	 * @param CallLike $node
 	 * @phpstan-param ForbiddenCalls $node
 	 * @noinspection PhpUndefinedClassInspection ForbiddenCalls is a type alias defined in PHPStan config
 	 * @param Scope $scope
 	 * @param int $param
 	 * @return Type|null
 	 */
-	private function getArgType(Node $node, Scope $scope, int $param): ?Type
+	private function getArgType(CallLike $node, Scope $scope, int $param): ?Type
 	{
-		$arg = $node->args[$param - 1] ?? null;
+		$arg = $node->getArgs()[$param - 1] ?? null;
 		return $arg ? $scope->getType($arg->value) : null;
 	}
 

--- a/src/DisallowedHelper.php
+++ b/src/DisallowedHelper.php
@@ -3,7 +3,6 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Rules\Disallowed;
 
-use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\CallLike;
 use PhpParser\Node\Identifier;
@@ -31,15 +30,7 @@ class DisallowedHelper
 	}
 
 
-	/**
-	 * @param Scope $scope
-	 * @param Expr|null $node
-	 * @phpstan-param ForbiddenCalls|null $node
-	 * @noinspection PhpUndefinedClassInspection ForbiddenCalls is a type alias defined in PHPStan config
-	 * @param DisallowedCall $disallowedCall
-	 * @return bool
-	 */
-	private function isAllowed(Scope $scope, ?Node $node, DisallowedCall $disallowedCall): bool
+	private function isAllowed(Scope $scope, ?CallLike $node, DisallowedCall $disallowedCall): bool
 	{
 		foreach ($disallowedCall->getAllowInCalls() as $call) {
 			if ($scope->getFunction() instanceof MethodReflection) {
@@ -68,15 +59,7 @@ class DisallowedHelper
 	}
 
 
-	/**
-	 * @param Scope $scope
-	 * @param Expr|null $node
-	 * @phpstan-param ForbiddenCalls|null $node
-	 * @noinspection PhpUndefinedClassInspection ForbiddenCalls is a type alias defined in PHPStan config
-	 * @param DisallowedCall $disallowedCall
-	 * @return bool
-	 */
-	private function hasAllowedParamsInAllowed(Scope $scope, ?Node $node, DisallowedCall $disallowedCall): bool
+	private function hasAllowedParamsInAllowed(Scope $scope, ?CallLike $node, DisallowedCall $disallowedCall): bool
 	{
 		if ($disallowedCall->getAllowExceptParamsInAllowed()) {
 			return $this->hasAllowedParams($scope, $node, $disallowedCall->getAllowExceptParamsInAllowed(), false);
@@ -90,14 +73,12 @@ class DisallowedHelper
 
 	/**
 	 * @param Scope $scope
-	 * @param Expr|null $node
-	 * @phpstan-param ForbiddenCalls|null $node
-	 * @noinspection PhpUndefinedClassInspection ForbiddenCalls is a type alias defined in PHPStan config
+	 * @param CallLike|null $node
 	 * @param array<int, DisallowedCallParam> $allowConfig
 	 * @param bool $paramsRequired
 	 * @return bool
 	 */
-	private function hasAllowedParams(Scope $scope, ?Node $node, array $allowConfig, bool $paramsRequired): bool
+	private function hasAllowedParams(Scope $scope, ?CallLike $node, array $allowConfig, bool $paramsRequired): bool
 	{
 		if (!$node) {
 			return true;
@@ -116,14 +97,6 @@ class DisallowedHelper
 	}
 
 
-	/**
-	 * @param CallLike $node
-	 * @phpstan-param ForbiddenCalls $node
-	 * @noinspection PhpUndefinedClassInspection ForbiddenCalls is a type alias defined in PHPStan config
-	 * @param Scope $scope
-	 * @param int $param
-	 * @return Type|null
-	 */
 	private function getArgType(CallLike $node, Scope $scope, int $param): ?Type
 	{
 		$arg = $node->getArgs()[$param - 1] ?? null;
@@ -132,9 +105,7 @@ class DisallowedHelper
 
 
 	/**
-	 * @param Expr|null $node
-	 * @phpstan-param ForbiddenCalls|null $node
-	 * @noinspection PhpUndefinedClassInspection ForbiddenCalls is a type alias defined in PHPStan config
+	 * @param CallLike|null $node
 	 * @param Scope $scope
 	 * @param string $name
 	 * @param string|null $displayName
@@ -142,7 +113,7 @@ class DisallowedHelper
 	 * @param string|null $message
 	 * @return string[]
 	 */
-	public function getDisallowedMessage(?Node $node, Scope $scope, string $name, ?string $displayName, array $disallowedCalls, ?string $message = null): array
+	public function getDisallowedMessage(?CallLike $node, Scope $scope, string $name, ?string $displayName, array $disallowedCalls, ?string $message = null): array
 	{
 		foreach ($disallowedCalls as $disallowedCall) {
 			if ($this->callMatches($disallowedCall, $name) && !$this->isAllowed($scope, $node, $disallowedCall)) {
@@ -160,12 +131,6 @@ class DisallowedHelper
 	}
 
 
-	/**
-	 * @noinspection PhpUndefinedClassInspection ForbiddenCalls is a type alias defined in PHPStan config
-	 * @param DisallowedCall $disallowedCall
-	 * @param string $name
-	 * @return bool
-	 */
 	private function callMatches(DisallowedCall $disallowedCall, string $name): bool
 	{
 		if ($name === $disallowedCall->getCall() || fnmatch($disallowedCall->getCall(), $name, FNM_NOESCAPE)) {
@@ -177,15 +142,13 @@ class DisallowedHelper
 
 	/**
 	 * @param Name|Expr $class
-	 * @param Node $node
-	 * @phpstan-param ForbiddenCalls $node
-	 * @noinspection PhpUndefinedClassInspection ForbiddenCalls is a type alias defined in PHPStan config
+	 * @param CallLike $node
 	 * @param Scope $scope
 	 * @param DisallowedCall[] $disallowedCalls
 	 * @return string[]
 	 * @throws ClassNotFoundException
 	 */
-	public function getDisallowedMethodMessage($class, Node $node, Scope $scope, array $disallowedCalls): array
+	public function getDisallowedMethodMessage($class, CallLike $node, Scope $scope, array $disallowedCalls): array
 	{
 		if (!isset($node->name) || !($node->name instanceof Identifier)) {
 			return [];


### PR DESCRIPTION
Use `CallLike->getArgs()` instead of `Node->args` (where `Node` is `FuncCall` etc.) because that excludes PHP 8.1's first-class callable "args".

The tests are now failing because they need PHPStan that uses that version of PHP Parser which has not been released yet (although nikic/php-parser was already updated in phpstan/phpstan-src@1c6ce5d).

When the new PHPStan version is released, version constraint should be updated here. (Will it be PHPStan 0.12.100? Or 1.0?)

Close #81
Close #85 