### PR TITLE
Can now specify root dir for all `allowIn` paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,23 @@ parameters:
                 - tests/*.test.php
 ```
 
-The paths in `allowIn` are relative to the config file location and support [fnmatch()](https://www.php.net/function.fnmatch) patterns.
+Paths in `allowIn` support [fnmatch()](https://www.php.net/function.fnmatch) patterns.
+
+Relative paths in `allowIn` are resolved based on the current working directory. When running PHPStan from a directory or subdirectory which is not your "root" directory, the paths will probably not work.
+Use `allowInRootDir` in that case to specify an absolute root directory for all `allowIn` paths. Absolute paths might change between machines (for example your local development machine and a continous integration machine) but you
+can use [`%rootDir%`](https://phpstan.org/config-reference#expanding-paths) to start with PHPStan's root directory (usually `/something/something/vendor/phpstan/phpstan`) and then `..` from there to your "root" directory.
+
+For example when PHPStan is installed in `/home/foo/vendor/phpstan/phpstan` and you're using a configuration like this:
+```neon
+parameters:
+    allowInRootDir: %rootDir%/../../..
+    disallowedMethodCalls:
+        -
+            method: 'PotentiallyDangerous\Logger::log()'
+            allowIn:
+                - path/to/some/file-*.php
+```
+then `Logger::log()` will be allowed in `/home/foo/path/to/some/file-bar.php`.
 
 To allow a previously disallowed method or function only when called from a different method or function in any file, use `allowInFunctions` (or `allowInMethods` alias):
 

--- a/extension.neon
+++ b/extension.neon
@@ -55,7 +55,7 @@ parametersSchema:
 	)
 
 services:
-	- Spaze\PHPStan\Rules\Disallowed\FileHelper
+	- Spaze\PHPStan\Rules\Disallowed\IsAllowedFileHelper
 	- Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory
 	- Spaze\PHPStan\Rules\Disallowed\DisallowedConstantFactory
 	- Spaze\PHPStan\Rules\Disallowed\DisallowedHelper

--- a/extension.neon
+++ b/extension.neon
@@ -1,4 +1,5 @@
 parameters:
+	allowInRootDir: null
 	disallowedNamespaces: []
 	disallowedMethodCalls: []
 	disallowedStaticCalls: []
@@ -6,6 +7,7 @@ parameters:
 	disallowedConstants: []
 
 parametersSchema:
+	allowInRootDir: schema(string(), nullable())
 	# These should be defined using `structure` with listed keys but it seems to me that PHPStan requires
 	# all keys to be present in a structure but `message` & `allow*` are optional.
 	disallowedNamespaces: listOf(
@@ -55,7 +57,7 @@ parametersSchema:
 	)
 
 services:
-	- Spaze\PHPStan\Rules\Disallowed\IsAllowedFileHelper
+	- Spaze\PHPStan\Rules\Disallowed\IsAllowedFileHelper(allowInRootDir: %allowInRootDir%)
 	- Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory
 	- Spaze\PHPStan\Rules\Disallowed\DisallowedConstantFactory
 	- Spaze\PHPStan\Rules\Disallowed\DisallowedHelper

--- a/src/DisallowedHelper.php
+++ b/src/DisallowedHelper.php
@@ -22,13 +22,13 @@ use Spaze\PHPStan\Rules\Disallowed\Params\DisallowedCallParam;
 class DisallowedHelper
 {
 
-	/** @var FileHelper */
-	private $fileHelper;
+	/** @var IsAllowedFileHelper */
+	private $isAllowedFileHelper;
 
 
-	public function __construct(FileHelper $fileHelper)
+	public function __construct(IsAllowedFileHelper $isAllowedFileHelper)
 	{
-		$this->fileHelper = $fileHelper;
+		$this->isAllowedFileHelper = $isAllowedFileHelper;
 	}
 
 
@@ -47,7 +47,7 @@ class DisallowedHelper
 			}
 		}
 		foreach ($disallowedCall->getAllowIn() as $allowedPath) {
-			if (fnmatch($this->fileHelper->absolutizePath($allowedPath), $scope->getFile())) {
+			if (fnmatch($this->isAllowedFileHelper->absolutizePath($allowedPath), $scope->getFile())) {
 				return $this->hasAllowedParamsInAllowed($scope, $node, $disallowedCall);
 			}
 		}
@@ -206,7 +206,7 @@ class DisallowedHelper
 	private function isAllowedPath(Scope $scope, DisallowedConstant $disallowedConstant): bool
 	{
 		foreach ($disallowedConstant->getAllowIn() as $allowedPath) {
-			if (fnmatch($this->fileHelper->absolutizePath($allowedPath), $scope->getFile())) {
+			if (fnmatch($this->isAllowedFileHelper->absolutizePath($allowedPath), $scope->getFile())) {
 				return true;
 			}
 		}

--- a/src/DisallowedNamespaceHelper.php
+++ b/src/DisallowedNamespaceHelper.php
@@ -10,13 +10,13 @@ use PHPStan\Rules\RuleErrorBuilder;
 class DisallowedNamespaceHelper
 {
 
-	/** @var FileHelper */
-	private $fileHelper;
+	/** @var IsAllowedFileHelper */
+	private $isAllowedFileHelper;
 
 
-	public function __construct(FileHelper $fileHelper)
+	public function __construct(IsAllowedFileHelper $isAllowedFileHelper)
 	{
-		$this->fileHelper = $fileHelper;
+		$this->isAllowedFileHelper = $isAllowedFileHelper;
 	}
 
 
@@ -28,7 +28,7 @@ class DisallowedNamespaceHelper
 	private function isAllowed(Scope $scope, DisallowedNamespace $disallowedNamespace): bool
 	{
 		foreach ($disallowedNamespace->getAllowIn() as $allowedPath) {
-			$match = fnmatch($this->fileHelper->absolutizePath($allowedPath), $scope->getFile());
+			$match = fnmatch($this->isAllowedFileHelper->absolutizePath($allowedPath), $scope->getFile());
 			if ($match) {
 				return true;
 			}

--- a/src/IsAllowedFileHelper.php
+++ b/src/IsAllowedFileHelper.php
@@ -11,10 +11,14 @@ class IsAllowedFileHelper
 	/** @var FileHelper */
 	private $fileHelper;
 
+	/** @var string|null */
+	private $allowInRootDir;
 
-	public function __construct(FileHelper $fileHelper)
+
+	public function __construct(FileHelper $fileHelper, ?string $allowInRootDir = null)
 	{
 		$this->fileHelper = $fileHelper;
+		$this->allowInRootDir = $allowInRootDir !== null ? $this->fileHelper->normalizePath($fileHelper->absolutizePath($allowInRootDir)) : null;
 	}
 
 
@@ -30,6 +34,9 @@ class IsAllowedFileHelper
 			return $path;
 		}
 
+		if ($this->allowInRootDir !== null) {
+			$path = rtrim($this->allowInRootDir, '/') . '/' . ltrim($path, '/');
+		}
 		return $this->fileHelper->normalizePath($this->fileHelper->absolutizePath($path));
 	}
 

--- a/src/IsAllowedFileHelper.php
+++ b/src/IsAllowedFileHelper.php
@@ -3,16 +3,16 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Rules\Disallowed;
 
-use PHPStan\File\FileHelper as PHPStanFileHelper;
+use PHPStan\File\FileHelper;
 
-class FileHelper
+class IsAllowedFileHelper
 {
 
-	/** @var PHPStanFileHelper */
+	/** @var FileHelper */
 	private $fileHelper;
 
 
-	public function __construct(PHPStanFileHelper $fileHelper)
+	public function __construct(FileHelper $fileHelper)
 	{
 		$this->fileHelper = $fileHelper;
 	}

--- a/tests/Calls/EchoCallsTest.php
+++ b/tests/Calls/EchoCallsTest.php
@@ -3,12 +3,12 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Rules\Disallowed\Calls;
 
-use PHPStan\File\FileHelper as PHPStanFileHelper;
+use PHPStan\File\FileHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedHelper;
-use Spaze\PHPStan\Rules\Disallowed\FileHelper;
+use Spaze\PHPStan\Rules\Disallowed\IsAllowedFileHelper;
 
 class EchoCallsTest extends RuleTestCase
 {
@@ -16,7 +16,7 @@ class EchoCallsTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		return new EchoCalls(
-			new DisallowedHelper(new FileHelper(new PHPStanFileHelper(__DIR__))),
+			new DisallowedHelper(new IsAllowedFileHelper(new FileHelper(__DIR__))),
 			new DisallowedCallFactory(),
 			[
 				[

--- a/tests/Calls/EmptyCallsTest.php
+++ b/tests/Calls/EmptyCallsTest.php
@@ -3,12 +3,12 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Rules\Disallowed\Calls;
 
-use PHPStan\File\FileHelper as PHPStanFileHelper;
+use PHPStan\File\FileHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedHelper;
-use Spaze\PHPStan\Rules\Disallowed\FileHelper;
+use Spaze\PHPStan\Rules\Disallowed\IsAllowedFileHelper;
 
 class EmptyCallsTest extends RuleTestCase
 {
@@ -16,7 +16,7 @@ class EmptyCallsTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		return new EmptyCalls(
-			new DisallowedHelper(new FileHelper(new PHPStanFileHelper(__DIR__))),
+			new DisallowedHelper(new IsAllowedFileHelper(new FileHelper(__DIR__))),
 			new DisallowedCallFactory(),
 			[
 				[

--- a/tests/Calls/EvalCallsTest.php
+++ b/tests/Calls/EvalCallsTest.php
@@ -3,12 +3,12 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Rules\Disallowed\Calls;
 
-use PHPStan\File\FileHelper as PHPStanFileHelper;
+use PHPStan\File\FileHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedHelper;
-use Spaze\PHPStan\Rules\Disallowed\FileHelper;
+use Spaze\PHPStan\Rules\Disallowed\IsAllowedFileHelper;
 
 class EvalCallsTest extends RuleTestCase
 {
@@ -16,7 +16,7 @@ class EvalCallsTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		return new EvalCalls(
-			new DisallowedHelper(new FileHelper(new PHPStanFileHelper(__DIR__))),
+			new DisallowedHelper(new IsAllowedFileHelper(new FileHelper(__DIR__))),
 			new DisallowedCallFactory(),
 			[
 				[

--- a/tests/Calls/ExitDieCallsTest.php
+++ b/tests/Calls/ExitDieCallsTest.php
@@ -3,12 +3,12 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Rules\Disallowed\Calls;
 
-use PHPStan\File\FileHelper as PHPStanFileHelper;
+use PHPStan\File\FileHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedHelper;
-use Spaze\PHPStan\Rules\Disallowed\FileHelper;
+use Spaze\PHPStan\Rules\Disallowed\IsAllowedFileHelper;
 
 class ExitDieCallsTest extends RuleTestCase
 {
@@ -16,7 +16,7 @@ class ExitDieCallsTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		return new ExitDieCalls(
-			new DisallowedHelper(new FileHelper(new PHPStanFileHelper(__DIR__))),
+			new DisallowedHelper(new IsAllowedFileHelper(new FileHelper(__DIR__))),
 			new DisallowedCallFactory(),
 			[
 				[

--- a/tests/Calls/FunctionCallsAllowInFunctionsTest.php
+++ b/tests/Calls/FunctionCallsAllowInFunctionsTest.php
@@ -3,12 +3,12 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Rules\Disallowed\Calls;
 
-use PHPStan\File\FileHelper as PHPStanFileHelper;
+use PHPStan\File\FileHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedHelper;
-use Spaze\PHPStan\Rules\Disallowed\FileHelper;
+use Spaze\PHPStan\Rules\Disallowed\IsAllowedFileHelper;
 
 class FunctionCallsAllowInFunctionsTest extends RuleTestCase
 {
@@ -16,7 +16,7 @@ class FunctionCallsAllowInFunctionsTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		return new FunctionCalls(
-			new DisallowedHelper(new FileHelper(new PHPStanFileHelper(__DIR__))),
+			new DisallowedHelper(new IsAllowedFileHelper(new FileHelper(__DIR__))),
 			new DisallowedCallFactory(),
 			[
 				[

--- a/tests/Calls/FunctionCallsAllowInMethodsTest.php
+++ b/tests/Calls/FunctionCallsAllowInMethodsTest.php
@@ -3,12 +3,12 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Rules\Disallowed\Calls;
 
-use PHPStan\File\FileHelper as PHPStanFileHelper;
+use PHPStan\File\FileHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedHelper;
-use Spaze\PHPStan\Rules\Disallowed\FileHelper;
+use Spaze\PHPStan\Rules\Disallowed\IsAllowedFileHelper;
 
 class FunctionCallsAllowInMethodsTest extends RuleTestCase
 {
@@ -16,7 +16,7 @@ class FunctionCallsAllowInMethodsTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		return new FunctionCalls(
-			new DisallowedHelper(new FileHelper(new PHPStanFileHelper(__DIR__))),
+			new DisallowedHelper(new IsAllowedFileHelper(new FileHelper(__DIR__))),
 			new DisallowedCallFactory(),
 			[
 				[

--- a/tests/Calls/FunctionCallsTest.php
+++ b/tests/Calls/FunctionCallsTest.php
@@ -3,12 +3,12 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Rules\Disallowed\Calls;
 
-use PHPStan\File\FileHelper as PHPStanFileHelper;
+use PHPStan\File\FileHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedHelper;
-use Spaze\PHPStan\Rules\Disallowed\FileHelper;
+use Spaze\PHPStan\Rules\Disallowed\IsAllowedFileHelper;
 
 class FunctionCallsTest extends RuleTestCase
 {
@@ -16,7 +16,7 @@ class FunctionCallsTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		return new FunctionCalls(
-			new DisallowedHelper(new FileHelper(new PHPStanFileHelper(__DIR__))),
+			new DisallowedHelper(new IsAllowedFileHelper(new FileHelper(__DIR__))),
 			new DisallowedCallFactory(),
 			[
 				[

--- a/tests/Calls/MethodCallsTest.php
+++ b/tests/Calls/MethodCallsTest.php
@@ -3,12 +3,12 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Rules\Disallowed\Calls;
 
-use PHPStan\File\FileHelper as PHPStanFileHelper;
+use PHPStan\File\FileHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedHelper;
-use Spaze\PHPStan\Rules\Disallowed\FileHelper;
+use Spaze\PHPStan\Rules\Disallowed\IsAllowedFileHelper;
 
 class MethodCallsTest extends RuleTestCase
 {
@@ -16,7 +16,7 @@ class MethodCallsTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		return new MethodCalls(
-			new DisallowedHelper(new FileHelper(new PHPStanFileHelper(__DIR__))),
+			new DisallowedHelper(new IsAllowedFileHelper(new FileHelper(__DIR__))),
 			new DisallowedCallFactory(),
 			[
 				[

--- a/tests/Calls/NewCallsTest.php
+++ b/tests/Calls/NewCallsTest.php
@@ -3,12 +3,12 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Rules\Disallowed\Calls;
 
-use PHPStan\File\FileHelper as PHPStanFileHelper;
+use PHPStan\File\FileHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedHelper;
-use Spaze\PHPStan\Rules\Disallowed\FileHelper;
+use Spaze\PHPStan\Rules\Disallowed\IsAllowedFileHelper;
 
 class NewCallsTest extends RuleTestCase
 {
@@ -16,7 +16,7 @@ class NewCallsTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		return new NewCalls(
-			new DisallowedHelper(new FileHelper(new PHPStanFileHelper(__DIR__))),
+			new DisallowedHelper(new IsAllowedFileHelper(new FileHelper(__DIR__))),
 			new DisallowedCallFactory(),
 			[
 				[

--- a/tests/Calls/PrintCallsTest.php
+++ b/tests/Calls/PrintCallsTest.php
@@ -3,12 +3,12 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Rules\Disallowed\Calls;
 
-use PHPStan\File\FileHelper as PHPStanFileHelper;
+use PHPStan\File\FileHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedHelper;
-use Spaze\PHPStan\Rules\Disallowed\FileHelper;
+use Spaze\PHPStan\Rules\Disallowed\IsAllowedFileHelper;
 
 class PrintCallsTest extends RuleTestCase
 {
@@ -16,7 +16,7 @@ class PrintCallsTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		return new PrintCalls(
-			new DisallowedHelper(new FileHelper(new PHPStanFileHelper(__DIR__))),
+			new DisallowedHelper(new IsAllowedFileHelper(new FileHelper(__DIR__))),
 			new DisallowedCallFactory(),
 			[
 				[

--- a/tests/Calls/ShellExecCallsTest.php
+++ b/tests/Calls/ShellExecCallsTest.php
@@ -3,12 +3,12 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Rules\Disallowed\Calls;
 
-use PHPStan\File\FileHelper as PHPStanFileHelper;
+use PHPStan\File\FileHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedHelper;
-use Spaze\PHPStan\Rules\Disallowed\FileHelper;
+use Spaze\PHPStan\Rules\Disallowed\IsAllowedFileHelper;
 
 class ShellExecCallsTest extends RuleTestCase
 {
@@ -16,7 +16,7 @@ class ShellExecCallsTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		return new ShellExecCalls(
-			new DisallowedHelper(new FileHelper(new PHPStanFileHelper(__DIR__))),
+			new DisallowedHelper(new IsAllowedFileHelper(new FileHelper(__DIR__))),
 			new DisallowedCallFactory(),
 			[
 				[

--- a/tests/Calls/StaticCallsTest.php
+++ b/tests/Calls/StaticCallsTest.php
@@ -3,12 +3,12 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Rules\Disallowed\Calls;
 
-use PHPStan\File\FileHelper as PHPStanFileHelper;
+use PHPStan\File\FileHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedHelper;
-use Spaze\PHPStan\Rules\Disallowed\FileHelper;
+use Spaze\PHPStan\Rules\Disallowed\IsAllowedFileHelper;
 
 class StaticCallsTest extends RuleTestCase
 {
@@ -16,7 +16,7 @@ class StaticCallsTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		return new StaticCalls(
-			new DisallowedHelper(new FileHelper(new PHPStanFileHelper(__DIR__))),
+			new DisallowedHelper(new IsAllowedFileHelper(new FileHelper(__DIR__))),
 			new DisallowedCallFactory(),
 			[
 				[

--- a/tests/Configs/DangerousConfigEvalCallsTest.php
+++ b/tests/Configs/DangerousConfigEvalCallsTest.php
@@ -4,13 +4,13 @@ declare(strict_types = 1);
 namespace Spaze\PHPStan\Rules\Disallowed\Configs;
 
 use Nette\Neon\Neon;
-use PHPStan\File\FileHelper as PHPStanFileHelper;
+use PHPStan\File\FileHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\Calls\EvalCalls;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedHelper;
-use Spaze\PHPStan\Rules\Disallowed\FileHelper;
+use Spaze\PHPStan\Rules\Disallowed\IsAllowedFileHelper;
 
 class DangerousConfigEvalCallsTest extends RuleTestCase
 {
@@ -20,7 +20,7 @@ class DangerousConfigEvalCallsTest extends RuleTestCase
 		// Load the configuration from this file
 		$config = Neon::decode(file_get_contents(__DIR__ . '/../../disallowed-dangerous-calls.neon'));
 		return new EvalCalls(
-			new DisallowedHelper(new FileHelper(new PHPStanFileHelper(__DIR__))),
+			new DisallowedHelper(new IsAllowedFileHelper(new FileHelper(__DIR__))),
 			new DisallowedCallFactory(),
 			$config['parameters']['disallowedFunctionCalls']
 		);

--- a/tests/Configs/DangerousConfigFunctionCallsTest.php
+++ b/tests/Configs/DangerousConfigFunctionCallsTest.php
@@ -4,13 +4,13 @@ declare(strict_types = 1);
 namespace Spaze\PHPStan\Rules\Disallowed\Configs;
 
 use Nette\Neon\Neon;
-use PHPStan\File\FileHelper as PHPStanFileHelper;
+use PHPStan\File\FileHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\Calls\FunctionCalls;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedHelper;
-use Spaze\PHPStan\Rules\Disallowed\FileHelper;
+use Spaze\PHPStan\Rules\Disallowed\IsAllowedFileHelper;
 
 class DangerousConfigFunctionCallsTest extends RuleTestCase
 {
@@ -20,7 +20,7 @@ class DangerousConfigFunctionCallsTest extends RuleTestCase
 		// Load the configuration from this file
 		$config = Neon::decode(file_get_contents(__DIR__ . '/../../disallowed-dangerous-calls.neon'));
 		return new FunctionCalls(
-			new DisallowedHelper(new FileHelper(new PHPStanFileHelper(__DIR__))),
+			new DisallowedHelper(new IsAllowedFileHelper(new FileHelper(__DIR__))),
 			new DisallowedCallFactory(),
 			$config['parameters']['disallowedFunctionCalls']
 		);

--- a/tests/Configs/ExecutionConfigFunctionCallsTest.php
+++ b/tests/Configs/ExecutionConfigFunctionCallsTest.php
@@ -4,13 +4,13 @@ declare(strict_types = 1);
 namespace Spaze\PHPStan\Rules\Disallowed\Configs;
 
 use Nette\Neon\Neon;
-use PHPStan\File\FileHelper as PHPStanFileHelper;
+use PHPStan\File\FileHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\Calls\FunctionCalls;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedHelper;
-use Spaze\PHPStan\Rules\Disallowed\FileHelper;
+use Spaze\PHPStan\Rules\Disallowed\IsAllowedFileHelper;
 
 class ExecutionConfigFunctionCallsTest extends RuleTestCase
 {
@@ -20,7 +20,7 @@ class ExecutionConfigFunctionCallsTest extends RuleTestCase
 		// Load the configuration from this file
 		$config = Neon::decode(file_get_contents(__DIR__ . '/../../disallowed-execution-calls.neon'));
 		return new FunctionCalls(
-			new DisallowedHelper(new FileHelper(new PHPStanFileHelper(__DIR__))),
+			new DisallowedHelper(new IsAllowedFileHelper(new FileHelper(__DIR__))),
 			new DisallowedCallFactory(),
 			$config['parameters']['disallowedFunctionCalls']
 		);

--- a/tests/Configs/ExecutionConfigShellExecCallsTest.php
+++ b/tests/Configs/ExecutionConfigShellExecCallsTest.php
@@ -4,13 +4,13 @@ declare(strict_types = 1);
 namespace Spaze\PHPStan\Rules\Disallowed\Configs;
 
 use Nette\Neon\Neon;
-use PHPStan\File\FileHelper as PHPStanFileHelper;
+use PHPStan\File\FileHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\Calls\ShellExecCalls;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedHelper;
-use Spaze\PHPStan\Rules\Disallowed\FileHelper;
+use Spaze\PHPStan\Rules\Disallowed\IsAllowedFileHelper;
 
 class ExecutionConfigShellExecCallsTest extends RuleTestCase
 {
@@ -20,7 +20,7 @@ class ExecutionConfigShellExecCallsTest extends RuleTestCase
 		// Load the configuration from this file
 		$config = Neon::decode(file_get_contents(__DIR__ . '/../../disallowed-execution-calls.neon'));
 		return new ShellExecCalls(
-			new DisallowedHelper(new FileHelper(new PHPStanFileHelper(__DIR__))),
+			new DisallowedHelper(new IsAllowedFileHelper(new FileHelper(__DIR__))),
 			new DisallowedCallFactory(),
 			$config['parameters']['disallowedFunctionCalls']
 		);

--- a/tests/Configs/InsecureConfigFunctionCallsTest.php
+++ b/tests/Configs/InsecureConfigFunctionCallsTest.php
@@ -4,13 +4,13 @@ declare(strict_types = 1);
 namespace Spaze\PHPStan\Rules\Disallowed\Configs;
 
 use Nette\Neon\Neon;
-use PHPStan\File\FileHelper as PHPStanFileHelper;
+use PHPStan\File\FileHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\Calls\FunctionCalls;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedHelper;
-use Spaze\PHPStan\Rules\Disallowed\FileHelper;
+use Spaze\PHPStan\Rules\Disallowed\IsAllowedFileHelper;
 
 class InsecureConfigFunctionCallsTest extends RuleTestCase
 {
@@ -20,7 +20,7 @@ class InsecureConfigFunctionCallsTest extends RuleTestCase
 		// Load the configuration from this file
 		$config = Neon::decode(file_get_contents(__DIR__ . '/../../disallowed-insecure-calls.neon'));
 		return new FunctionCalls(
-			new DisallowedHelper(new FileHelper(new PHPStanFileHelper(__DIR__))),
+			new DisallowedHelper(new IsAllowedFileHelper(new FileHelper(__DIR__))),
 			new DisallowedCallFactory(),
 			$config['parameters']['disallowedFunctionCalls']
 		);

--- a/tests/Configs/InsecureConfigMethodCallsTest.php
+++ b/tests/Configs/InsecureConfigMethodCallsTest.php
@@ -4,13 +4,13 @@ declare(strict_types = 1);
 namespace Spaze\PHPStan\Rules\Disallowed\Configs;
 
 use Nette\Neon\Neon;
-use PHPStan\File\FileHelper as PHPStanFileHelper;
+use PHPStan\File\FileHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\Calls\MethodCalls;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedHelper;
-use Spaze\PHPStan\Rules\Disallowed\FileHelper;
+use Spaze\PHPStan\Rules\Disallowed\IsAllowedFileHelper;
 
 class InsecureConfigMethodCallsTest extends RuleTestCase
 {
@@ -20,7 +20,7 @@ class InsecureConfigMethodCallsTest extends RuleTestCase
 		// Load the configuration from this file
 		$config = Neon::decode(file_get_contents(__DIR__ . '/../../disallowed-insecure-calls.neon'));
 		return new MethodCalls(
-			new DisallowedHelper(new FileHelper(new PHPStanFileHelper(__DIR__))),
+			new DisallowedHelper(new IsAllowedFileHelper(new FileHelper(__DIR__))),
 			new DisallowedCallFactory(),
 			$config['parameters']['disallowedMethodCalls']
 		);

--- a/tests/Configs/LooseConfigFunctionCallsTest.php
+++ b/tests/Configs/LooseConfigFunctionCallsTest.php
@@ -4,13 +4,13 @@ declare(strict_types = 1);
 namespace Spaze\PHPStan\Rules\Disallowed\Configs;
 
 use Nette\Neon\Neon;
-use PHPStan\File\FileHelper as PHPStanFileHelper;
+use PHPStan\File\FileHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\Calls\FunctionCalls;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedHelper;
-use Spaze\PHPStan\Rules\Disallowed\FileHelper;
+use Spaze\PHPStan\Rules\Disallowed\IsAllowedFileHelper;
 
 class LooseConfigFunctionCallsTest extends RuleTestCase
 {
@@ -28,7 +28,7 @@ class LooseConfigFunctionCallsTest extends RuleTestCase
 			}
 		}
 		return new FunctionCalls(
-			new DisallowedHelper(new FileHelper(new PHPStanFileHelper(__DIR__))),
+			new DisallowedHelper(new IsAllowedFileHelper(new FileHelper(__DIR__))),
 			new DisallowedCallFactory(),
 			$config['parameters']['disallowedFunctionCalls']
 		);

--- a/tests/IsAllowedFileHelperTest.php
+++ b/tests/IsAllowedFileHelperTest.php
@@ -4,19 +4,19 @@ declare(strict_types = 1);
 namespace Spaze\PHPStan\Rules\Disallowed;
 
 use Generator;
-use PHPStan\File\FileHelper as PHPStanFileHelper;
+use PHPStan\File\FileHelper;
 use PHPUnit\Framework\TestCase;
 
-class FileHelperTest extends TestCase
+class IsAllowedFileHelperTest extends TestCase
 {
 
-	/** @var FileHelper */
-	private $fileHelper;
+	/** @var IsAllowedFileHelper */
+	private $isAllowedHelper;
 
 
 	protected function setUp(): void
 	{
-		$this->fileHelper = new FileHelper(new PHPStanFileHelper(__DIR__));
+		$this->isAllowedHelper = new IsAllowedFileHelper(new FileHelper(__DIR__));
 	}
 
 
@@ -27,7 +27,7 @@ class FileHelperTest extends TestCase
 	 */
 	public function testAbsolutizePath(string $input, string $output): void
 	{
-		$this->assertSame($output, $this->fileHelper->absolutizePath($input));
+		$this->assertSame($output, $this->isAllowedHelper->absolutizePath($input));
 	}
 
 

--- a/tests/IsAllowedFileHelperTest.php
+++ b/tests/IsAllowedFileHelperTest.php
@@ -13,10 +13,14 @@ class IsAllowedFileHelperTest extends TestCase
 	/** @var IsAllowedFileHelper */
 	private $isAllowedHelper;
 
+	/** @var IsAllowedFileHelper */
+	private $isAllowedHelperWithRootDir;
+
 
 	protected function setUp(): void
 	{
 		$this->isAllowedHelper = new IsAllowedFileHelper(new FileHelper(__DIR__));
+		$this->isAllowedHelperWithRootDir = new IsAllowedFileHelper(new FileHelper(__DIR__), '/foo/bar');
 	}
 
 
@@ -25,20 +29,50 @@ class IsAllowedFileHelperTest extends TestCase
 	 * @param string $output
 	 * @dataProvider pathProvider
 	 */
-	public function testAbsolutizePath(string $input, string $output): void
+	public function testAbsolutizePath(string $input, string $output, string $outputWithDir): void
 	{
 		$this->assertSame($output, $this->isAllowedHelper->absolutizePath($input));
+		$this->assertSame($outputWithDir, $this->isAllowedHelperWithRootDir->absolutizePath($input));
 	}
 
 
 	public function pathProvider(): Generator
 	{
-		yield ['src', __DIR__ . '/src'];
-		yield ['src/*', __DIR__ . '/src/*'];
-		yield ['../src/*', str_replace(basename(__DIR__) . '/../', '', __DIR__ . '/../src/*')];
-		yield ['src/foo/../*', __DIR__ . '/src/*'];
-		yield ['*/src', '*/src'];
-		yield ['*/../src', '*/../src'];
+		yield [
+			'src',
+			__DIR__ . '/src',
+			'/foo/bar/src',
+		];
+		yield [
+			'src/*',
+			__DIR__ . '/src/*',
+			'/foo/bar/src/*',
+		];
+		yield [
+			'../src/*',
+			str_replace(basename(__DIR__) . '/../', '', __DIR__ . '/../src/*'),
+			'/foo/src/*',
+		];
+		yield [
+			'src/foo/../*',
+			__DIR__ . '/src/*',
+			'/foo/bar/src/*',
+		];
+		yield [
+			'*/src',
+			'*/src',
+			'*/src',
+		];
+		yield [
+			'*/../src',
+			'*/../src',
+			'*/../src',
+		];
+		yield [
+			'\\src\\foo\\bar\\',
+			__DIR__ . '/src/foo/bar',
+			'/foo/bar/src/foo/bar',
+		];
 	}
 
 }

--- a/tests/Usages/ClassConstantInvalidUsagesTest.php
+++ b/tests/Usages/ClassConstantInvalidUsagesTest.php
@@ -3,12 +3,12 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Rules\Disallowed\Usages;
 
-use PHPStan\File\FileHelper as PHPStanFileHelper;
+use PHPStan\File\FileHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedConstantFactory;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedHelper;
-use Spaze\PHPStan\Rules\Disallowed\FileHelper;
+use Spaze\PHPStan\Rules\Disallowed\IsAllowedFileHelper;
 
 class ClassConstantInvalidUsagesTest extends RuleTestCase
 {
@@ -16,7 +16,7 @@ class ClassConstantInvalidUsagesTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		return new ClassConstantUsages(
-			new DisallowedHelper(new FileHelper(new PHPStanFileHelper(__DIR__))),
+			new DisallowedHelper(new IsAllowedFileHelper(new FileHelper(__DIR__))),
 			new DisallowedConstantFactory(),
 			[]
 		);

--- a/tests/Usages/ClassConstantUsagesTest.php
+++ b/tests/Usages/ClassConstantUsagesTest.php
@@ -3,12 +3,12 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Rules\Disallowed\Usages;
 
-use PHPStan\File\FileHelper as PHPStanFileHelper;
+use PHPStan\File\FileHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedConstantFactory;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedHelper;
-use Spaze\PHPStan\Rules\Disallowed\FileHelper;
+use Spaze\PHPStan\Rules\Disallowed\IsAllowedFileHelper;
 
 class ClassConstantUsagesTest extends RuleTestCase
 {
@@ -16,7 +16,7 @@ class ClassConstantUsagesTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		return new ClassConstantUsages(
-			new DisallowedHelper(new FileHelper(new PHPStanFileHelper(__DIR__))),
+			new DisallowedHelper(new IsAllowedFileHelper(new FileHelper(__DIR__))),
 			new DisallowedConstantFactory(),
 			[
 				[

--- a/tests/Usages/ConstantUsagesTest.php
+++ b/tests/Usages/ConstantUsagesTest.php
@@ -3,12 +3,12 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Rules\Disallowed\Usages;
 
-use PHPStan\File\FileHelper as PHPStanFileHelper;
+use PHPStan\File\FileHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedConstantFactory;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedHelper;
-use Spaze\PHPStan\Rules\Disallowed\FileHelper;
+use Spaze\PHPStan\Rules\Disallowed\IsAllowedFileHelper;
 
 class ConstantUsagesTest extends RuleTestCase
 {
@@ -16,7 +16,7 @@ class ConstantUsagesTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		return new ConstantUsages(
-			new DisallowedHelper(new FileHelper(new PHPStanFileHelper(__DIR__))),
+			new DisallowedHelper(new IsAllowedFileHelper(new FileHelper(__DIR__))),
 			new DisallowedConstantFactory(),
 			[
 				[

--- a/tests/Usages/NamespaceUsagesTest.php
+++ b/tests/Usages/NamespaceUsagesTest.php
@@ -3,12 +3,12 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Rules\Disallowed\Usages;
 
-use PHPStan\File\FileHelper as PHPStanFileHelper;
+use PHPStan\File\FileHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedNamespaceFactory;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedNamespaceHelper;
-use Spaze\PHPStan\Rules\Disallowed\FileHelper;
+use Spaze\PHPStan\Rules\Disallowed\IsAllowedFileHelper;
 
 class NamespaceUsagesTest extends RuleTestCase
 {
@@ -16,7 +16,7 @@ class NamespaceUsagesTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		return new NamespaceUsages(
-			new DisallowedNamespaceHelper(new FileHelper(new PHPStanFileHelper(__DIR__))),
+			new DisallowedNamespaceHelper(new IsAllowedFileHelper(new FileHelper(__DIR__))),
 			new DisallowedNamespaceFactory(),
 			[
 				[


### PR DESCRIPTION
Seems I can't get the "root" directory in an automated way. Directives like `ignoreError`'s `path`/`paths` [resolve relative paths](https://phpstan.org/user-guide/ignoring-errors#ignoring-in-configuration-file) based on the directory of the config file is in but those are [special cases](https://github.com/phpstan/phpstan-src/blob/13047ff2264f7672ad819470b6a801283f353aa8/src/DependencyInjection/NeonAdapter.php#L103-L124) which I can't add into.

Fix #100