### PR TITLE
Lint `extension.neon` (and all `.neon` files, if any)

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -64,6 +64,34 @@ jobs:
     - name: Run tests
       run: ${{ matrix.run }}
 
+  lint-neon:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        php-version:
+          - "8.2"
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: "Install PHP"
+        uses: shivammathur/setup-php@v2
+        with:
+          coverage: "none"
+          php-version: "${{ matrix.php-version }}"
+
+      - name: PHP info
+        run: |
+          php -v
+          php -m
+
+      - name: Install dependencies
+        run: composer update --no-progress --no-interaction
+
+      - name: Run tests
+        run: composer lint-neon
+
   phpunit:
     runs-on: ${{ matrix.operating-system }}
 

--- a/composer.json
+++ b/composer.json
@@ -39,12 +39,14 @@
 		"lint": "vendor/bin/parallel-lint --colors src/ tests/",
 		"lint-7.x": "vendor/bin/parallel-lint --colors src/ tests/ --exclude tests/libs/TypesEverywhere.php --exclude tests/src/disallowed/functionCallsNamedParams.php --exclude tests/src/disallowed-allow/functionCallsNamedParams.php --exclude tests/src/disallowed/attributeUsages.php --exclude tests/src/disallowed-allow/attributeUsages.php",
 		"lint-8.0": "vendor/bin/parallel-lint --colors src/ tests/ --exclude tests/libs/TypesEverywhere.php",
+		"lint-neon": "vendor/bin/neon-lint .",
 		"phpcs": "vendor/bin/phpcs src/ tests/",
 		"cs-fix": "vendor/bin/phpcbf src/ tests/",
 		"phpstan": "vendor/bin/phpstan --ansi analyse --configuration phpstan.neon",
 		"phpunit": "vendor/bin/phpunit --colors=always",
 		"test": [
 			"@lint",
+			"@lint-neon",
 			"@phpcs",
 			"@phpstan",
 			"@phpunit"

--- a/extension.neon
+++ b/extension.neon
@@ -18,7 +18,7 @@ parametersSchema:
 			anyOf(
 				string(),
 				listOf(string()),
-				arrayOf(anyOf(int(), string(), bool()))
+				arrayOf(anyOf(int(), string(), bool())),
 			)
 		)
 	)
@@ -27,7 +27,7 @@ parametersSchema:
 			anyOf(
 				string(),
 				listOf(string()),
-				arrayOf(anyOf(int(), string(), bool()))
+				arrayOf(anyOf(int(), string(), bool())),
 			)
 		)
 	)
@@ -36,8 +36,8 @@ parametersSchema:
 			anyOf(
 				string(),
 				listOf(string()),
-				arrayOf(anyOf(int(), string(), bool()))
-				listOf(arrayOf(anyOf(int(), string(), bool())))
+				arrayOf(anyOf(int(), string(), bool())),
+				listOf(arrayOf(anyOf(int(), string(), bool()))),
 			)
 		)
 	)
@@ -46,8 +46,8 @@ parametersSchema:
 			anyOf(
 				string(),
 				listOf(string()),
-				arrayOf(anyOf(int(), string(), bool()))
-				listOf(arrayOf(anyOf(int(), string(), bool())))
+				arrayOf(anyOf(int(), string(), bool())),
+				listOf(arrayOf(anyOf(int(), string(), bool()))),
 			)
 		)
 	)
@@ -56,8 +56,8 @@ parametersSchema:
 			anyOf(
 				string(),
 				listOf(string()),
-				arrayOf(anyOf(int(), string(), bool()))
-				listOf(arrayOf(anyOf(int(), string(), bool())))
+				arrayOf(anyOf(int(), string(), bool())),
+				listOf(arrayOf(anyOf(int(), string(), bool()))),
 			)
 		)
 	)
@@ -66,7 +66,7 @@ parametersSchema:
 			anyOf(
 				string(),
 				listOf(string()),
-				arrayOf(anyOf(int(), string(), bool()))
+				arrayOf(anyOf(int(), string(), bool())),
 			)
 		)
 	)
@@ -75,7 +75,7 @@ parametersSchema:
 			anyOf(
 				string(),
 				listOf(string()),
-				arrayOf(anyOf(int(), string(), bool()))
+				arrayOf(anyOf(int(), string(), bool())),
 			)
 		)
 	)
@@ -84,7 +84,7 @@ parametersSchema:
 			anyOf(
 				string(),
 				listOf(string()),
-				arrayOf(anyOf(int(), string(), bool()))
+				arrayOf(anyOf(int(), string(), bool())),
 			)
 		)
 	)


### PR DESCRIPTION
The linter will not find issues with the file like wrong Neon entities (`arrrrrr-ayOf`, instead of `arrayOf` etc.) or missing `listOf` line (like in #190) but at least something.

Also adding trailing comma to param declarations, it also works without it but it's confusing.