### PR TITLE
Use PHP Parser 4.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
 	},
 	"require-dev": {
 		"nette/neon": "^3.2",
+		"nikic/php-parser": "~4.12.0",
 		"phpunit/phpunit": "^7.0 || ^9.4.2",
 		"php-parallel-lint/php-parallel-lint": "^1.2",
 		"php-parallel-lint/php-console-highlighter": "^0.5.0",


### PR DESCRIPTION
Because 4.13 introduced support for first-class callables which breaks things, see #81.

Close #83