### PR TITLE
Better describe a disallowed "namespace"

### DIFF
--- a/src/DisallowedNamespaceHelper.php
+++ b/src/DisallowedNamespaceHelper.php
@@ -38,11 +38,12 @@ class DisallowedNamespaceHelper
 
 	/**
 	 * @param string $namespace
+	 * @param string $description
 	 * @param Scope $scope
 	 * @param DisallowedNamespace[] $disallowedNamespaces
 	 * @return RuleError[]
 	 */
-	public function getDisallowedMessage(string $namespace, Scope $scope, array $disallowedNamespaces): array
+	public function getDisallowedMessage(string $namespace, string $description, Scope $scope, array $disallowedNamespaces): array
 	{
 		foreach ($disallowedNamespaces as $disallowedNamespace) {
 			if ($this->isAllowed($scope, $disallowedNamespace)) {
@@ -55,7 +56,8 @@ class DisallowedNamespaceHelper
 
 			return [
 				RuleErrorBuilder::message(sprintf(
-					'Namespace %s is forbidden, %s%s',
+					'%s %s is forbidden, %s%s',
+					$description,
 					$namespace,
 					$disallowedNamespace->getMessage(),
 					$disallowedNamespace->getNamespace() !== $namespace ? " [{$namespace} matches {$disallowedNamespace->getNamespace()}]" : ''

--- a/src/Usages/NamespaceUsages.php
+++ b/src/Usages/NamespaceUsages.php
@@ -57,12 +57,14 @@ class NamespaceUsages implements Rule
 	public function processNode(Node $node, Scope $scope): array
 	{
 		if ($node instanceof FullyQualified) {
+			$description = 'Class';
 			$namespaces = [$node->toString()];
 		} elseif ($node instanceof UseUse) {
 			$namespaces = [$node->name->toString()];
 		} elseif ($node instanceof StaticCall && $node->class instanceof Name) {
 			$namespaces = [$node->class->toString()];
 		} elseif ($node instanceof ClassConstFetch && $node->class instanceof Name) {
+			$description = 'Class';
 			$namespaces = [$node->class->toString()];
 		} elseif ($node instanceof Class_ && ($node->extends !== null || count($node->implements) > 0)) {
 			$namespaces = [];
@@ -75,8 +77,8 @@ class NamespaceUsages implements Rule
 				$namespaces[] = $implement->toString();
 			}
 		} elseif ($node instanceof TraitUse) {
+			$description = 'Trait';
 			$namespaces = [];
-
 			foreach ($node->traits as $trait) {
 				$namespaces[] = $trait->toString();
 			}
@@ -88,7 +90,7 @@ class NamespaceUsages implements Rule
 		foreach ($namespaces as $namespace) {
 			$errors = array_merge(
 				$errors,
-				$this->disallowedHelper->getDisallowedMessage(ltrim($namespace, '\\'), $scope, $this->disallowedNamespace)
+				$this->disallowedHelper->getDisallowedMessage(ltrim($namespace, '\\'), $description ?? 'Namespace', $scope, $this->disallowedNamespace)
 			);
 		}
 

--- a/tests/Usages/NamespaceUsagesTest.php
+++ b/tests/Usages/NamespaceUsagesTest.php
@@ -106,11 +106,11 @@ class NamespaceUsagesTest extends RuleTestCase
 				13,
 			],
 			[
-				'Namespace Traits\TestTrait is forbidden, no TestTrait',
+				'Trait Traits\TestTrait is forbidden, no TestTrait',
 				16,
 			],
 			[
-				'Namespace Waldo\Quux\blade is forbidden, no blade [Waldo\Quux\blade matches Waldo\Quux\Blade]',
+				'Class Waldo\Quux\blade is forbidden, no blade [Waldo\Quux\blade matches Waldo\Quux\Blade]',
 				23,
 			],
 			[
@@ -118,7 +118,7 @@ class NamespaceUsagesTest extends RuleTestCase
 				31,
 			],
 			[
-				'Namespace Waldo\Foo\Bar is forbidden, no FooBar [Waldo\Foo\Bar matches Waldo\Foo\bar]',
+				'Class Waldo\Foo\Bar is forbidden, no FooBar [Waldo\Foo\Bar matches Waldo\Foo\bar]',
 				37,
 			],
 		]);


### PR DESCRIPTION
Because sometimes a _namespace_ is also a _class_, sometimes a _trait_. There might be more cases to change the description for, but for now this is good enough.