### PR TITLE
Check `allowedIn` trait files, if the call is in a trait

### DIFF
--- a/src/DisallowedHelper.php
+++ b/src/DisallowedHelper.php
@@ -47,7 +47,8 @@ class DisallowedHelper
 			}
 		}
 		foreach ($disallowedCall->getAllowIn() as $allowedPath) {
-			if (fnmatch($this->isAllowedFileHelper->absolutizePath($allowedPath), $scope->getFile())) {
+			$file = $scope->getTraitReflection() ? $scope->getTraitReflection()->getFileName() : $scope->getFile();
+			if ($file !== null && fnmatch($this->isAllowedFileHelper->absolutizePath($allowedPath), $file)) {
 				return $this->hasAllowedParamsInAllowed($scope, $node, $disallowedCall);
 			}
 		}


### PR DESCRIPTION
If the call is in a trait, check if the call is allowed *in the trait file*, not *in the calling class file*.

Unfortunately, can't write a test for it as `$scope->getTraitReflection()` returns null in tests.

Fix #99