### PR TITLE
Allow superglobal when allowed in a trait

### DIFF
--- a/src/DisallowedHelper.php
+++ b/src/DisallowedHelper.php
@@ -47,8 +47,7 @@ class DisallowedHelper
 			}
 		}
 		foreach ($disallowedCall->getAllowIn() as $allowedPath) {
-			$file = $scope->getTraitReflection() ? $scope->getTraitReflection()->getFileName() : $scope->getFile();
-			if ($file !== null && fnmatch($this->isAllowedFileHelper->absolutizePath($allowedPath), $file)) {
+			if ($this->isAllowedFileHelper->matches($scope, $allowedPath)) {
 				return $this->hasAllowedParamsInAllowed($scope, $node, $disallowedCall);
 			}
 		}
@@ -207,7 +206,7 @@ class DisallowedHelper
 	private function isAllowedPath(Scope $scope, DisallowedConstant $disallowedConstant): bool
 	{
 		foreach ($disallowedConstant->getAllowIn() as $allowedPath) {
-			if (fnmatch($this->isAllowedFileHelper->absolutizePath($allowedPath), $scope->getFile())) {
+			if ($this->isAllowedFileHelper->matches($scope, $allowedPath)) {
 				return true;
 			}
 		}

--- a/src/DisallowedNamespaceHelper.php
+++ b/src/DisallowedNamespaceHelper.php
@@ -28,8 +28,7 @@ class DisallowedNamespaceHelper
 	private function isAllowed(Scope $scope, DisallowedNamespace $disallowedNamespace): bool
 	{
 		foreach ($disallowedNamespace->getAllowIn() as $allowedPath) {
-			$match = fnmatch($this->isAllowedFileHelper->absolutizePath($allowedPath), $scope->getFile());
-			if ($match) {
+			if ($this->isAllowedFileHelper->matches($scope, $allowedPath)) {
 				return true;
 			}
 		}

--- a/src/DisallowedSuperglobalHelper.php
+++ b/src/DisallowedSuperglobalHelper.php
@@ -23,7 +23,7 @@ class DisallowedSuperglobalHelper
 	private function isAllowedPath(Scope $scope, DisallowedSuperglobal $disallowedSuperglobal): bool
 	{
 		foreach ($disallowedSuperglobal->getAllowIn() as $allowedPath) {
-			if (fnmatch($this->isAllowedFileHelper->absolutizePath($allowedPath), $scope->getFile())) {
+			if ($this->isAllowedFileHelper->matches($scope, $allowedPath)) {
 				return true;
 			}
 		}

--- a/src/IsAllowedFileHelper.php
+++ b/src/IsAllowedFileHelper.php
@@ -3,6 +3,7 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Rules\Disallowed;
 
+use PHPStan\Analyser\Scope;
 use PHPStan\File\FileHelper;
 
 class IsAllowedFileHelper
@@ -28,7 +29,7 @@ class IsAllowedFileHelper
 	 * @param string $path
 	 * @return string
 	 */
-	public function absolutizePath(string $path): string
+	private function absolutizePath(string $path): string
 	{
 		if (strpos($path, '*') === 0) {
 			return $path;
@@ -38,6 +39,13 @@ class IsAllowedFileHelper
 			$path = rtrim($this->allowInRootDir, '/') . '/' . ltrim($path, '/');
 		}
 		return $this->fileHelper->normalizePath($this->fileHelper->absolutizePath($path));
+	}
+
+
+	public function matches(Scope $scope, string $allowedPath): bool
+	{
+		$file = $scope->getTraitReflection() ? $scope->getTraitReflection()->getFileName() : $scope->getFile();
+		return $file !== null && fnmatch($this->absolutizePath($allowedPath), $file);
 	}
 
 }

--- a/tests/IsAllowedFileHelperTest.php
+++ b/tests/IsAllowedFileHelperTest.php
@@ -4,10 +4,15 @@ declare(strict_types = 1);
 namespace Spaze\PHPStan\Rules\Disallowed;
 
 use Generator;
+use PHPStan\Analyser\ScopeContext;
+use PHPStan\Analyser\ScopeFactory;
 use PHPStan\File\FileHelper;
-use PHPUnit\Framework\TestCase;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Testing\PHPStanTestCase;
+use Traits\TestClass;
+use Traits\TestTrait;
 
-class IsAllowedFileHelperTest extends TestCase
+class IsAllowedFileHelperTest extends PHPStanTestCase
 {
 
 	/** @var IsAllowedFileHelper */
@@ -16,23 +21,31 @@ class IsAllowedFileHelperTest extends TestCase
 	/** @var IsAllowedFileHelper */
 	private $isAllowedHelperWithRootDir;
 
+	/** @var ScopeFactory */
+	private $scopeFactory;
+
+	/** @var ReflectionProvider */
+	private $reflectionProvider;
+
 
 	protected function setUp(): void
 	{
 		$this->isAllowedHelper = new IsAllowedFileHelper(new FileHelper(__DIR__));
 		$this->isAllowedHelperWithRootDir = new IsAllowedFileHelper(new FileHelper(__DIR__), '/foo/bar');
+		$this->reflectionProvider = $this->createReflectionProvider();
+		$this->scopeFactory = $this->createScopeFactory($this->reflectionProvider, self::getContainer()->getService('typeSpecifier'));
 	}
 
 
 	/**
-	 * @param string $input
-	 * @param string $output
 	 * @dataProvider pathProvider
 	 */
-	public function testAbsolutizePath(string $input, string $output, string $outputWithDir): void
+	public function testMatches(string $allowedPath, string $file, string $fileWithRootDir): void
 	{
-		$this->assertSame($output, $this->isAllowedHelper->absolutizePath($input));
-		$this->assertSame($outputWithDir, $this->isAllowedHelperWithRootDir->absolutizePath($input));
+		$context = ScopeContext::create($file);
+		$this->assertTrue($this->isAllowedHelper->matches($this->scopeFactory->create($context), $allowedPath));
+		$context = ScopeContext::create($fileWithRootDir);
+		$this->assertTrue($this->isAllowedHelperWithRootDir->matches($this->scopeFactory->create($context), $allowedPath));
 	}
 
 
@@ -45,18 +58,18 @@ class IsAllowedFileHelperTest extends TestCase
 		];
 		yield [
 			'src/*',
-			__DIR__ . '/src/*',
-			'/foo/bar/src/*',
+			__DIR__ . '/src/waldo.php',
+			'/foo/bar/src/waldo.php',
 		];
 		yield [
 			'../src/*',
-			str_replace(basename(__DIR__) . '/../', '', __DIR__ . '/../src/*'),
-			'/foo/src/*',
+			str_replace(basename(__DIR__) . '/../', '', __DIR__ . '/../src/waldo.php'),
+			'/foo/src/waldo.php',
 		];
 		yield [
 			'src/foo/../*',
-			__DIR__ . '/src/*',
-			'/foo/bar/src/*',
+			__DIR__ . '/src/waldo.php',
+			'/foo/bar/src/waldo.php',
 		];
 		yield [
 			'*/src',
@@ -73,6 +86,15 @@ class IsAllowedFileHelperTest extends TestCase
 			__DIR__ . '/src/foo/bar',
 			'/foo/bar/src/foo/bar',
 		];
+	}
+
+
+	public function testMatchesInTraits(): void
+	{
+		$classReflection = $this->reflectionProvider->getClass(TestClass::class);
+		$traitReflection = $this->reflectionProvider->getClass(TestTrait::class);
+		$context = ScopeContext::create($classReflection->getFileName())->enterClass($classReflection)->enterTrait($traitReflection);
+		$this->assertTrue($this->isAllowedHelper->matches($this->scopeFactory->create($context), $traitReflection->getFileName()));
 	}
 
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,4 +9,5 @@ require_once __DIR__ . '/libs/Inheritance.php';
 require_once __DIR__ . '/libs/Royale.php';
 require_once __DIR__ . '/libs/SomeInterface.php';
 require_once __DIR__ . '/libs/Option.php';
+require_once __DIR__ . '/libs/TestTrait.php';
 require_once __DIR__ . '/libs/Traits.php';

--- a/tests/libs/TestTrait.php
+++ b/tests/libs/TestTrait.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types = 1);
+
+namespace Traits;
+
+trait TestTrait
+{
+
+	public function x(): void
+	{
+	}
+
+
+	public function y(): void
+	{
+	}
+
+
+	public static function z(): void
+	{
+	}
+
+}

--- a/tests/libs/Traits.php
+++ b/tests/libs/Traits.php
@@ -3,25 +3,6 @@ declare(strict_types = 1);
 
 namespace Traits;
 
-trait TestTrait
-{
-
-	public function x(): void
-	{
-	}
-
-
-	public function y(): void
-	{
-	}
-
-
-	public static function z(): void
-	{
-	}
-
-}
-
 
 trait AnotherTrait
 {


### PR DESCRIPTION
`IsAllowedFileHelper` now does the matching, it doesn't just concatenate some strings anymore.

First I wanted to also iterate say `DisallowedCalls::allowedIn` in the method but there are some other conditions that will influence the return value sometimes too, like exactly in `DisallowedCalls`:
https://github.com/spaze/phpstan-disallowed-calls/blob/a16e9219f02c3b70099fe640abbb39b0452aa8d4/src/DisallowedHelper.php#L49-L54

Plus now the trait-related code is actually tested.

Fix #106