### PR TITLE
Require symfony/polyfill-php80 for dev/tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
 		"phpunit/phpunit": "^8.5 || ^10.1",
 		"php-parallel-lint/php-parallel-lint": "^1.2",
 		"php-parallel-lint/php-console-highlighter": "^1.0",
-		"spaze/coding-standard": "^1.6"
+		"spaze/coding-standard": "^1.6",
+		"symfony/polyfill-php80": "^1.27"
 	},
 	"autoload": {
 		"psr-4": {"Spaze\\PHPStan\\Rules\\Disallowed\\": "src"}

--- a/tests/Allowed/AllowedPathTest.php
+++ b/tests/Allowed/AllowedPathTest.php
@@ -13,10 +13,6 @@ use PHPStan\Testing\PHPStanTestCase;
 use Traits\TestClass;
 use Traits\TestTrait;
 
-/**
- * @requires function str_starts_with
- * ... for now because https://github.com/phpstan/phpstan/issues/9300
- */
 class AllowedPathTest extends PHPStanTestCase
 {
 


### PR DESCRIPTION
Better than to have `@requires function str_starts_with` in each test that would need it because the number of tests will grow and you can't tell if the test needs str_starts_with() until you run the test on a PHP version without the function.

This way it's more general and slightly more visible maybe.

See https://github.com/phpstan/phpstan/issues/9300