### PR TITLE
Extra test to ensure `FQCN::class` is disallowed properly

### DIFF
--- a/tests/Calls/FunctionCallsTest.php
+++ b/tests/Calls/FunctionCallsTest.php
@@ -9,6 +9,7 @@ use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedHelper;
 use Spaze\PHPStan\Rules\Disallowed\IsAllowedFileHelper;
+use Waldo\Quux\Blade;
 
 class FunctionCallsTest extends RuleTestCase
 {
@@ -171,6 +172,17 @@ class FunctionCallsTest extends RuleTestCase
 						2,
 					],
 				],
+				[
+					'function' => 'mocky()',
+					'message' => 'mocking Blade is not allowed.',
+					'allowIn' => [
+						'../src/disallowed-allowed/*.php',
+						'../src/*-allow/*.*',
+					],
+					'disallowParams' => [
+						1 => Blade::class,
+					],
+				],
 			]
 		);
 	}
@@ -266,6 +278,10 @@ class FunctionCallsTest extends RuleTestCase
 			[
 				'Calling array_filter() is forbidden, callback parameter must be given.',
 				74,
+			],
+			[
+				'Calling mocky() is forbidden, mocking Blade is not allowed.',
+				81,
 			],
 		]);
 		// Based on the configuration above, no errors in this file:

--- a/tests/libs/Functions.php
+++ b/tests/libs/Functions.php
@@ -34,3 +34,7 @@ function baz(string $name = '', string $value = '', int $expires = 0, string $pa
 function waldo(string $name = '', string $value = '', int $expires = 0, string $path = ''): bool
 {
 }
+
+function mocky(string $className): void
+{
+}

--- a/tests/src/disallowed-allow/functionCalls.php
+++ b/tests/src/disallowed-allow/functionCalls.php
@@ -75,3 +75,7 @@ array_filter(['1', '2']);
 array_filter(['1', '2'], function () {
 	return true;
 });
+
+// allowed when not FQCN to Blade class
+mocky(\Fiction\Pulp\Royale::class);
+mocky(\Waldo\Quux\Blade::class);

--- a/tests/src/disallowed/functionCalls.php
+++ b/tests/src/disallowed/functionCalls.php
@@ -75,3 +75,7 @@ array_filter(['1', '2']);
 array_filter(['1', '2'], function () {
 	return true;
 });
+
+// allowed when not FQCN to Blade class
+mocky(\Fiction\Pulp\Royale::class);
+mocky(\Waldo\Quux\Blade::class);


### PR DESCRIPTION
Not sure why I [thought](https://github.com/spaze/phpstan-disallowed-calls/pull/159#issuecomment-1374415195) that before this wasn't working (it was) but good to add the extra tests anyway 😊 