### PR TITLE
Params can be specified as an array now

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ The function or method names support [fnmatch()](https://www.php.net/function.fn
 
 ### Allow with specified parameters only
 
-You can also narrow down the allowed items when called with some parameters (doesn't apply to constants for obvious reasons). For example, you want to disallow calling `print_r()` but want to allow `print_r(..., true)`.
+You can also narrow down the allowed items when called with some parameters (applies only to disallowed method, static & function calls, for obvious reasons). For example, you want to disallow calling `print_r()` but want to allow `print_r(..., true)`.
 This can be done with optional `allowParamsInAllowed` or `allowParamsAnywhere` configuration keys:
 
 ```neon

--- a/extension.neon
+++ b/extension.neon
@@ -36,6 +36,7 @@ parametersSchema:
 				string(),
 				listOf(string()),
 				arrayOf(anyOf(int(), string(), bool()))
+				listOf(arrayOf(anyOf(int(), string(), bool())))
 			)
 		)
 	)
@@ -45,6 +46,7 @@ parametersSchema:
 				string(),
 				listOf(string()),
 				arrayOf(anyOf(int(), string(), bool()))
+				listOf(arrayOf(anyOf(int(), string(), bool())))
 			)
 		)
 	)
@@ -54,6 +56,7 @@ parametersSchema:
 				string(),
 				listOf(string()),
 				arrayOf(anyOf(int(), string(), bool()))
+				listOf(arrayOf(anyOf(int(), string(), bool())))
 			)
 		)
 	)


### PR DESCRIPTION
Starting with [2.11.0](https://github.com/spaze/phpstan-disallowed-calls/releases/tag/v2.11.0) when the named params support was introduced in #141.

Close #153