### PR TITLE
Support `$foo::BAR` where `$foo` is declared as `class-string<Foo>`

### DIFF
--- a/src/RuleErrors/DisallowedConstantRuleErrors.php
+++ b/src/RuleErrors/DisallowedConstantRuleErrors.php
@@ -39,7 +39,7 @@ class DisallowedConstantRuleErrors
 				$errorBuilder = RuleErrorBuilder::message(sprintf(
 					'Using %s%s is forbidden, %s',
 					$disallowedConstant->getConstant(),
-					$displayName && $displayName !== $disallowedConstant->getConstant() ? ' (as ' . $displayName . ')' : '',
+					$displayName && ltrim($displayName, '\\') !== $disallowedConstant->getConstant() ? ' (as ' . $displayName . ')' : '',
 					$disallowedConstant->getMessage()
 				));
 				if ($disallowedConstant->getErrorIdentifier()) {

--- a/tests/Usages/ClassConstantInvalidUsagesTest.php
+++ b/tests/Usages/ClassConstantInvalidUsagesTest.php
@@ -50,8 +50,8 @@ class ClassConstantInvalidUsagesTest extends RuleTestCase
 				14,
 			],
 			[
-				'Cannot access constant UTC on class-string<DateTimeZone>',
-				18,
+				'Cannot access constant FTC on class-string<DateTimeZone>',
+				24,
 			],
 		]);
 	}

--- a/tests/src/invalid/constantUsages.php
+++ b/tests/src/invalid/constantUsages.php
@@ -13,6 +13,12 @@ $monster::COOKIE;
 $monster = DateTime::class;
 $monster::COOKIE;
 
+// a valid type, for a change
 /** @var class-string<DateTimeZone> $tz */
 $tz = DateTimeZone::class;
 $tz::UTC;
+
+// this constant doesn't exist
+/** @var class-string<DateTimeZone> $tz */
+$tz = DateTimeZone::class;
+$tz::FTC;


### PR DESCRIPTION
This PR will:
- update ClassConstantUsages rule to not fail when accessing constant on class-string that can be resolved to appropriate class

Fixes #44 (partly, not the general `class-string` case)