### PR TITLE
Disable backslash escaping in "is allowed" helper

### DIFF
--- a/src/IsAllowedFileHelper.php
+++ b/src/IsAllowedFileHelper.php
@@ -45,7 +45,7 @@ class IsAllowedFileHelper
 	public function matches(Scope $scope, string $allowedPath): bool
 	{
 		$file = $scope->getTraitReflection() ? $scope->getTraitReflection()->getFileName() : $scope->getFile();
-		return $file !== null && fnmatch($this->absolutizePath($allowedPath), $file);
+		return $file !== null && fnmatch($this->absolutizePath($allowedPath), $file, FNM_NOESCAPE);
 	}
 
 


### PR DESCRIPTION
`allowIn` will fail to match files on Windows without the `FNM_NOESCAPE` flag