### PR TITLE
Add missing `int()` to `disallowedMethodCalls` type structure

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -22,7 +22,8 @@ parametersSchema:
 			anyOf(
 				string(),
 				listOf(string()),
-				arrayOf(anyOf(int(), string(), bool()))
+				arrayOf(anyOf(int(), string(), bool())),
+				int()
 			)
 		)
 	)


### PR DESCRIPTION
Forgot to add this in https://github.com/spaze/phpstan-disallowed-calls/pull/87
Fixes:
```
Invalid configuration:
The option 'parameters › disallowedMethodCalls › 2 › allowCount' expects to be string|list|array, 1 given.
```

Too bad the tests don't pick this up :(