### PR TITLE
`disallowedAttributes` (named) params can also be an array

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -85,6 +85,7 @@ parametersSchema:
 				string(),
 				listOf(string()),
 				arrayOf(anyOf(int(), string(), bool())),
+				listOf(arrayOf(anyOf(int(), string(), bool()))),
 			)
 		)
 	)


### PR DESCRIPTION
Otherwise it won't accept:
```php
'disallowedAttributes' => [
            [
                'attribute' => Doctrine\ORM\Mapping\Entity::class,
                'message' => 'every entity requires a repository class.',
                'allowParamsAnywhereAnyValue' => [
                    [
                        'position' => 1,
                        'name' => 'repositoryClass',
                    ],
                ],
            ],
        ],
```

```
Invalid configuration:
The item 'parameters › disallowedAttributes › 0 › allowParamsAnywhereAnyValue › 0' expects to be string, array given.
Invalid configuration:
The item 'parameters › disallowedAttributes › 0 › allowParamsAnywhereAnyValue › 0' expects to be int|string|bool, array given.
```