### PR TITLE
Allow specifying `errorIdentifier` to `RuleError`

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ parameters:
         -
             method: 'Redis::connect()'
             message: 'use our own Redis instead'
+            errorIdentifier: 'redis.connect'
 
     disallowedStaticCalls:
         -
@@ -135,6 +136,8 @@ parameters:
 ```
 
 The `message` key is optional. Functions and methods can be specified with or without `()`. Omitting `()` is not recommended though to avoid confusing method calls with class constants.
+
+The `errorIdentifier` key is optional. It can be used to provide a unique identifier to the PHPStan error.
 
 Use wildcard (`*`) to ignore all functions, methods, namespaces starting with a prefix, for example:
 ```neon

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,7 +3,7 @@ parameters:
 		- src
 	level: max
 	typeAliases:
-		ForbiddenCallsConfig: 'array<array{function?:string, method?:string, message?:string, allowIn?:string[], allowInFunctions?:string[], allowInMethods?:string[], allowParamsInAllowed?:array<integer, integer|boolean|string>, allowParamsInAllowedAnyValue?:array<integer, integer>, allowParamsAnywhere?:array<integer, integer|boolean|string>, allowParamsAnywhereAnyValue?:array<integer, integer>, allowExceptParamsInAllowed?:array<integer, integer|boolean|string>, allowExceptParams?:array<integer, integer|boolean|string>, allowExceptCaseInsensitiveParams?:array<integer, integer|boolean|string>}>'
+		ForbiddenCallsConfig: 'array<array{function?:string, method?:string, message?:string, allowIn?:string[], allowInFunctions?:string[], allowInMethods?:string[], allowParamsInAllowed?:array<integer, integer|boolean|string>, allowParamsInAllowedAnyValue?:array<integer, integer>, allowParamsAnywhere?:array<integer, integer|boolean|string>, allowParamsAnywhereAnyValue?:array<integer, integer>, allowExceptParamsInAllowed?:array<integer, integer|boolean|string>, allowExceptParams?:array<integer, integer|boolean|string>, allowExceptCaseInsensitiveParams?:array<integer, integer|boolean|string>, errorIdentifier?:string}>'
 
 includes:
 	- vendor/phpstan/phpstan/conf/bleedingEdge.neon

--- a/src/Calls/EchoCalls.php
+++ b/src/Calls/EchoCalls.php
@@ -7,6 +7,7 @@ use PhpParser\Node;
 use PhpParser\Node\Stmt\Echo_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
 use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCall;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
@@ -52,7 +53,7 @@ class EchoCalls implements Rule
 	/**
 	 * @param Echo_ $node
 	 * @param Scope $scope
-	 * @return string[]
+	 * @return RuleError[]
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{

--- a/src/Calls/EmptyCalls.php
+++ b/src/Calls/EmptyCalls.php
@@ -7,6 +7,7 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\Empty_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
 use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCall;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
@@ -52,7 +53,7 @@ class EmptyCalls implements Rule
 	/**
 	 * @param Empty_ $node
 	 * @param Scope $scope
-	 * @return string[]
+	 * @return RuleError[]
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{

--- a/src/Calls/EvalCalls.php
+++ b/src/Calls/EvalCalls.php
@@ -7,6 +7,7 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\Eval_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
 use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCall;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
@@ -52,7 +53,7 @@ class EvalCalls implements Rule
 	/**
 	 * @param Eval_ $node
 	 * @param Scope $scope
-	 * @return string[]
+	 * @return RuleError[]
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{

--- a/src/Calls/ExitDieCalls.php
+++ b/src/Calls/ExitDieCalls.php
@@ -7,6 +7,7 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\Exit_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
 use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCall;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
@@ -52,7 +53,7 @@ class ExitDieCalls implements Rule
 	/**
 	 * @param Exit_ $node
 	 * @param Scope $scope
-	 * @return string[]
+	 * @return RuleError[]
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{

--- a/src/Calls/FunctionCalls.php
+++ b/src/Calls/FunctionCalls.php
@@ -8,6 +8,7 @@ use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
 use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCall;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
@@ -53,7 +54,7 @@ class FunctionCalls implements Rule
 	/**
 	 * @param FuncCall $node
 	 * @param Scope $scope
-	 * @return string[]
+	 * @return RuleError[]
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{

--- a/src/Calls/MethodCalls.php
+++ b/src/Calls/MethodCalls.php
@@ -8,6 +8,7 @@ use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Broker\ClassNotFoundException;
 use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
 use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCall;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
@@ -55,7 +56,7 @@ class MethodCalls implements Rule
 	/**
 	 * @param MethodCall $node
 	 * @param Scope $scope
-	 * @return string[]
+	 * @return RuleError[]
 	 * @throws ClassNotFoundException
 	 */
 	public function processNode(Node $node, Scope $scope): array

--- a/src/Calls/NewCalls.php
+++ b/src/Calls/NewCalls.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\ConstantScalarType;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCall;
@@ -55,7 +56,7 @@ class NewCalls implements Rule
 	/**
 	 * @param New_ $node
 	 * @param Scope $scope
-	 * @return string[]
+	 * @return RuleError[]
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{

--- a/src/Calls/PrintCalls.php
+++ b/src/Calls/PrintCalls.php
@@ -7,6 +7,7 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\Print_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
 use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCall;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
@@ -52,7 +53,7 @@ class PrintCalls implements Rule
 	/**
 	 * @param Print_ $node
 	 * @param Scope $scope
-	 * @return string[]
+	 * @return RuleError[]
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{

--- a/src/Calls/ShellExecCalls.php
+++ b/src/Calls/ShellExecCalls.php
@@ -7,6 +7,7 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\ShellExec;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
 use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCall;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
@@ -56,7 +57,7 @@ class ShellExecCalls implements Rule
 	/**
 	 * @param ShellExec $node
 	 * @param Scope $scope
-	 * @return string[]
+	 * @return RuleError[]
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{

--- a/src/Calls/StaticCalls.php
+++ b/src/Calls/StaticCalls.php
@@ -8,6 +8,7 @@ use PhpParser\Node\Expr\StaticCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Broker\ClassNotFoundException;
 use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
 use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCall;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
@@ -55,7 +56,7 @@ class StaticCalls implements Rule
 	/**
 	 * @param StaticCall $node
 	 * @param Scope $scope
-	 * @return string[]
+	 * @return RuleError[]
 	 * @throws ClassNotFoundException
 	 */
 	public function processNode(Node $node, Scope $scope): array

--- a/src/DisallowedCall.php
+++ b/src/DisallowedCall.php
@@ -32,6 +32,9 @@ class DisallowedCall
 	/** @var array<int, DisallowedCallParam> */
 	private $allowExceptParams;
 
+	/** @var string */
+	private $errorIdentifier;
+
 
 	/**
 	 * DisallowedCall constructor.
@@ -44,8 +47,9 @@ class DisallowedCall
 	 * @param array<int, DisallowedCallParam> $allowParamsAnywhere
 	 * @param array<int, DisallowedCallParam> $allowExceptParamsInAllowed
 	 * @param array<int, DisallowedCallParam> $allowExceptParams
+	 * @param string $errorIdentifier
 	 */
-	public function __construct(string $call, ?string $message, array $allowIn, array $allowInCalls, array $allowParamsInAllowed, array $allowParamsAnywhere, array $allowExceptParamsInAllowed, array $allowExceptParams)
+	public function __construct(string $call, ?string $message, array $allowIn, array $allowInCalls, array $allowParamsInAllowed, array $allowParamsAnywhere, array $allowExceptParamsInAllowed, array $allowExceptParams, string $errorIdentifier)
 	{
 		$this->call = $call;
 		$this->message = $message;
@@ -55,6 +59,7 @@ class DisallowedCall
 		$this->allowParamsAnywhere = $allowParamsAnywhere;
 		$this->allowExceptParamsInAllowed = $allowExceptParamsInAllowed;
 		$this->allowExceptParams = $allowExceptParams;
+		$this->errorIdentifier = $errorIdentifier;
 	}
 
 
@@ -121,6 +126,12 @@ class DisallowedCall
 	public function getAllowExceptParams(): array
 	{
 		return $this->allowExceptParams;
+	}
+
+
+	public function getErrorIdentifier(): string
+	{
+		return $this->errorIdentifier;
 	}
 
 

--- a/src/DisallowedCallFactory.php
+++ b/src/DisallowedCallFactory.php
@@ -61,7 +61,8 @@ class DisallowedCallFactory
 				$allowParamsInAllowed,
 				$allowParamsAnywhere,
 				$allowExceptParamsInAllowed,
-				$allowExceptParams
+				$allowExceptParams,
+				$disallowedCall['errorIdentifier'] ?? ''
 			);
 			$calls[$disallowedCall->getKey()] = $disallowedCall;
 		}

--- a/src/DisallowedConstant.php
+++ b/src/DisallowedConstant.php
@@ -15,6 +15,9 @@ class DisallowedConstant
 	/** @var string[] */
 	private $allowIn;
 
+	/** @var string */
+	private $errorIdentifier;
+
 
 	/**
 	 * DisallowedCall constructor.
@@ -22,12 +25,14 @@ class DisallowedConstant
 	 * @param string $constant
 	 * @param string|null $message
 	 * @param string[] $allowIn
+	 * @param string $errorIdentifier
 	 */
-	public function __construct(string $constant, ?string $message, array $allowIn)
+	public function __construct(string $constant, ?string $message, array $allowIn, string $errorIdentifier)
 	{
 		$this->constant = ltrim($constant, '\\');
 		$this->message = $message;
 		$this->allowIn = $allowIn;
+		$this->errorIdentifier = $errorIdentifier;
 	}
 
 
@@ -49,6 +54,12 @@ class DisallowedConstant
 	public function getAllowIn(): array
 	{
 		return $this->allowIn;
+	}
+
+
+	public function getErrorIdentifier(): string
+	{
+		return $this->errorIdentifier;
 	}
 
 }

--- a/src/DisallowedConstantFactory.php
+++ b/src/DisallowedConstantFactory.php
@@ -9,7 +9,7 @@ class DisallowedConstantFactory
 {
 
 	/**
-	 * @param array<array{class?:string, constant?:string, message?:string, allowIn?:string[]}> $config
+	 * @param array<array{class?:string, constant?:string, message?:string, allowIn?:string[], errorIdentifier?:string}> $config
 	 * @return DisallowedConstant[]
 	 * @throws ShouldNotHappenException
 	 */
@@ -25,7 +25,8 @@ class DisallowedConstantFactory
 			$disallowedConstant = new DisallowedConstant(
 				$class ? "{$class}::{$constant}" : $constant,
 				$disallowedConstant['message'] ?? null,
-				$disallowedConstant['allowIn'] ?? []
+				$disallowedConstant['allowIn'] ?? [],
+				$disallowedConstant['errorIdentifier'] ?? ''
 			);
 			$constants[$disallowedConstant->getConstant()] = $disallowedConstant;
 		}

--- a/src/DisallowedNamespace.php
+++ b/src/DisallowedNamespace.php
@@ -15,17 +15,22 @@ class DisallowedNamespace
 	/** @var string[] */
 	private $allowIn;
 
+	/** @var string */
+	private $errorIdentifier;
+
 
 	/**
 	 * @param string $namespace
 	 * @param string|null $message
 	 * @param string[] $allowIn
+	 * @param string $errorIdentifier
 	 */
-	public function __construct(string $namespace, ?string $message, array $allowIn)
+	public function __construct(string $namespace, ?string $message, array $allowIn, string $errorIdentifier)
 	{
 		$this->namespace = ltrim($namespace, '\\');
 		$this->message = $message;
 		$this->allowIn = $allowIn;
+		$this->errorIdentifier = $errorIdentifier;
 	}
 
 
@@ -47,6 +52,12 @@ class DisallowedNamespace
 	public function getAllowIn(): array
 	{
 		return $this->allowIn;
+	}
+
+
+	public function getErrorIdentifier(): string
+	{
+		return $this->errorIdentifier;
 	}
 
 }

--- a/src/DisallowedNamespaceFactory.php
+++ b/src/DisallowedNamespaceFactory.php
@@ -7,7 +7,7 @@ class DisallowedNamespaceFactory
 {
 
 	/**
-	 * @param array<array{namespace:string, message?:string, allowIn?:string[], allowParamsInAllowed?:array<int, int|bool|string>, allowParamsAnywhere?:array<int, int|bool|string>}> $config
+	 * @param array<array{namespace:string, message?:string, allowIn?:string[], allowParamsInAllowed?:array<int, int|bool|string>, allowParamsAnywhere?:array<int, int|bool|string>, errorIdentifier?:string}> $config
 	 * @return DisallowedNamespace[]
 	 */
 	public function createFromConfig(array $config): array
@@ -17,7 +17,8 @@ class DisallowedNamespaceFactory
 			$disallowed = new DisallowedNamespace(
 				$disallowed['namespace'],
 				$disallowed['message'] ?? null,
-				$disallowed['allowIn'] ?? []
+				$disallowed['allowIn'] ?? [],
+				$disallowed['errorIdentifier'] ?? ''
 			);
 			$disallowedNamespaces[$disallowed->getNamespace()] = $disallowed;
 		}

--- a/src/DisallowedNamespaceHelper.php
+++ b/src/DisallowedNamespaceHelper.php
@@ -4,6 +4,8 @@ declare(strict_types = 1);
 namespace Spaze\PHPStan\Rules\Disallowed;
 
 use PHPStan\Analyser\Scope;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
 
 class DisallowedNamespaceHelper
 {
@@ -39,7 +41,7 @@ class DisallowedNamespaceHelper
 	 * @param string $namespace
 	 * @param Scope $scope
 	 * @param DisallowedNamespace[] $disallowedNamespaces
-	 * @return string[]
+	 * @return RuleError[]
 	 */
 	public function getDisallowedMessage(string $namespace, Scope $scope, array $disallowedNamespaces): array
 	{
@@ -53,12 +55,14 @@ class DisallowedNamespaceHelper
 			}
 
 			return [
-				sprintf(
+				RuleErrorBuilder::message(sprintf(
 					'Namespace %s is forbidden, %s%s',
 					$namespace,
 					$disallowedNamespace->getMessage(),
 					$disallowedNamespace->getNamespace() !== $namespace ? " [{$namespace} matches {$disallowedNamespace->getNamespace()}]" : ''
-				),
+				))
+					->identifier($disallowedNamespace->getErrorIdentifier())
+					->build(),
 			];
 		}
 

--- a/src/Usages/ClassConstantUsages.php
+++ b/src/Usages/ClassConstantUsages.php
@@ -8,6 +8,8 @@ use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Identifier;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\TypeWithClassName;
@@ -54,7 +56,7 @@ class ClassConstantUsages implements Rule
 	/**
 	 * @param ClassConstFetch $node
 	 * @param Scope $scope
-	 * @return string[]
+	 * @return RuleError[]
 	 * @throws ShouldNotHappenException
 	 */
 	public function processNode(Node $node, Scope $scope): array
@@ -78,11 +80,11 @@ class ClassConstantUsages implements Rule
 		} else {
 			if ($usedOnType->hasConstant($constant)->no()) {
 				return [
-					sprintf(
+					RuleErrorBuilder::message(sprintf(
 						'Cannot access constant %s on %s',
 						$constant,
 						$usedOnType->describe(VerbosityLevel::getRecommendedLevelByType($usedOnType))
-					),
+					))->build(),
 				];
 			} else {
 				$className = $usedOnType->getConstant($constant)->getDeclaringClass()->getDisplayName();

--- a/src/Usages/ConstantUsages.php
+++ b/src/Usages/ConstantUsages.php
@@ -7,6 +7,7 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\ConstFetch;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
 use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedConstant;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedConstantFactory;
@@ -50,7 +51,7 @@ class ConstantUsages implements Rule
 	/**
 	 * @param ConstFetch $node
 	 * @param Scope $scope
-	 * @return string[]
+	 * @return RuleError[]
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{

--- a/src/Usages/NamespaceUsages.php
+++ b/src/Usages/NamespaceUsages.php
@@ -13,6 +13,7 @@ use PhpParser\Node\Stmt\TraitUse;
 use PhpParser\Node\Stmt\UseUse;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedNamespace;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedNamespaceFactory;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedNamespaceHelper;
@@ -51,7 +52,7 @@ class NamespaceUsages implements Rule
 	/**
 	 * @param Node $node
 	 * @param Scope $scope
-	 * @return string[]
+	 * @return RuleError[]
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{


### PR DESCRIPTION
Ultimately every error in PHPStan should have its own unique identifier so that its
possible to group by error type and ignore errors based on identifier.

https://github.com/phpstan/phpstan/issues/1686#issuecomment-532996159
https://github.com/phpstan/phpstan/issues/3065