### PR TITLE
Drop PHP 7.1 support, require PHP 7.2

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -10,7 +10,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - 7.1
           - 7.2
           - 7.3
           - 7.4

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		}
 	},
 	"require": {
-		"php": "^7.1 || ^8.0",
+		"php": "^7.2 || ^8.0",
 		"phpstan/phpstan": "^1.0"
 	},
 	"require-dev": {


### PR DESCRIPTION
The newer coding standard requires 7.2+ and also:
![image](https://user-images.githubusercontent.com/1966648/194678422-c8be26e7-d6c1-48fa-8fb4-a9962cbf1703.png)
