### PR TITLE
Check whether the disallowed function exists in global namespace

### DIFF
--- a/src/Calls/FunctionCalls.php
+++ b/src/Calls/FunctionCalls.php
@@ -62,15 +62,21 @@ class FunctionCalls implements Rule
 		if (!($node->name instanceof Name)) {
 			return [];
 		}
-		$name = $node->name->getAttribute('namespacedName') ?? $node->name;
-		if (!$name instanceof Name) {
+		$namespacedName = $node->name->getAttribute('namespacedName');
+		if ($namespacedName !== null && !($namespacedName instanceof Name)) {
 			throw new ShouldNotHappenException();
 		}
-		$displayName = $node->name->getAttribute('originalName') ?? $node->name;
-		if (!$displayName instanceof Name) {
+		$displayName = $node->name->getAttribute('originalName');
+		if ($displayName !== null && !($displayName instanceof Name)) {
 			throw new ShouldNotHappenException();
 		}
-		return $this->disallowedHelper->getDisallowedMessage($node, $scope, (string)$name, (string)$displayName, $this->disallowedCalls);
+		foreach ([$namespacedName, $node->name] as $name) {
+			$message = $this->disallowedHelper->getDisallowedMessage($node, $scope, (string)$name, (string)($displayName ?? $node->name), $this->disallowedCalls);
+			if ($message) {
+				return $message;
+			}
+		}
+		return [];
 	}
 
 }

--- a/tests/Calls/FunctionCallsInMultipleNamespacesTest.php
+++ b/tests/Calls/FunctionCallsInMultipleNamespacesTest.php
@@ -27,6 +27,9 @@ class FunctionCallsInMultipleNamespacesTest extends RuleTestCase
 					'function' => 'MyNamespace\__()',
 					'message' => 'ha ha ha nope',
 				],
+				[
+					'function' => 'printf()',
+				],
 			]
 		);
 	}
@@ -47,8 +50,24 @@ class FunctionCallsInMultipleNamespacesTest extends RuleTestCase
 				23,
 			],
 			[
+				'Calling printf() is forbidden, because reasons',
+				26,
+			],
+			[
+				'Calling printf() is forbidden, because reasons',
+				27,
+			],
+			[
 				'Calling MyNamespace\__() (as alias()) is forbidden, ha ha ha nope',
-				32,
+				35,
+			],
+			[
+				'Calling printf() is forbidden, because reasons',
+				36,
+			],
+			[
+				'Calling printf() is forbidden, because reasons',
+				37,
 			],
 		]);
 	}

--- a/tests/libs/FunctionInMultipleNamespaces.php
+++ b/tests/libs/FunctionInMultipleNamespaces.php
@@ -23,6 +23,9 @@ namespace MyNamespace {
 		return __();  // The __ used here is MyNamespace\__
 	}
 
+	printf('oo');
+	\printf('oo');
+
 }
 
 namespace {
@@ -30,6 +33,8 @@ namespace {
 	use function MyNamespace\__ as alias;
 
 	alias();
+	printf('oo');
+	\printf('oo');
 
 }
 


### PR DESCRIPTION
A not fully-qualified call in a namespace `NS` (e.g. `foo`, but not `\foo()`) was only checked as `NS\foo()` but not as `foo()`. Need to check the global namespace too, not just in the current one.

Fix #124