### PR TITLE
Case-(in)sensitivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,10 @@ parameters:
 
 Calling `waldo()` is disallowed, and allowed back again only when the file is in the `views/` subdirectory **and** `waldo()` is called in the file with a 2nd parameter being the string `quux`.
 
+## Case-(in)sensitivity
+
+Function names, method names, namespaces are matched irrespective of their case (disallowing `print_r` will also find `print_R` calls), while anything else like constants, file names, paths are not.
+
 ## Detect disallowed calls without any other PHPStan rules
 
 If you want to use this PHPStan extension without running any other PHPStan rules, you can use `phpstan.neon` config file that looks like this (the `customRulesetUsed: true` and the missing `level` key are the important bits):

--- a/src/DisallowedHelper.php
+++ b/src/DisallowedHelper.php
@@ -40,7 +40,7 @@ class DisallowedHelper
 			} else {
 				$name = '';
 			}
-			if (fnmatch($call, $name, FNM_NOESCAPE)) {
+			if (fnmatch($call, $name, FNM_NOESCAPE | FNM_CASEFOLD)) {
 				return $this->hasAllowedParamsInAllowed($scope, $node, $disallowedCall);
 			}
 		}
@@ -133,7 +133,7 @@ class DisallowedHelper
 
 	private function callMatches(DisallowedCall $disallowedCall, string $name): bool
 	{
-		if ($name === $disallowedCall->getCall() || fnmatch($disallowedCall->getCall(), $name, FNM_NOESCAPE)) {
+		if ($name === $disallowedCall->getCall() || fnmatch($disallowedCall->getCall(), $name, FNM_NOESCAPE | FNM_CASEFOLD)) {
 			return true;
 		}
 		return false;

--- a/src/DisallowedNamespaceHelper.php
+++ b/src/DisallowedNamespaceHelper.php
@@ -72,7 +72,7 @@ class DisallowedNamespaceHelper
 			return true;
 		}
 
-		if (fnmatch($pattern, $value, FNM_NOESCAPE)) {
+		if (fnmatch($pattern, $value, FNM_NOESCAPE | FNM_CASEFOLD)) {
 			return true;
 		}
 

--- a/tests/Calls/FunctionCallsAllowInMethodsTest.php
+++ b/tests/Calls/FunctionCallsAllowInMethodsTest.php
@@ -28,7 +28,7 @@ class FunctionCallsAllowInMethodsTest extends RuleTestCase
 				[
 					'function' => 'sha1_file()',
 					'allowInFunctions' => [
-						'\\Fiction\\Pulp\\Royale::withoutCheese()',
+						'\\Fiction\\Pulp\\Royale::WithoutCheese()',
 					],
 					'allowParamsInAllowed' => [
 						2 => true,

--- a/tests/Calls/FunctionCallsTest.php
+++ b/tests/Calls/FunctionCallsTest.php
@@ -161,7 +161,7 @@ class FunctionCallsTest extends RuleTestCase
 				7,
 			],
 			[
-				'Calling print_r() is forbidden, nope',
+				'Calling print_R() is forbidden, nope [print_R() matches print_r()]',
 				8,
 			],
 			[

--- a/tests/Calls/MethodCallsTest.php
+++ b/tests/Calls/MethodCallsTest.php
@@ -33,6 +33,30 @@ class MethodCallsTest extends RuleTestCase
 					],
 				],
 				[
+					'method' => 'Waldo\Quux\Blade::movie()',
+					'message' => 'was good',
+					'allowIn' => [
+						'../src/disallowed-allowed/*.php',
+						'../src/*-allow/*.*',
+					],
+				],
+				[
+					'method' => 'Waldo\Quux\Blade::sequel()',
+					'message' => 'too',
+					'allowIn' => [
+						'../src/disallowed-allowed/*.php',
+						'../src/*-allow/*.*',
+					],
+				],
+				[
+					'method' => 'Waldo\Quux\Blade::Trinity()',
+					'message' => 'holy trinity',
+					'allowIn' => [
+						'../src/disallowed-allowed/*.php',
+						'../src/*-allow/*.*',
+					],
+				],
+				[
 					'method' => 'Inheritance\Base::x*()',
 					'message' => 'Base::x*() methods are dangerous',
 					'allowIn' => [
@@ -134,6 +158,30 @@ class MethodCallsTest extends RuleTestCase
 			[
 				'Calling DateTime::format() is forbidden, why too kay',
 				55,
+			],
+			[
+				'Calling Waldo\Quux\Blade::movie() is forbidden, was good',
+				60,
+			],
+			[
+				'Calling Waldo\Quux\Blade::movie() is forbidden, was good',
+				61,
+			],
+			[
+				'Calling Waldo\Quux\Blade::Sequel() is forbidden, too [Waldo\Quux\Blade::Sequel() matches Waldo\Quux\Blade::sequel()]',
+				62,
+			],
+			[
+				'Calling Waldo\Quux\Blade::Sequel() is forbidden, too [Waldo\Quux\Blade::Sequel() matches Waldo\Quux\Blade::sequel()]',
+				63,
+			],
+			[
+				'Calling Waldo\Quux\Blade::trinity() is forbidden, holy trinity [Waldo\Quux\Blade::trinity() matches Waldo\Quux\Blade::Trinity()]',
+				64,
+			],
+			[
+				'Calling Waldo\Quux\Blade::trinity() is forbidden, holy trinity [Waldo\Quux\Blade::trinity() matches Waldo\Quux\Blade::Trinity()]',
+				65,
 			],
 		]);
 		$this->analyse([__DIR__ . '/../src/disallowed-allow/methodCalls.php'], [

--- a/tests/Calls/StaticCallsTest.php
+++ b/tests/Calls/StaticCallsTest.php
@@ -38,7 +38,7 @@ class StaticCallsTest extends RuleTestCase
 					'allowParamsInAllowed' => [],
 				],
 				[
-					'method' => 'Fiction\Pulp\Royale::withoutCheese',
+					'method' => 'Fiction\Pulp\Royale::WithoutCheese',
 					'message' => 'a Quarter Pounder without Cheese?',
 					'allowIn' => [
 						'../src/disallowed-allowed/*.php',
@@ -123,19 +123,19 @@ class StaticCallsTest extends RuleTestCase
 				8,
 			],
 			[
-				'Calling Fiction\Pulp\Royale::withBadCheese() is forbidden, a Quarter Pounder with Cheese? [Fiction\Pulp\Royale::withBadCheese() matches Fiction\Pulp\*::withBad*()]',
+				'Calling Fiction\Pulp\Royale::WithBadCheese() is forbidden, a Quarter Pounder with Cheese? [Fiction\Pulp\Royale::WithBadCheese() matches Fiction\Pulp\*::withBad*()]',
 				9,
 			],
 			[
-				'Calling Fiction\Pulp\Royale::withoutCheese() is forbidden, a Quarter Pounder without Cheese?',
+				'Calling Fiction\Pulp\Royale::withoutCheese() is forbidden, a Quarter Pounder without Cheese? [Fiction\Pulp\Royale::withoutCheese() matches Fiction\Pulp\Royale::WithoutCheese()]',
 				12,
 			],
 			[
-				'Calling Fiction\Pulp\Royale::withoutCheese() is forbidden, a Quarter Pounder without Cheese?',
+				'Calling Fiction\Pulp\Royale::withoutCheese() is forbidden, a Quarter Pounder without Cheese? [Fiction\Pulp\Royale::withoutCheese() matches Fiction\Pulp\Royale::WithoutCheese()]',
 				14,
 			],
 			[
-				'Calling Fiction\Pulp\Royale::withoutCheese() is forbidden, a Quarter Pounder without Cheese?',
+				'Calling Fiction\Pulp\Royale::withoutCheese() is forbidden, a Quarter Pounder without Cheese? [Fiction\Pulp\Royale::withoutCheese() matches Fiction\Pulp\Royale::WithoutCheese()]',
 				18,
 			],
 			[
@@ -165,11 +165,11 @@ class StaticCallsTest extends RuleTestCase
 		]);
 		$this->analyse([__DIR__ . '/../src/disallowed-allow/staticCalls.php'], [
 			[
-				'Calling Fiction\Pulp\Royale::withoutCheese() is forbidden, a Quarter Pounder without Cheese?',
+				'Calling Fiction\Pulp\Royale::withoutCheese() is forbidden, a Quarter Pounder without Cheese? [Fiction\Pulp\Royale::withoutCheese() matches Fiction\Pulp\Royale::WithoutCheese()]',
 				18,
 			],
 			[
-				'Calling Fiction\Pulp\Royale::withoutCheese() is forbidden, a Quarter Pounder without Cheese?',
+				'Calling Fiction\Pulp\Royale::withoutCheese() is forbidden, a Quarter Pounder without Cheese? [Fiction\Pulp\Royale::withoutCheese() matches Fiction\Pulp\Royale::WithoutCheese()]',
 				21,
 			],
 		]);

--- a/tests/Usages/NamespaceUsagesTest.php
+++ b/tests/Usages/NamespaceUsagesTest.php
@@ -52,7 +52,7 @@ class NamespaceUsagesTest extends RuleTestCase
 					],
 				],
 				[
-					'namespace' => 'Waldo\Foo\Bar',
+					'namespace' => 'Waldo\Foo\bar',
 					'message' => 'no FooBar',
 					'allowIn' => [
 						'../src/disallowed-allowed/*.php',
@@ -95,11 +95,11 @@ class NamespaceUsagesTest extends RuleTestCase
 				9,
 			],
 			[
-				'Namespace Waldo\Foo\Bar is forbidden, no FooBar',
+				'Namespace Waldo\Foo\Bar is forbidden, no FooBar [Waldo\Foo\Bar matches Waldo\Foo\bar]',
 				10,
 			],
 			[
-				'Namespace Waldo\Quux\Blade is forbidden, no blade',
+				'Namespace Waldo\Quux\blade is forbidden, no blade [Waldo\Quux\blade matches Waldo\Quux\Blade]',
 				11,
 			],
 			[
@@ -115,16 +115,16 @@ class NamespaceUsagesTest extends RuleTestCase
 				16,
 			],
 			[
-				'Namespace Waldo\Quux\Blade is forbidden, no blade',
-				22,
+				'Namespace Waldo\Quux\blade is forbidden, no blade [Waldo\Quux\blade matches Waldo\Quux\Blade]',
+				23,
 			],
 			[
 				'Namespace Inheritance\Sub is forbidden, no sub',
-				30,
+				31,
 			],
 			[
-				'Namespace Waldo\Foo\Bar is forbidden, no FooBar',
-				36,
+				'Namespace Waldo\Foo\Bar is forbidden, no FooBar [Waldo\Foo\Bar matches Waldo\Foo\bar]',
+				37,
 			],
 		]);
 		$this->analyse([__DIR__ . '/../src/disallowed-allow/namespaceUsages.php'], []);

--- a/tests/libs/Blade.php
+++ b/tests/libs/Blade.php
@@ -20,4 +20,19 @@ class Blade
 	{
 	}
 
+
+	public function movie(): void
+	{
+	}
+
+
+	public function Sequel(): void
+	{
+	}
+
+
+	public function trinity(): void
+	{
+	}
+
 }

--- a/tests/libs/Royale.php
+++ b/tests/libs/Royale.php
@@ -16,7 +16,7 @@ class Royale
 	}
 
 
-	public static function withBadCheese(): void
+	public static function WithBadCheese(): void
 	{
 		$foo = md5_file(__FILE__);
 	}

--- a/tests/src/disallowed-allow/functionCalls.php
+++ b/tests/src/disallowed-allow/functionCalls.php
@@ -5,7 +5,7 @@ use function Foo\Bar\waldo;
 
 // allowed by path
 var_dump('foo', true);
-print_r('bar');
+print_R('bar');
 \printf('foobar');
 \Foo\Bar\waldo();
 waldo(123);

--- a/tests/src/disallowed-allow/methodCalls.php
+++ b/tests/src/disallowed-allow/methodCalls.php
@@ -26,7 +26,7 @@ $testClass = new Traits\TestClass();
 $testClass->x();
 $testClassToo = new Traits\AnotherTestClass();
 $testClassToo->y();
-$testClassToo->zzTop();
+$testClassToo->zZTop();
 
 // object creation allowed by path
 new ClassWithConstructor();
@@ -55,3 +55,11 @@ $some->getIterator();
 (new DateTime())->format('y');
 (new DateTime())->format('Y');
 new DateTime('tOmOrRoW');
+
+// case-insensitive methods allowed by path
+$blade->movie();
+$blade->Movie();
+$blade->sequel();
+$blade->Sequel();
+$blade->trinity();
+$blade->Trinity();

--- a/tests/src/disallowed-allow/namespaceUsages.php
+++ b/tests/src/disallowed-allow/namespaceUsages.php
@@ -8,7 +8,7 @@ use Inheritance\Base;
 use Inheritance\Sub;
 use Traits\TestTrait;
 use Waldo\Foo\Bar;
-use Waldo\Quux\Blade;
+use Waldo\Quux\blade;
 
 class Service extends Base implements SomeInterface
 {
@@ -19,6 +19,7 @@ class Service extends Base implements SomeInterface
 	private $blade;
 
 
+	// phpcs:ignore SlevomatCodingStandard.Namespaces.UnusedUses.MismatchingCaseSensitivity
 	public function __construct(Blade $blade)
 	{
 		$this->blade = $blade;

--- a/tests/src/disallowed-allow/staticCalls.php
+++ b/tests/src/disallowed-allow/staticCalls.php
@@ -5,13 +5,13 @@ use Fiction\Pulp;
 
 // allowed by path
 \Fiction\Pulp\Royale::withCheese();
-Pulp\Royale::withCheese();
+Pulp\Royale::WithCheese();
 Pulp\Royale::withBadCheese();
 
 // allowed by path and only with these params
 Pulp\Royale::withoutCheese(1, 2, 3);
 $a = 3;
-Pulp\Royale::withoutCheese(1, 2, $a);
+Pulp\Royale::WithoutCheese(1, 2, $a);
 
 // disallowed call, allowed by path but params don't match allowed
 $a = 5;

--- a/tests/src/disallowed/functionCalls.php
+++ b/tests/src/disallowed/functionCalls.php
@@ -5,7 +5,7 @@ use function Foo\Bar\waldo;
 
 // disallowed
 var_dump('foo', true);
-print_r('bar');
+print_R('bar');
 \printf('foobar');
 \Foo\Bar\waldo();
 waldo(123);

--- a/tests/src/disallowed/methodCalls.php
+++ b/tests/src/disallowed/methodCalls.php
@@ -26,7 +26,7 @@ $testClass = new Traits\TestClass();
 $testClass->x();
 $testClassToo = new Traits\AnotherTestClass();
 $testClassToo->y();
-$testClassToo->zzTop();
+$testClassToo->zZTop();
 
 // disallowed object creation
 new ClassWithConstructor();
@@ -55,3 +55,11 @@ $some->getIterator();
 (new DateTime())->format('y');
 (new DateTime())->format('Y');
 new DateTime('tOmOrRoW');
+
+// disallowed case-insensitive methods
+$blade->movie();
+$blade->Movie();
+$blade->sequel();
+$blade->Sequel();
+$blade->trinity();
+$blade->Trinity();

--- a/tests/src/disallowed/namespaceUsages.php
+++ b/tests/src/disallowed/namespaceUsages.php
@@ -8,7 +8,7 @@ use Inheritance\Base;
 use Inheritance\Sub;
 use Traits\TestTrait;
 use Waldo\Foo\Bar;
-use Waldo\Quux\Blade;
+use Waldo\Quux\blade;
 
 class Service extends Base implements SomeInterface
 {
@@ -19,6 +19,7 @@ class Service extends Base implements SomeInterface
 	private $blade;
 
 
+	// phpcs:ignore SlevomatCodingStandard.Namespaces.UnusedUses.MismatchingCaseSensitivity
 	public function __construct(Blade $blade)
 	{
 		$this->blade = $blade;

--- a/tests/src/disallowed/staticCalls.php
+++ b/tests/src/disallowed/staticCalls.php
@@ -5,13 +5,13 @@ use Fiction\Pulp;
 
 // disallowed method
 \Fiction\Pulp\Royale::withCheese();
-Pulp\Royale::withCheese();
+Pulp\Royale::WithCheese();
 Pulp\Royale::withBadCheese();
 
 // disallowed call, params match allowed but path doesn't
 Pulp\Royale::withoutCheese(1, 2, 3);
 $a = 3;
-Pulp\Royale::withoutCheese(1, 2, $a);
+Pulp\Royale::WithoutCheese(1, 2, $a);
 
 // disallowed call, params don't match allowed
 $a = 5;


### PR DESCRIPTION
Function names, method names, namespaces are matched irrespective of their case (disallowing `print_r` will also find `print_R` calls), while anything else like constants, file names, paths are not.

Fix #93