### PR TITLE
Drop redundant Value in param classes

### DIFF
--- a/src/DisallowedCallFactory.php
+++ b/src/DisallowedCallFactory.php
@@ -5,12 +5,12 @@ namespace Spaze\PHPStan\Rules\Disallowed;
 
 use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\Params\DisallowedCallParamValue;
-use Spaze\PHPStan\Rules\Disallowed\Params\DisallowedCallParamValueValueAny;
-use Spaze\PHPStan\Rules\Disallowed\Params\DisallowedCallParamValueValueCaseInsensitiveExcept;
-use Spaze\PHPStan\Rules\Disallowed\Params\DisallowedCallParamValueValueExcept;
-use Spaze\PHPStan\Rules\Disallowed\Params\DisallowedCallParamValueValueFlagExcept;
-use Spaze\PHPStan\Rules\Disallowed\Params\DisallowedCallParamValueValueFlagSpecific;
-use Spaze\PHPStan\Rules\Disallowed\Params\DisallowedCallParamValueValueSpecific;
+use Spaze\PHPStan\Rules\Disallowed\Params\DisallowedCallParamValueAny;
+use Spaze\PHPStan\Rules\Disallowed\Params\DisallowedCallParamValueCaseInsensitiveExcept;
+use Spaze\PHPStan\Rules\Disallowed\Params\DisallowedCallParamValueExcept;
+use Spaze\PHPStan\Rules\Disallowed\Params\DisallowedCallParamValueFlagExcept;
+use Spaze\PHPStan\Rules\Disallowed\Params\DisallowedCallParamValueFlagSpecific;
+use Spaze\PHPStan\Rules\Disallowed\Params\DisallowedCallParamValueSpecific;
 
 class DisallowedCallFactory
 {
@@ -40,37 +40,37 @@ class DisallowedCallFactory
 					$allowExceptInCalls[] = $this->normalizeCall($disallowedCall);
 				}
 				foreach ($disallowed['allowParamsInAllowed'] ?? [] as $param => $value) {
-					$allowParamsInAllowed[$param] = $this->paramFactory(DisallowedCallParamValueValueSpecific::class, $param, $value);
+					$allowParamsInAllowed[$param] = $this->paramFactory(DisallowedCallParamValueSpecific::class, $param, $value);
 				}
 				foreach ($disallowed['allowParamsInAllowedAnyValue'] ?? [] as $param => $value) {
-					$allowParamsInAllowed[$param] = $this->paramFactory(DisallowedCallParamValueValueAny::class, $param, $value);
+					$allowParamsInAllowed[$param] = $this->paramFactory(DisallowedCallParamValueAny::class, $param, $value);
 				}
 				foreach ($disallowed['allowParamFlagsInAllowed'] ?? [] as $param => $value) {
-					$allowParamsInAllowed[$param] = $this->paramFactory(DisallowedCallParamValueValueFlagSpecific::class, $param, $value);
+					$allowParamsInAllowed[$param] = $this->paramFactory(DisallowedCallParamValueFlagSpecific::class, $param, $value);
 				}
 				foreach ($disallowed['allowParamsAnywhere'] ?? [] as $param => $value) {
-					$allowParamsAnywhere[$param] = $this->paramFactory(DisallowedCallParamValueValueSpecific::class, $param, $value);
+					$allowParamsAnywhere[$param] = $this->paramFactory(DisallowedCallParamValueSpecific::class, $param, $value);
 				}
 				foreach ($disallowed['allowParamsAnywhereAnyValue'] ?? [] as $param => $value) {
-					$allowParamsAnywhere[$param] = $this->paramFactory(DisallowedCallParamValueValueAny::class, $param, $value);
+					$allowParamsAnywhere[$param] = $this->paramFactory(DisallowedCallParamValueAny::class, $param, $value);
 				}
 				foreach ($disallowed['allowParamFlagsAnywhere'] ?? [] as $param => $value) {
-					$allowParamsAnywhere[$param] = $this->paramFactory(DisallowedCallParamValueValueFlagSpecific::class, $param, $value);
+					$allowParamsAnywhere[$param] = $this->paramFactory(DisallowedCallParamValueFlagSpecific::class, $param, $value);
 				}
 				foreach ($disallowed['allowExceptParamsInAllowed'] ?? $disallowed['disallowParamsInAllowed'] ?? [] as $param => $value) {
-					$allowExceptParamsInAllowed[$param] = $this->paramFactory(DisallowedCallParamValueValueExcept::class, $param, $value);
+					$allowExceptParamsInAllowed[$param] = $this->paramFactory(DisallowedCallParamValueExcept::class, $param, $value);
 				}
 				foreach ($disallowed['allowExceptParamFlagsInAllowed'] ?? $disallowed['disallowParamFlagsInAllowed'] ?? [] as $param => $value) {
-					$allowExceptParamsInAllowed[$param] = $this->paramFactory(DisallowedCallParamValueValueFlagExcept::class, $param, $value);
+					$allowExceptParamsInAllowed[$param] = $this->paramFactory(DisallowedCallParamValueFlagExcept::class, $param, $value);
 				}
 				foreach ($disallowed['allowExceptParams'] ?? $disallowed['disallowParams'] ?? [] as $param => $value) {
-					$allowExceptParams[$param] = $this->paramFactory(DisallowedCallParamValueValueExcept::class, $param, $value);
+					$allowExceptParams[$param] = $this->paramFactory(DisallowedCallParamValueExcept::class, $param, $value);
 				}
 				foreach ($disallowed['allowExceptParamFlags'] ?? $disallowed['disallowParamFlags'] ?? [] as $param => $value) {
-					$allowExceptParams[$param] = $this->paramFactory(DisallowedCallParamValueValueFlagExcept::class, $param, $value);
+					$allowExceptParams[$param] = $this->paramFactory(DisallowedCallParamValueFlagExcept::class, $param, $value);
 				}
 				foreach ($disallowed['allowExceptCaseInsensitiveParams'] ?? $disallowed['disallowCaseInsensitiveParams'] ?? [] as $param => $value) {
-					$allowExceptParams[$param] = $this->paramFactory(DisallowedCallParamValueValueCaseInsensitiveExcept::class, $param, $value);
+					$allowExceptParams[$param] = $this->paramFactory(DisallowedCallParamValueCaseInsensitiveExcept::class, $param, $value);
 				}
 				$disallowedCall = new DisallowedCall(
 					$this->normalizeCall($call),
@@ -114,7 +114,7 @@ class DisallowedCallFactory
 				$paramPosition = $value['position'];
 				$paramName = $value['name'] ?? null;
 				$paramValue = $value['value'] ?? null;
-			} elseif ($class === DisallowedCallParamValueValueAny::class) {
+			} elseif ($class === DisallowedCallParamValueAny::class) {
 				if (is_numeric($value)) {
 					$paramPosition = $value;
 					$paramName = null;

--- a/src/Params/DisallowedCallParamValueAny.php
+++ b/src/Params/DisallowedCallParamValueAny.php
@@ -8,7 +8,7 @@ use PHPStan\Type\ConstantScalarType;
 /**
  * @extends DisallowedCallParamValue<int|bool|string|null>
  */
-final class DisallowedCallParamValueValueAny extends DisallowedCallParamValue
+final class DisallowedCallParamValueAny extends DisallowedCallParamValue
 {
 
 	public function matches(ConstantScalarType $type): bool

--- a/src/Params/DisallowedCallParamValueCaseInsensitiveExcept.php
+++ b/src/Params/DisallowedCallParamValueCaseInsensitiveExcept.php
@@ -9,7 +9,7 @@ use PHPStan\Type\ConstantScalarType;
 /**
  * @extends DisallowedCallParamValue<int|bool|string|null>
  */
-class DisallowedCallParamValueValueCaseInsensitiveExcept extends DisallowedCallParamValue
+class DisallowedCallParamValueCaseInsensitiveExcept extends DisallowedCallParamValue
 {
 
 	public function matches(ConstantScalarType $type): bool

--- a/src/Params/DisallowedCallParamValueExcept.php
+++ b/src/Params/DisallowedCallParamValueExcept.php
@@ -8,7 +8,7 @@ use PHPStan\Type\ConstantScalarType;
 /**
  * @extends DisallowedCallParamValue<int|bool|string|null>
  */
-class DisallowedCallParamValueValueExcept extends DisallowedCallParamValue
+class DisallowedCallParamValueExcept extends DisallowedCallParamValue
 {
 
 	public function matches(ConstantScalarType $type): bool

--- a/src/Params/DisallowedCallParamValueFlagExcept.php
+++ b/src/Params/DisallowedCallParamValueFlagExcept.php
@@ -9,7 +9,7 @@ use PHPStan\Type\ConstantScalarType;
 /**
  * @extends DisallowedCallParamValue<int>
  */
-class DisallowedCallParamValueValueFlagSpecific extends DisallowedCallParamValue
+class DisallowedCallParamValueFlagExcept extends DisallowedCallParamValue
 {
 
 	public function matches(ConstantScalarType $type): bool
@@ -17,7 +17,7 @@ class DisallowedCallParamValueValueFlagSpecific extends DisallowedCallParamValue
 		if (!$type instanceof ConstantIntegerType) {
 			return false;
 		}
-		return ($this->getValue() & $type->getValue()) !== 0;
+		return ($this->getValue() & $type->getValue()) === 0;
 	}
 
 }

--- a/src/Params/DisallowedCallParamValueFlagSpecific.php
+++ b/src/Params/DisallowedCallParamValueFlagSpecific.php
@@ -9,7 +9,7 @@ use PHPStan\Type\ConstantScalarType;
 /**
  * @extends DisallowedCallParamValue<int>
  */
-class DisallowedCallParamValueValueFlagExcept extends DisallowedCallParamValue
+class DisallowedCallParamValueFlagSpecific extends DisallowedCallParamValue
 {
 
 	public function matches(ConstantScalarType $type): bool
@@ -17,7 +17,7 @@ class DisallowedCallParamValueValueFlagExcept extends DisallowedCallParamValue
 		if (!$type instanceof ConstantIntegerType) {
 			return false;
 		}
-		return ($this->getValue() & $type->getValue()) === 0;
+		return ($this->getValue() & $type->getValue()) !== 0;
 	}
 
 }

--- a/src/Params/DisallowedCallParamValueSpecific.php
+++ b/src/Params/DisallowedCallParamValueSpecific.php
@@ -8,7 +8,7 @@ use PHPStan\Type\ConstantScalarType;
 /**
  * @extends DisallowedCallParamValue<int|bool|string|null>
  */
-class DisallowedCallParamValueValueSpecific extends DisallowedCallParamValue
+class DisallowedCallParamValueSpecific extends DisallowedCallParamValue
 {
 
 	public function matches(ConstantScalarType $type): bool


### PR DESCRIPTION
This seems to be introduced by recently renaming DisallowedCallParam to DisallowedCallParamValue and it got propagated sneakily.