### PR TITLE
Don't throw "Cannot access constant FOO on mixed"

### DIFF
--- a/src/Usages/ClassConstantUsages.php
+++ b/src/Usages/ClassConstantUsages.php
@@ -102,7 +102,7 @@ class ClassConstantUsages implements Rule
 		} else {
 			if ($usedOnType->hasConstant($constant)->yes()) {
 				$classNames = [$usedOnType->getConstant($constant)->getDeclaringClass()->getDisplayName()];
-			} else {
+			} elseif ($type->hasConstant($constant)->no()) {
 				return [
 					RuleErrorBuilder::message(sprintf(
 						'Cannot access constant %s on %s',
@@ -110,6 +110,8 @@ class ClassConstantUsages implements Rule
 						$type->describe(VerbosityLevel::getRecommendedLevelByType($type))
 					))->build(),
 				];
+			} else {
+				return [];
 			}
 		}
 		return $this->disallowedConstantRuleErrors->get($this->getFullyQualified($classNames, $constant), $scope, $displayName, $this->disallowedConstants);

--- a/tests/src/invalid/constantUsages.php
+++ b/tests/src/invalid/constantUsages.php
@@ -22,3 +22,6 @@ $tz::UTC;
 /** @var class-string<DateTimeZone> $tz */
 $tz = DateTimeZone::class;
 $tz::FTC;
+
+/** @var mixed $tz */
+$tz::ALL;


### PR DESCRIPTION
Mixed type object may have the constant but we're not sure, only throw the error when we're damn sure. This regression has been introduced in #186