### PR TITLE
Test calling and disallowing a function when its `disallowedParam` is `array|string|null`

### DIFF
--- a/tests/Calls/FunctionCallsTest.php
+++ b/tests/Calls/FunctionCallsTest.php
@@ -187,6 +187,16 @@ class FunctionCallsTest extends RuleTestCase
 						1 => Blade::class,
 					],
 				],
+				[
+					'function' => '\Foo\Bar\Waldo\config()',
+					'allowIn' => [
+						'../src/disallowed-allow/*.php',
+						'../src/*-allow/*.*',
+					],
+					'disallowParams' => [
+						1 => 'string-key',
+					],
+				],
 			]
 		);
 	}
@@ -286,6 +296,10 @@ class FunctionCallsTest extends RuleTestCase
 			[
 				'Calling Foo\Bar\Waldo\mocky() is forbidden, mocking Blade is not allowed.',
 				83,
+			],
+			[
+				'Calling Foo\Bar\Waldo\config() is forbidden, because reasons',
+				91,
 			],
 		]);
 		// Based on the configuration above, no errors in this file:

--- a/tests/libs/Functions.php
+++ b/tests/libs/Functions.php
@@ -39,3 +39,11 @@ function waldo(string $name = '', string $value = '', int $expires = 0, string $
 function mocky(string $className): void
 {
 }
+
+
+/**
+ * @param array|string|null $key
+ */
+function config($key = null)
+{
+}

--- a/tests/src/disallowed-allow/functionCalls.php
+++ b/tests/src/disallowed-allow/functionCalls.php
@@ -84,3 +84,8 @@ mocky(\Waldo\Quux\Blade::class);
 
 // not disallowed
 hash((new stdClass())->property . 'foo', 'NAH');
+
+// not disallowed param
+\Foo\Bar\Waldo\config(['key' => 'string']);
+// allowed by path
+\Foo\Bar\Waldo\config('string-key');

--- a/tests/src/disallowed/functionCalls.php
+++ b/tests/src/disallowed/functionCalls.php
@@ -84,3 +84,8 @@ array_filter(['1', '2'], function () {
 
 // not disallowed
 hash((new stdClass())->property . 'foo', 'NAH');
+
+// not disallowed param
+\Foo\Bar\Waldo\config(['key' => 'string']);
+// disallowed param
+\Foo\Bar\Waldo\config('string-key');


### PR DESCRIPTION
When trying to disallow the usage of a particular configuration key in Laravel, this false positive was discovered.

the Laravel `config()` helper can take a string or array as it's first argument, strings are used to read and arrays are used to update the configuration.

when a `disallowParams` was set to disallow the use of a constant string as the first argument, calls that provided an array were falsey flagged as disallowed.

this rectifies that issue, however i'm not convinced this is the best way to go about this due to unfamiliarity with this codebase, but it resolves the cases i had to hand, so feel free to let me know if there's a better way

thanks for your time