### PR TITLE
If there's no error identifier, make it null instead of an empty string

### DIFF
--- a/src/DisallowedCall.php
+++ b/src/DisallowedCall.php
@@ -32,7 +32,7 @@ class DisallowedCall
 	/** @var array<int, DisallowedCallParam> */
 	private $allowExceptParams;
 
-	/** @var string */
+	/** @var string|null */
 	private $errorIdentifier;
 
 
@@ -47,9 +47,9 @@ class DisallowedCall
 	 * @param array<int, DisallowedCallParam> $allowParamsAnywhere
 	 * @param array<int, DisallowedCallParam> $allowExceptParamsInAllowed
 	 * @param array<int, DisallowedCallParam> $allowExceptParams
-	 * @param string $errorIdentifier
+	 * @param string|null $errorIdentifier
 	 */
-	public function __construct(string $call, ?string $message, array $allowIn, array $allowInCalls, array $allowParamsInAllowed, array $allowParamsAnywhere, array $allowExceptParamsInAllowed, array $allowExceptParams, string $errorIdentifier)
+	public function __construct(string $call, ?string $message, array $allowIn, array $allowInCalls, array $allowParamsInAllowed, array $allowParamsAnywhere, array $allowExceptParamsInAllowed, array $allowExceptParams, ?string $errorIdentifier)
 	{
 		$this->call = $call;
 		$this->message = $message;
@@ -129,7 +129,7 @@ class DisallowedCall
 	}
 
 
-	public function getErrorIdentifier(): string
+	public function getErrorIdentifier(): ?string
 	{
 		return $this->errorIdentifier;
 	}

--- a/src/DisallowedCallFactory.php
+++ b/src/DisallowedCallFactory.php
@@ -63,7 +63,7 @@ class DisallowedCallFactory
 					$allowParamsAnywhere,
 					$allowExceptParamsInAllowed,
 					$allowExceptParams,
-					$disallowed['errorIdentifier'] ?? ''
+					$disallowed['errorIdentifier'] ?? null
 				);
 				$disallowedCalls[$disallowedCall->getKey()] = $disallowedCall;
 			}

--- a/src/DisallowedConstant.php
+++ b/src/DisallowedConstant.php
@@ -15,7 +15,7 @@ class DisallowedConstant
 	/** @var string[] */
 	private $allowIn;
 
-	/** @var string */
+	/** @var string|null */
 	private $errorIdentifier;
 
 
@@ -25,9 +25,9 @@ class DisallowedConstant
 	 * @param string $constant
 	 * @param string|null $message
 	 * @param string[] $allowIn
-	 * @param string $errorIdentifier
+	 * @param string|null $errorIdentifier
 	 */
-	public function __construct(string $constant, ?string $message, array $allowIn, string $errorIdentifier)
+	public function __construct(string $constant, ?string $message, array $allowIn, ?string $errorIdentifier)
 	{
 		$this->constant = ltrim($constant, '\\');
 		$this->message = $message;
@@ -57,7 +57,7 @@ class DisallowedConstant
 	}
 
 
-	public function getErrorIdentifier(): string
+	public function getErrorIdentifier(): ?string
 	{
 		return $this->errorIdentifier;
 	}

--- a/src/DisallowedConstantFactory.php
+++ b/src/DisallowedConstantFactory.php
@@ -28,7 +28,7 @@ class DisallowedConstantFactory
 					$class ? "{$class}::{$constant}" : $constant,
 					$disallowed['message'] ?? null,
 					$disallowed['allowIn'] ?? [],
-					$disallowed['errorIdentifier'] ?? ''
+					$disallowed['errorIdentifier'] ?? null
 				);
 				$disallowedConstants[$disallowedConstant->getConstant()] = $disallowedConstant;
 			}

--- a/src/DisallowedHelper.php
+++ b/src/DisallowedHelper.php
@@ -119,15 +119,17 @@ class DisallowedHelper
 	{
 		foreach ($disallowedCalls as $disallowedCall) {
 			if ($this->callMatches($disallowedCall, $name) && !$this->isAllowed($scope, $node, $disallowedCall)) {
+				$errorBuilder = RuleErrorBuilder::message(sprintf(
+					$message ?? 'Calling %s is forbidden, %s%s',
+					($displayName && $displayName !== $name) ? "{$name}() (as {$displayName}())" : "{$name}()",
+					$disallowedCall->getMessage(),
+					$disallowedCall->getCall() !== $name ? " [{$name}() matches {$disallowedCall->getCall()}()]" : ''
+				));
+				if ($disallowedCall->getErrorIdentifier()) {
+					$errorBuilder->identifier($disallowedCall->getErrorIdentifier());
+				}
 				return [
-					RuleErrorBuilder::message(sprintf(
-						$message ?? 'Calling %s is forbidden, %s%s',
-						($displayName && $displayName !== $name) ? "{$name}() (as {$displayName}())" : "{$name}()",
-						$disallowedCall->getMessage(),
-						$disallowedCall->getCall() !== $name ? " [{$name}() matches {$disallowedCall->getCall()}()]" : ''
-					))
-						->identifier($disallowedCall->getErrorIdentifier())
-						->build(),
+					$errorBuilder->build(),
 				];
 			}
 		}
@@ -225,15 +227,17 @@ class DisallowedHelper
 	{
 		foreach ($disallowedConstants as $disallowedConstant) {
 			if ($disallowedConstant->getConstant() === $constant && !$this->isAllowedPath($scope, $disallowedConstant)) {
+				$errorBuilder = RuleErrorBuilder::message(sprintf(
+					'Using %s%s is forbidden, %s',
+					$disallowedConstant->getConstant(),
+					$displayName && $displayName !== $disallowedConstant->getConstant() ? ' (as ' . $displayName . ')' : '',
+					$disallowedConstant->getMessage()
+				));
+				if ($disallowedConstant->getErrorIdentifier()) {
+					$errorBuilder->identifier($disallowedConstant->getErrorIdentifier());
+				}
 				return [
-					RuleErrorBuilder::message(sprintf(
-						'Using %s%s is forbidden, %s',
-						$disallowedConstant->getConstant(),
-						$displayName && $displayName !== $disallowedConstant->getConstant() ? ' (as ' . $displayName . ')' : '',
-						$disallowedConstant->getMessage()
-					))
-						->identifier($disallowedConstant->getErrorIdentifier())
-						->build(),
+					$errorBuilder->build(),
 				];
 			}
 		}

--- a/src/DisallowedNamespace.php
+++ b/src/DisallowedNamespace.php
@@ -15,7 +15,7 @@ class DisallowedNamespace
 	/** @var string[] */
 	private $allowIn;
 
-	/** @var string */
+	/** @var string|null */
 	private $errorIdentifier;
 
 
@@ -23,9 +23,9 @@ class DisallowedNamespace
 	 * @param string $namespace
 	 * @param string|null $message
 	 * @param string[] $allowIn
-	 * @param string $errorIdentifier
+	 * @param string|null $errorIdentifier
 	 */
-	public function __construct(string $namespace, ?string $message, array $allowIn, string $errorIdentifier)
+	public function __construct(string $namespace, ?string $message, array $allowIn, ?string $errorIdentifier)
 	{
 		$this->namespace = ltrim($namespace, '\\');
 		$this->message = $message;
@@ -55,7 +55,7 @@ class DisallowedNamespace
 	}
 
 
-	public function getErrorIdentifier(): string
+	public function getErrorIdentifier(): ?string
 	{
 		return $this->errorIdentifier;
 	}

--- a/src/DisallowedNamespaceFactory.php
+++ b/src/DisallowedNamespaceFactory.php
@@ -26,7 +26,7 @@ class DisallowedNamespaceFactory
 					$namespace,
 					$disallowed['message'] ?? null,
 					$disallowed['allowIn'] ?? [],
-					$disallowed['errorIdentifier'] ?? ''
+					$disallowed['errorIdentifier'] ?? null
 				);
 				$disallowedNamespaces[$disallowedNamespace->getNamespace()] = $disallowedNamespace;
 			}

--- a/src/DisallowedNamespaceHelper.php
+++ b/src/DisallowedNamespaceHelper.php
@@ -54,16 +54,18 @@ class DisallowedNamespaceHelper
 				continue;
 			}
 
+			$errorBuilder = RuleErrorBuilder::message(sprintf(
+				'%s %s is forbidden, %s%s',
+				$description,
+				$namespace,
+				$disallowedNamespace->getMessage(),
+				$disallowedNamespace->getNamespace() !== $namespace ? " [{$namespace} matches {$disallowedNamespace->getNamespace()}]" : ''
+			));
+			if ($disallowedNamespace->getErrorIdentifier()) {
+				$errorBuilder->identifier($disallowedNamespace->getErrorIdentifier());
+			}
 			return [
-				RuleErrorBuilder::message(sprintf(
-					'%s %s is forbidden, %s%s',
-					$description,
-					$namespace,
-					$disallowedNamespace->getMessage(),
-					$disallowedNamespace->getNamespace() !== $namespace ? " [{$namespace} matches {$disallowedNamespace->getNamespace()}]" : ''
-				))
-					->identifier($disallowedNamespace->getErrorIdentifier())
-					->build(),
+				$errorBuilder->build(),
 			];
 		}
 

--- a/src/DisallowedSuperglobalFactory.php
+++ b/src/DisallowedSuperglobalFactory.php
@@ -46,7 +46,7 @@ class DisallowedSuperglobalFactory implements DisallowedVariableFactory
 					$superglobal,
 					$disallowed['message'] ?? null,
 					$disallowed['allowIn'] ?? [],
-					$disallowed['errorIdentifier'] ?? ''
+					$disallowed['errorIdentifier'] ?? null
 				);
 				$disallowedSuperglobals[$disallowedSuperglobal->getVariable()] = $disallowedSuperglobal;
 			}

--- a/src/DisallowedVariable.php
+++ b/src/DisallowedVariable.php
@@ -15,7 +15,7 @@ class DisallowedVariable
 	/** @var string[] */
 	private $allowIn;
 
-	/** @var string */
+	/** @var string|null */
 	private $errorIdentifier;
 
 
@@ -23,9 +23,9 @@ class DisallowedVariable
 	 * @param string $variable
 	 * @param string|null $message
 	 * @param string[] $allowIn
-	 * @param string $errorIdentifier
+	 * @param string|null $errorIdentifier
 	 */
-	public function __construct(string $variable, ?string $message, array $allowIn, string $errorIdentifier)
+	public function __construct(string $variable, ?string $message, array $allowIn, ?string $errorIdentifier)
 	{
 		$this->variable = $variable;
 		$this->message = $message;
@@ -55,7 +55,7 @@ class DisallowedVariable
 	}
 
 
-	public function getErrorIdentifier(): string
+	public function getErrorIdentifier(): ?string
 	{
 		return $this->errorIdentifier;
 	}

--- a/src/DisallowedVariableHelper.php
+++ b/src/DisallowedVariableHelper.php
@@ -41,14 +41,16 @@ class DisallowedVariableHelper
 	{
 		foreach ($disallowedVariables as $disallowedVariable) {
 			if ($disallowedVariable->getVariable() === $variable && !$this->isAllowedPath($scope, $disallowedVariable)) {
+				$errorBuilder = RuleErrorBuilder::message(sprintf(
+					'Using %s is forbidden, %s',
+					$disallowedVariable->getVariable(),
+					$disallowedVariable->getMessage()
+				));
+				if ($disallowedVariable->getErrorIdentifier()) {
+					$errorBuilder->identifier($disallowedVariable->getErrorIdentifier());
+				}
 				return [
-					RuleErrorBuilder::message(sprintf(
-						'Using %s is forbidden, %s',
-						$disallowedVariable->getVariable(),
-						$disallowedVariable->getMessage()
-					))
-						->identifier($disallowedVariable->getErrorIdentifier())
-						->build(),
+					$errorBuilder->build(),
 				];
 			}
 		}


### PR DESCRIPTION
Follow-up to #97, an internal only thing