### PR TITLE
Use the same types in phpdoc as what the method signature says

### DIFF
--- a/src/Usages/ClassConstantUsages.php
+++ b/src/Usages/ClassConstantUsages.php
@@ -64,7 +64,7 @@ class ClassConstantUsages implements Rule
 
 
 	/**
-	 * @param ClassConstFetch $node
+	 * @param Node $node
 	 * @param Scope $scope
 	 * @return RuleError[]
 	 * @throws ShouldNotHappenException

--- a/src/Usages/VariableUsages.php
+++ b/src/Usages/VariableUsages.php
@@ -46,7 +46,7 @@ class VariableUsages implements Rule
 
 
 	/**
-	 * @param Variable $node
+	 * @param Node $node
 	 * @param Scope $scope
 	 * @return RuleError[]
 	 * @throws ShouldNotHappenException


### PR DESCRIPTION
Resolves

```
 ------ --------------------------------------------------------------------------------------------------------------------------------------------
  Line   Usages/ClassConstantUsages.php
 ------ --------------------------------------------------------------------------------------------------------------------------------------------
  73     Instanceof between PhpParser\Node\Expr\ClassConstFetch and PhpParser\Node\Expr\ClassConstFetch will always evaluate to true.
         💡 Because the type is coming from a PHPDoc, you can turn off this check by setting treatPhpDocTypesAsCertain: false in your phpstan.neon.
 ------ --------------------------------------------------------------------------------------------------------------------------------------------

 ------ --------------------------------------------------------------------------------------------------------------------------------------------
  Line   Usages/VariableUsages.php
 ------ --------------------------------------------------------------------------------------------------------------------------------------------
  56     Instanceof between PhpParser\Node\Expr\Variable and PhpParser\Node\Expr\Variable will always evaluate to true.
         💡 Because the type is coming from a PHPDoc, you can turn off this check by setting treatPhpDocTypesAsCertain: false in your phpstan.neon.
 ------ --------------------------------------------------------------------------------------------------------------------------------------------
```