### PR TITLE
Can exclude some attributes, calls, namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,18 @@ parameters:
 ```
 The wildcard makes most sense when used as the rightmost character of the function or method name, optionally followed by `()`, but you can use it anywhere for example to disallow all functions that end with `y`: `function: '*y()'`. The matching is powered by [`fnmatch`](https://www.php.net/function.fnmatch) so you can use even multiple wildcards if you wish because w\*y n\*t.
 
+If there's this one function, method, namespace, attribute (or multiple of them) that you'd like to exclude from the set, you can do that with `exclude`:
+```neon
+parameters:
+    disallowedFunctionCalls:
+        -
+            function: 'pcntl_*()'
+            exclude:
+                - 'pcntl_foobar()'
+```
+This config would disallow all `pcntl` functions except (an imaginary) `pcntl_foobar()`.
+Please note `exclude` also accepts [`fnmatch`](https://www.php.net/function.fnmatch) patterns so please be careful to not create a contradicting config.
+
 You can treat some language constructs as functions and disallow it in `disallowedFunctionCalls`. Currently detected language constructs are:
 - `die()`
 - `echo()`

--- a/extension.neon
+++ b/extension.neon
@@ -99,6 +99,7 @@ services:
 	- Spaze\PHPStan\Rules\Disallowed\DisallowedNamespaceFactory
 	- Spaze\PHPStan\Rules\Disallowed\DisallowedSuperglobalFactory
 	- Spaze\PHPStan\Rules\Disallowed\Formatter\Formatter
+	- Spaze\PHPStan\Rules\Disallowed\Identifier\Identifier
 	- Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer
 	- Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedAttributeRuleErrors
 	- Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedConstantRuleErrors

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,8 +7,8 @@ parameters:
 		CallParamAnyValueConfig: 'array<int|string, int|array{position:int, value?:int|bool|string, name?:string}>'
 		CallParamFlagAnyValueConfig: 'array<int|string, int|array{position:int, value?:int, name?:string}>'
 		AllowDirectives: 'allowIn?:string[], allowExceptIn?:string[], disallowIn?:string[], allowInFunctions?:string[], allowInMethods?:string[], allowExceptInFunctions?:string[], allowExceptInMethods?:string[], disallowInFunctions?:string[], disallowInMethods?:string[], allowParamsInAllowed?:CallParamConfig, allowParamsInAllowedAnyValue?:CallParamAnyValueConfig, allowParamFlagsInAllowed?:CallParamFlagAnyValueConfig, allowParamsAnywhere?:CallParamConfig, allowParamsAnywhereAnyValue?:CallParamAnyValueConfig, allowParamFlagsAnywhere?:CallParamFlagAnyValueConfig, allowExceptParamsInAllowed?:CallParamConfig, allowExceptParamFlagsInAllowed?:CallParamFlagAnyValueConfig, disallowParamFlagsInAllowed?:CallParamFlagAnyValueConfig, disallowParamsInAllowed?:CallParamConfig, allowExceptParams?:CallParamConfig, disallowParams?:CallParamConfig, allowExceptParamFlags?:CallParamFlagAnyValueConfig, disallowParamFlags?:CallParamFlagAnyValueConfig, allowExceptCaseInsensitiveParams?:CallParamConfig, disallowCaseInsensitiveParams?:CallParamConfig'
-		ForbiddenCallsConfig: 'array<array{function?:string|list<string>, method?:string|list<string>, message?:string, %typeAliases.AllowDirectives%, errorIdentifier?:string, errorTip?:string}>'
-		DisallowedAttributesConfig: 'array<array{attribute:string|list<string>, message?:string, %typeAliases.AllowDirectives%, errorIdentifier?:string, errorTip?:string}>'
+		ForbiddenCallsConfig: 'array<array{function?:string|list<string>, method?:string|list<string>, exclude?:list<string>, message?:string, %typeAliases.AllowDirectives%, errorIdentifier?:string, errorTip?:string}>'
+		DisallowedAttributesConfig: 'array<array{attribute:string|list<string>, exclude?:list<string>, message?:string, %typeAliases.AllowDirectives%, errorIdentifier?:string, errorTip?:string}>'
 		AllowDirectivesConfig: 'array{%typeAliases.AllowDirectives%}'
 
 includes:

--- a/src/DisallowedAttribute.php
+++ b/src/DisallowedAttribute.php
@@ -11,6 +11,9 @@ class DisallowedAttribute implements DisallowedWithParams
 	/** @var string */
 	private $attribute;
 
+	/** @var list<string> */
+	private $excludes;
+
 	/** @var string|null */
 	private $message;
 
@@ -26,6 +29,7 @@ class DisallowedAttribute implements DisallowedWithParams
 
 	/**
 	 * @param string $attribute
+	 * @param list<string> $excludes
 	 * @param string|null $message
 	 * @param AllowedConfig $allowedConfig
 	 * @param string|null $errorIdentifier
@@ -33,12 +37,14 @@ class DisallowedAttribute implements DisallowedWithParams
 	 */
 	public function __construct(
 		string $attribute,
+		array $excludes,
 		?string $message,
 		AllowedConfig $allowedConfig,
 		?string $errorIdentifier,
 		?string $errorTip
 	) {
 		$this->attribute = $attribute;
+		$this->excludes = $excludes;
 		$this->message = $message;
 		$this->allowedConfig = $allowedConfig;
 		$this->errorIdentifier = $errorIdentifier;
@@ -49,6 +55,15 @@ class DisallowedAttribute implements DisallowedWithParams
 	public function getAttribute(): string
 	{
 		return $this->attribute;
+	}
+
+
+	/**
+	 * @return list<string>
+	 */
+	public function getExcludes(): array
+	{
+		return $this->excludes;
 	}
 
 

--- a/src/DisallowedAttributeFactory.php
+++ b/src/DisallowedAttributeFactory.php
@@ -35,9 +35,14 @@ class DisallowedAttributeFactory
 		$disallowedAttributes = [];
 		foreach ($config as $disallowed) {
 			$attributes = $disallowed['attribute'];
+			$excludes = [];
+			foreach ($disallowed['exclude'] ?? [] as $exclude) {
+				$excludes[] = $this->normalizer->normalizeNamespace($exclude);
+			}
 			foreach ((array)$attributes as $attribute) {
 				$disallowedAttribute = new DisallowedAttribute(
 					$this->normalizer->normalizeNamespace($attribute),
+					$excludes,
 					$disallowed['message'] ?? null,
 					$this->allowed->getConfig($disallowed),
 					$disallowed['errorIdentifier'] ?? null,

--- a/src/DisallowedCall.php
+++ b/src/DisallowedCall.php
@@ -11,6 +11,9 @@ class DisallowedCall implements DisallowedWithParams
 	/** @var string */
 	private $call;
 
+	/** @var list<string> */
+	private $excludes;
+
 	/** @var string|null */
 	private $message;
 
@@ -26,6 +29,7 @@ class DisallowedCall implements DisallowedWithParams
 
 	/**
 	 * @param string $call
+	 * @param list<string> $excludes
 	 * @param string|null $message
 	 * @param AllowedConfig $allowedConfig
 	 * @param string|null $errorIdentifier
@@ -33,12 +37,14 @@ class DisallowedCall implements DisallowedWithParams
 	 */
 	public function __construct(
 		string $call,
+		array $excludes,
 		?string $message,
 		AllowedConfig $allowedConfig,
 		?string $errorIdentifier,
 		?string $errorTip
 	) {
 		$this->call = $call;
+		$this->excludes = $excludes;
 		$this->message = $message;
 		$this->allowedConfig = $allowedConfig;
 		$this->errorIdentifier = $errorIdentifier;
@@ -49,6 +55,15 @@ class DisallowedCall implements DisallowedWithParams
 	public function getCall(): string
 	{
 		return $this->call;
+	}
+
+
+	/**
+	 * @return list<string>
+	 */
+	public function getExcludes(): array
+	{
+		return $this->excludes;
 	}
 
 

--- a/src/DisallowedCallFactory.php
+++ b/src/DisallowedCallFactory.php
@@ -46,11 +46,16 @@ class DisallowedCallFactory
 			if (!$calls) {
 				throw new ShouldNotHappenException("Either 'method' or 'function' must be set in configuration items");
 			}
+			$excludes = [];
+			foreach ($disallowed['exclude'] ?? [] as $exclude) {
+				$excludes[] = $this->normalizer->normalizeCall($exclude);
+			}
 			$calls = (array)$calls;
 			try {
 				foreach ($calls as $call) {
 					$disallowedCall = new DisallowedCall(
 						$this->normalizer->normalizeCall($call),
+						$excludes,
 						$disallowed['message'] ?? null,
 						$this->allowed->getConfig($disallowed),
 						$disallowed['errorIdentifier'] ?? null,

--- a/src/DisallowedNamespace.php
+++ b/src/DisallowedNamespace.php
@@ -11,6 +11,9 @@ class DisallowedNamespace implements Disallowed
 	/** @var string */
 	private $namespace;
 
+	/** @var list<string> */
+	private $excludes;
+
 	/** @var string|null */
 	private $message;
 
@@ -29,6 +32,7 @@ class DisallowedNamespace implements Disallowed
 
 	/**
 	 * @param string $namespace
+	 * @param list<string> $excludes
 	 * @param string|null $message
 	 * @param string[] $allowIn
 	 * @param string[] $allowExceptIn
@@ -37,6 +41,7 @@ class DisallowedNamespace implements Disallowed
 	 */
 	public function __construct(
 		string $namespace,
+		array $excludes,
 		?string $message,
 		array $allowIn,
 		array $allowExceptIn,
@@ -44,6 +49,7 @@ class DisallowedNamespace implements Disallowed
 		?string $errorTip
 	) {
 		$this->namespace = $namespace;
+		$this->excludes = $excludes;
 		$this->message = $message;
 		$this->allowIn = $allowIn;
 		$this->allowExceptIn = $allowExceptIn;
@@ -55,6 +61,15 @@ class DisallowedNamespace implements Disallowed
 	public function getNamespace(): string
 	{
 		return $this->namespace;
+	}
+
+
+	/**
+	 * @return list<string>
+	 */
+	public function getExcludes(): array
+	{
+		return $this->excludes;
 	}
 
 

--- a/src/DisallowedNamespaceFactory.php
+++ b/src/DisallowedNamespaceFactory.php
@@ -20,7 +20,7 @@ class DisallowedNamespaceFactory
 
 
 	/**
-	 * @param array<array{namespace?:string, class?:string, message?:string, allowIn?:string[], allowExceptIn?:string[], disallowIn?:string[], errorIdentifier?:string, errorTip?:string}> $config
+	 * @param array<array{namespace?:string, class?:string, exclude?:list<string>, message?:string, allowIn?:string[], allowExceptIn?:string[], disallowIn?:string[], errorIdentifier?:string, errorTip?:string}> $config
 	 * @return DisallowedNamespace[]
 	 */
 	public function createFromConfig(array $config): array
@@ -32,9 +32,14 @@ class DisallowedNamespaceFactory
 			if (!$namespaces) {
 				throw new ShouldNotHappenException("Either 'namespace' or 'class' must be set in configuration items");
 			}
+			$excludes = [];
+			foreach ($disallowed['exclude'] ?? [] as $exclude) {
+				$excludes[] = $this->normalizer->normalizeNamespace($exclude);
+			}
 			foreach ((array)$namespaces as $namespace) {
 				$disallowedNamespace = new DisallowedNamespace(
 					$this->normalizer->normalizeNamespace($namespace),
+					$excludes,
 					$disallowed['message'] ?? null,
 					$disallowed['allowIn'] ?? [],
 					$disallowed['allowExceptIn'] ?? $disallowed['disallowIn'] ?? [],

--- a/src/Identifier/Identifier.php
+++ b/src/Identifier/Identifier.php
@@ -9,15 +9,23 @@ class Identifier
 	/**
 	 * @param string $pattern
 	 * @param string $value
+	 * @param list<string> $excludes
 	 * @return bool
 	 */
-	public function matches(string $pattern, string $value): bool
+	public function matches(string $pattern, string $value, array $excludes): bool
 	{
 		$matches = false;
 		if ($pattern === $value) {
 			$matches = true;
 		} elseif (fnmatch($pattern, $value, FNM_NOESCAPE | FNM_CASEFOLD)) {
 			$matches = true;
+		}
+		if ($matches) {
+			foreach ($excludes as $exclude) {
+				if (fnmatch($exclude, $value, FNM_NOESCAPE | FNM_CASEFOLD)) {
+					return false;
+				}
+			}
 		}
 		return $matches;
 	}

--- a/src/Identifier/Identifier.php
+++ b/src/Identifier/Identifier.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Rules\Disallowed\Identifier;
+
+class Identifier
+{
+
+	/**
+	 * @param string $pattern
+	 * @param string $value
+	 * @return bool
+	 */
+	public function matches(string $pattern, string $value): bool
+	{
+		$matches = false;
+		if ($pattern === $value) {
+			$matches = true;
+		} elseif (fnmatch($pattern, $value, FNM_NOESCAPE | FNM_CASEFOLD)) {
+			$matches = true;
+		}
+		return $matches;
+	}
+
+}

--- a/src/RuleErrors/DisallowedAttributeRuleErrors.php
+++ b/src/RuleErrors/DisallowedAttributeRuleErrors.php
@@ -9,6 +9,7 @@ use PHPStan\Rules\RuleError;
 use PHPStan\Rules\RuleErrorBuilder;
 use Spaze\PHPStan\Rules\Disallowed\Allowed\Allowed;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedAttribute;
+use Spaze\PHPStan\Rules\Disallowed\Identifier\Identifier;
 
 class DisallowedAttributeRuleErrors
 {
@@ -16,10 +17,14 @@ class DisallowedAttributeRuleErrors
 	/** @var Allowed */
 	private $allowed;
 
+	/** @var Identifier */
+	private $identifier;
 
-	public function __construct(Allowed $allowed)
+
+	public function __construct(Allowed $allowed, Identifier $identifier)
 	{
 		$this->allowed = $allowed;
+		$this->identifier = $identifier;
 	}
 
 
@@ -33,7 +38,7 @@ class DisallowedAttributeRuleErrors
 	{
 		foreach ($disallowedAttributes as $disallowedAttribute) {
 			$attributeName = $attribute->name->toString();
-			if (!$this->matchesAttribute($disallowedAttribute->getAttribute(), $attributeName)) {
+			if (!$this->identifier->matches($disallowedAttribute->getAttribute(), $attributeName)) {
 				continue;
 			}
 			if ($this->allowed->isAllowed($scope, $attribute->args, $disallowedAttribute)) {
@@ -58,20 +63,6 @@ class DisallowedAttributeRuleErrors
 		}
 
 		return [];
-	}
-
-
-	private function matchesAttribute(string $pattern, string $value): bool
-	{
-		if ($pattern === $value) {
-			return true;
-		}
-
-		if (fnmatch($pattern, $value, FNM_NOESCAPE | FNM_CASEFOLD)) {
-			return true;
-		}
-
-		return false;
 	}
 
 }

--- a/src/RuleErrors/DisallowedAttributeRuleErrors.php
+++ b/src/RuleErrors/DisallowedAttributeRuleErrors.php
@@ -38,7 +38,7 @@ class DisallowedAttributeRuleErrors
 	{
 		foreach ($disallowedAttributes as $disallowedAttribute) {
 			$attributeName = $attribute->name->toString();
-			if (!$this->identifier->matches($disallowedAttribute->getAttribute(), $attributeName)) {
+			if (!$this->identifier->matches($disallowedAttribute->getAttribute(), $attributeName, $disallowedAttribute->getExcludes())) {
 				continue;
 			}
 			if ($this->allowed->isAllowed($scope, $attribute->args, $disallowedAttribute)) {

--- a/src/RuleErrors/DisallowedCallsRuleErrors.php
+++ b/src/RuleErrors/DisallowedCallsRuleErrors.php
@@ -42,7 +42,7 @@ class DisallowedCallsRuleErrors
 	public function get(?CallLike $node, Scope $scope, string $name, ?string $displayName, array $disallowedCalls, ?string $message = null): array
 	{
 		foreach ($disallowedCalls as $disallowedCall) {
-			$callMatches = $this->identifier->matches($disallowedCall->getCall(), $name);
+			$callMatches = $this->identifier->matches($disallowedCall->getCall(), $name, $disallowedCall->getExcludes());
 			if ($callMatches && !$this->allowed->isAllowed($scope, isset($node) ? $node->getArgs() : null, $disallowedCall)) {
 				$errorBuilder = RuleErrorBuilder::message(sprintf(
 					$message ?? 'Calling %s is forbidden, %s%s',

--- a/src/RuleErrors/DisallowedCallsRuleErrors.php
+++ b/src/RuleErrors/DisallowedCallsRuleErrors.php
@@ -10,6 +10,7 @@ use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\Allowed\Allowed;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCall;
+use Spaze\PHPStan\Rules\Disallowed\Identifier\Identifier;
 
 class DisallowedCallsRuleErrors
 {
@@ -17,10 +18,14 @@ class DisallowedCallsRuleErrors
 	/** @var Allowed */
 	private $allowed;
 
+	/** @var Identifier */
+	private $identifier;
 
-	public function __construct(Allowed $allowed)
+
+	public function __construct(Allowed $allowed, Identifier $identifier)
 	{
 		$this->allowed = $allowed;
+		$this->identifier = $identifier;
 	}
 
 
@@ -37,7 +42,7 @@ class DisallowedCallsRuleErrors
 	public function get(?CallLike $node, Scope $scope, string $name, ?string $displayName, array $disallowedCalls, ?string $message = null): array
 	{
 		foreach ($disallowedCalls as $disallowedCall) {
-			$callMatches = $name === $disallowedCall->getCall() || fnmatch($disallowedCall->getCall(), $name, FNM_NOESCAPE | FNM_CASEFOLD);
+			$callMatches = $this->identifier->matches($disallowedCall->getCall(), $name);
 			if ($callMatches && !$this->allowed->isAllowed($scope, isset($node) ? $node->getArgs() : null, $disallowedCall)) {
 				$errorBuilder = RuleErrorBuilder::message(sprintf(
 					$message ?? 'Calling %s is forbidden, %s%s',

--- a/src/RuleErrors/DisallowedNamespaceRuleErrors.php
+++ b/src/RuleErrors/DisallowedNamespaceRuleErrors.php
@@ -41,7 +41,7 @@ class DisallowedNamespaceRuleErrors
 				continue;
 			}
 
-			if (!$this->identifier->matches($disallowedNamespace->getNamespace(), $namespace)) {
+			if (!$this->identifier->matches($disallowedNamespace->getNamespace(), $namespace, $disallowedNamespace->getExcludes())) {
 				continue;
 			}
 

--- a/src/RuleErrors/DisallowedNamespaceRuleErrors.php
+++ b/src/RuleErrors/DisallowedNamespaceRuleErrors.php
@@ -8,6 +8,7 @@ use PHPStan\Rules\RuleError;
 use PHPStan\Rules\RuleErrorBuilder;
 use Spaze\PHPStan\Rules\Disallowed\Allowed\AllowedPath;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedNamespace;
+use Spaze\PHPStan\Rules\Disallowed\Identifier\Identifier;
 
 class DisallowedNamespaceRuleErrors
 {
@@ -15,10 +16,14 @@ class DisallowedNamespaceRuleErrors
 	/** @var AllowedPath */
 	private $allowedPath;
 
+	/** @var Identifier */
+	private $identifier;
 
-	public function __construct(AllowedPath $allowedPath)
+
+	public function __construct(AllowedPath $allowedPath, Identifier $identifier)
 	{
 		$this->allowedPath = $allowedPath;
+		$this->identifier = $identifier;
 	}
 
 
@@ -36,7 +41,7 @@ class DisallowedNamespaceRuleErrors
 				continue;
 			}
 
-			if (!$this->matchesNamespace($disallowedNamespace->getNamespace(), $namespace)) {
+			if (!$this->identifier->matches($disallowedNamespace->getNamespace(), $namespace)) {
 				continue;
 			}
 
@@ -59,20 +64,6 @@ class DisallowedNamespaceRuleErrors
 		}
 
 		return [];
-	}
-
-
-	private function matchesNamespace(string $pattern, string $value): bool
-	{
-		if ($pattern === $value) {
-			return true;
-		}
-
-		if (fnmatch($pattern, $value, FNM_NOESCAPE | FNM_CASEFOLD)) {
-			return true;
-		}
-
-		return false;
 	}
 
 }

--- a/tests/Calls/EchoCallsTest.php
+++ b/tests/Calls/EchoCallsTest.php
@@ -11,6 +11,7 @@ use Spaze\PHPStan\Rules\Disallowed\Allowed\Allowed;
 use Spaze\PHPStan\Rules\Disallowed\Allowed\AllowedPath;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\Formatter\Formatter;
+use Spaze\PHPStan\Rules\Disallowed\Identifier\Identifier;
 use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
 
@@ -26,7 +27,7 @@ class EchoCallsTest extends RuleTestCase
 		$formatter = new Formatter($normalizer);
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath(new FileHelper(__DIR__)));
 		return new EchoCalls(
-			new DisallowedCallsRuleErrors($allowed),
+			new DisallowedCallsRuleErrors($allowed, new Identifier()),
 			new DisallowedCallFactory($formatter, $normalizer, $allowed),
 			[
 				[

--- a/tests/Calls/EmptyCallsTest.php
+++ b/tests/Calls/EmptyCallsTest.php
@@ -11,6 +11,7 @@ use Spaze\PHPStan\Rules\Disallowed\Allowed\Allowed;
 use Spaze\PHPStan\Rules\Disallowed\Allowed\AllowedPath;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\Formatter\Formatter;
+use Spaze\PHPStan\Rules\Disallowed\Identifier\Identifier;
 use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
 
@@ -26,7 +27,7 @@ class EmptyCallsTest extends RuleTestCase
 		$formatter = new Formatter($normalizer);
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath(new FileHelper(__DIR__)));
 		return new EmptyCalls(
-			new DisallowedCallsRuleErrors($allowed),
+			new DisallowedCallsRuleErrors($allowed, new Identifier()),
 			new DisallowedCallFactory($formatter, $normalizer, $allowed),
 			[
 				[

--- a/tests/Calls/EvalCallsTest.php
+++ b/tests/Calls/EvalCallsTest.php
@@ -11,6 +11,7 @@ use Spaze\PHPStan\Rules\Disallowed\Allowed\Allowed;
 use Spaze\PHPStan\Rules\Disallowed\Allowed\AllowedPath;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\Formatter\Formatter;
+use Spaze\PHPStan\Rules\Disallowed\Identifier\Identifier;
 use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
 
@@ -26,7 +27,7 @@ class EvalCallsTest extends RuleTestCase
 		$formatter = new Formatter($normalizer);
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath(new FileHelper(__DIR__)));
 		return new EvalCalls(
-			new DisallowedCallsRuleErrors($allowed),
+			new DisallowedCallsRuleErrors($allowed, new Identifier()),
 			new DisallowedCallFactory($formatter, $normalizer, $allowed),
 			[
 				[

--- a/tests/Calls/ExitDieCallsTest.php
+++ b/tests/Calls/ExitDieCallsTest.php
@@ -11,6 +11,7 @@ use Spaze\PHPStan\Rules\Disallowed\Allowed\Allowed;
 use Spaze\PHPStan\Rules\Disallowed\Allowed\AllowedPath;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\Formatter\Formatter;
+use Spaze\PHPStan\Rules\Disallowed\Identifier\Identifier;
 use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
 
@@ -26,7 +27,7 @@ class ExitDieCallsTest extends RuleTestCase
 		$formatter = new Formatter($normalizer);
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath(new FileHelper(__DIR__)));
 		return new ExitDieCalls(
-			new DisallowedCallsRuleErrors($allowed),
+			new DisallowedCallsRuleErrors($allowed, new Identifier()),
 			new DisallowedCallFactory($formatter, $normalizer, $allowed),
 			[
 				[

--- a/tests/Calls/FunctionCallsAllowInFunctionsTest.php
+++ b/tests/Calls/FunctionCallsAllowInFunctionsTest.php
@@ -11,6 +11,7 @@ use Spaze\PHPStan\Rules\Disallowed\Allowed\Allowed;
 use Spaze\PHPStan\Rules\Disallowed\Allowed\AllowedPath;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\Formatter\Formatter;
+use Spaze\PHPStan\Rules\Disallowed\Identifier\Identifier;
 use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
 
@@ -26,7 +27,7 @@ class FunctionCallsAllowInFunctionsTest extends RuleTestCase
 		$formatter = new Formatter($normalizer);
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath(new FileHelper(__DIR__)));
 		return new FunctionCalls(
-			new DisallowedCallsRuleErrors($allowed),
+			new DisallowedCallsRuleErrors($allowed, new Identifier()),
 			new DisallowedCallFactory($formatter, $normalizer, $allowed),
 			[
 				[

--- a/tests/Calls/FunctionCallsAllowInMethodsTest.php
+++ b/tests/Calls/FunctionCallsAllowInMethodsTest.php
@@ -11,6 +11,7 @@ use Spaze\PHPStan\Rules\Disallowed\Allowed\Allowed;
 use Spaze\PHPStan\Rules\Disallowed\Allowed\AllowedPath;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\Formatter\Formatter;
+use Spaze\PHPStan\Rules\Disallowed\Identifier\Identifier;
 use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
 
@@ -26,7 +27,7 @@ class FunctionCallsAllowInMethodsTest extends RuleTestCase
 		$formatter = new Formatter($normalizer);
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath(new FileHelper(__DIR__)));
 		return new FunctionCalls(
-			new DisallowedCallsRuleErrors($allowed),
+			new DisallowedCallsRuleErrors($allowed, new Identifier()),
 			new DisallowedCallFactory($formatter, $normalizer, $allowed),
 			[
 				[

--- a/tests/Calls/FunctionCallsInMultipleNamespacesTest.php
+++ b/tests/Calls/FunctionCallsInMultipleNamespacesTest.php
@@ -11,6 +11,7 @@ use Spaze\PHPStan\Rules\Disallowed\Allowed\Allowed;
 use Spaze\PHPStan\Rules\Disallowed\Allowed\AllowedPath;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\Formatter\Formatter;
+use Spaze\PHPStan\Rules\Disallowed\Identifier\Identifier;
 use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
 
@@ -26,7 +27,7 @@ class FunctionCallsInMultipleNamespacesTest extends RuleTestCase
 		$formatter = new Formatter($normalizer);
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath(new FileHelper(__DIR__)));
 		return new FunctionCalls(
-			new DisallowedCallsRuleErrors($allowed),
+			new DisallowedCallsRuleErrors($allowed, new Identifier()),
 			new DisallowedCallFactory($formatter, $normalizer, $allowed),
 			[
 				[

--- a/tests/Calls/FunctionCallsNamedParamsTest.php
+++ b/tests/Calls/FunctionCallsNamedParamsTest.php
@@ -11,6 +11,7 @@ use Spaze\PHPStan\Rules\Disallowed\Allowed\Allowed;
 use Spaze\PHPStan\Rules\Disallowed\Allowed\AllowedPath;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\Formatter\Formatter;
+use Spaze\PHPStan\Rules\Disallowed\Identifier\Identifier;
 use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
 
@@ -29,7 +30,7 @@ class FunctionCallsNamedParamsTest extends RuleTestCase
 		$formatter = new Formatter($normalizer);
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath(new FileHelper(__DIR__)));
 		return new FunctionCalls(
-			new DisallowedCallsRuleErrors($allowed),
+			new DisallowedCallsRuleErrors($allowed, new Identifier()),
 			new DisallowedCallFactory($formatter, $normalizer, $allowed),
 			[
 				[

--- a/tests/Calls/FunctionCallsTest.php
+++ b/tests/Calls/FunctionCallsTest.php
@@ -11,6 +11,7 @@ use Spaze\PHPStan\Rules\Disallowed\Allowed\Allowed;
 use Spaze\PHPStan\Rules\Disallowed\Allowed\AllowedPath;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\Formatter\Formatter;
+use Spaze\PHPStan\Rules\Disallowed\Identifier\Identifier;
 use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
 use Waldo\Quux\Blade;
@@ -27,7 +28,7 @@ class FunctionCallsTest extends RuleTestCase
 		$formatter = new Formatter($normalizer);
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath(new FileHelper(__DIR__)));
 		return new FunctionCalls(
-			new DisallowedCallsRuleErrors($allowed),
+			new DisallowedCallsRuleErrors($allowed, new Identifier()),
 			new DisallowedCallFactory($formatter, $normalizer, $allowed),
 			[
 				[

--- a/tests/Calls/FunctionCallsTest.php
+++ b/tests/Calls/FunctionCallsTest.php
@@ -71,6 +71,9 @@ class FunctionCallsTest extends RuleTestCase
 				],
 				[
 					'function' => 'shell_*',
+					'exclude' => [
+						'shell_b*()',
+					],
 					'allowIn' => [
 						'../src/disallowed-allow/*.php',
 						'../src/*-allow/*.*',

--- a/tests/Calls/FunctionCallsUnsupportedParamConfigTest.php
+++ b/tests/Calls/FunctionCallsUnsupportedParamConfigTest.php
@@ -10,6 +10,7 @@ use Spaze\PHPStan\Rules\Disallowed\Allowed\Allowed;
 use Spaze\PHPStan\Rules\Disallowed\Allowed\AllowedPath;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\Formatter\Formatter;
+use Spaze\PHPStan\Rules\Disallowed\Identifier\Identifier;
 use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
 
@@ -27,7 +28,7 @@ class FunctionCallsUnsupportedParamConfigTest extends PHPStanTestCase
 		$formatter = new Formatter($normalizer);
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath(new FileHelper(__DIR__)));
 		new FunctionCalls(
-			new DisallowedCallsRuleErrors($allowed),
+			new DisallowedCallsRuleErrors($allowed, new Identifier()),
 			new DisallowedCallFactory($formatter, $normalizer, $allowed),
 			[
 				[

--- a/tests/Calls/MethodCallsTest.php
+++ b/tests/Calls/MethodCallsTest.php
@@ -11,6 +11,7 @@ use Spaze\PHPStan\Rules\Disallowed\Allowed\Allowed;
 use Spaze\PHPStan\Rules\Disallowed\Allowed\AllowedPath;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\Formatter\Formatter;
+use Spaze\PHPStan\Rules\Disallowed\Identifier\Identifier;
 use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedMethodRuleErrors;
@@ -29,7 +30,7 @@ class MethodCallsTest extends RuleTestCase
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath(new FileHelper(__DIR__)));
 		return new MethodCalls(
 			new DisallowedMethodRuleErrors(
-				new DisallowedCallsRuleErrors($allowed),
+				new DisallowedCallsRuleErrors($allowed, new Identifier()),
 				new TypeResolver(),
 				$formatter
 			),

--- a/tests/Calls/NewCallsTest.php
+++ b/tests/Calls/NewCallsTest.php
@@ -11,6 +11,7 @@ use Spaze\PHPStan\Rules\Disallowed\Allowed\Allowed;
 use Spaze\PHPStan\Rules\Disallowed\Allowed\AllowedPath;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\Formatter\Formatter;
+use Spaze\PHPStan\Rules\Disallowed\Identifier\Identifier;
 use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
 
@@ -26,7 +27,7 @@ class NewCallsTest extends RuleTestCase
 		$formatter = new Formatter($normalizer);
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath(new FileHelper(__DIR__)));
 		return new NewCalls(
-			new DisallowedCallsRuleErrors($allowed),
+			new DisallowedCallsRuleErrors($allowed, new Identifier()),
 			new DisallowedCallFactory($formatter, $normalizer, $allowed),
 			[
 				[

--- a/tests/Calls/PrintCallsTest.php
+++ b/tests/Calls/PrintCallsTest.php
@@ -11,6 +11,7 @@ use Spaze\PHPStan\Rules\Disallowed\Allowed\Allowed;
 use Spaze\PHPStan\Rules\Disallowed\Allowed\AllowedPath;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\Formatter\Formatter;
+use Spaze\PHPStan\Rules\Disallowed\Identifier\Identifier;
 use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
 
@@ -26,7 +27,7 @@ class PrintCallsTest extends RuleTestCase
 		$formatter = new Formatter($normalizer);
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath(new FileHelper(__DIR__)));
 		return new PrintCalls(
-			new DisallowedCallsRuleErrors($allowed),
+			new DisallowedCallsRuleErrors($allowed, new Identifier()),
 			new DisallowedCallFactory($formatter, $normalizer, $allowed),
 			[
 				[

--- a/tests/Calls/ShellExecCallsTest.php
+++ b/tests/Calls/ShellExecCallsTest.php
@@ -11,6 +11,7 @@ use Spaze\PHPStan\Rules\Disallowed\Allowed\Allowed;
 use Spaze\PHPStan\Rules\Disallowed\Allowed\AllowedPath;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\Formatter\Formatter;
+use Spaze\PHPStan\Rules\Disallowed\Identifier\Identifier;
 use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
 
@@ -26,7 +27,7 @@ class ShellExecCallsTest extends RuleTestCase
 		$formatter = new Formatter($normalizer);
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath(new FileHelper(__DIR__)));
 		return new ShellExecCalls(
-			new DisallowedCallsRuleErrors($allowed),
+			new DisallowedCallsRuleErrors($allowed, new Identifier()),
 			new DisallowedCallFactory($formatter, $normalizer, $allowed),
 			[
 				[

--- a/tests/Calls/StaticCallsTest.php
+++ b/tests/Calls/StaticCallsTest.php
@@ -11,6 +11,7 @@ use Spaze\PHPStan\Rules\Disallowed\Allowed\Allowed;
 use Spaze\PHPStan\Rules\Disallowed\Allowed\AllowedPath;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\Formatter\Formatter;
+use Spaze\PHPStan\Rules\Disallowed\Identifier\Identifier;
 use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedMethodRuleErrors;
@@ -29,7 +30,7 @@ class StaticCallsTest extends RuleTestCase
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath(new FileHelper(__DIR__)));
 		return new StaticCalls(
 			new DisallowedMethodRuleErrors(
-				new DisallowedCallsRuleErrors($allowed),
+				new DisallowedCallsRuleErrors($allowed, new Identifier()),
 				new TypeResolver(),
 				$formatter
 			),

--- a/tests/Configs/DangerousConfigEvalCallsTest.php
+++ b/tests/Configs/DangerousConfigEvalCallsTest.php
@@ -13,6 +13,7 @@ use Spaze\PHPStan\Rules\Disallowed\Allowed\AllowedPath;
 use Spaze\PHPStan\Rules\Disallowed\Calls\EvalCalls;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\Formatter\Formatter;
+use Spaze\PHPStan\Rules\Disallowed\Identifier\Identifier;
 use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
 
@@ -30,7 +31,7 @@ class DangerousConfigEvalCallsTest extends RuleTestCase
 		$formatter = new Formatter($normalizer);
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath(new FileHelper(__DIR__)));
 		return new EvalCalls(
-			new DisallowedCallsRuleErrors($allowed),
+			new DisallowedCallsRuleErrors($allowed, new Identifier()),
 			new DisallowedCallFactory($formatter, $normalizer, $allowed),
 			$config['parameters']['disallowedFunctionCalls']
 		);

--- a/tests/Configs/DangerousConfigFunctionCallsTest.php
+++ b/tests/Configs/DangerousConfigFunctionCallsTest.php
@@ -13,6 +13,7 @@ use Spaze\PHPStan\Rules\Disallowed\Allowed\AllowedPath;
 use Spaze\PHPStan\Rules\Disallowed\Calls\FunctionCalls;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\Formatter\Formatter;
+use Spaze\PHPStan\Rules\Disallowed\Identifier\Identifier;
 use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
 
@@ -30,7 +31,7 @@ class DangerousConfigFunctionCallsTest extends RuleTestCase
 		$formatter = new Formatter($normalizer);
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath(new FileHelper(__DIR__)));
 		return new FunctionCalls(
-			new DisallowedCallsRuleErrors($allowed),
+			new DisallowedCallsRuleErrors($allowed, new Identifier()),
 			new DisallowedCallFactory($formatter, $normalizer, $allowed),
 			$config['parameters']['disallowedFunctionCalls']
 		);

--- a/tests/Configs/ExecutionConfigFunctionCallsTest.php
+++ b/tests/Configs/ExecutionConfigFunctionCallsTest.php
@@ -13,6 +13,7 @@ use Spaze\PHPStan\Rules\Disallowed\Allowed\AllowedPath;
 use Spaze\PHPStan\Rules\Disallowed\Calls\FunctionCalls;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\Formatter\Formatter;
+use Spaze\PHPStan\Rules\Disallowed\Identifier\Identifier;
 use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
 
@@ -30,7 +31,7 @@ class ExecutionConfigFunctionCallsTest extends RuleTestCase
 		$formatter = new Formatter($normalizer);
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath(new FileHelper(__DIR__)));
 		return new FunctionCalls(
-			new DisallowedCallsRuleErrors($allowed),
+			new DisallowedCallsRuleErrors($allowed, new Identifier()),
 			new DisallowedCallFactory($formatter, $normalizer, $allowed),
 			$config['parameters']['disallowedFunctionCalls']
 		);

--- a/tests/Configs/ExecutionConfigShellExecCallsTest.php
+++ b/tests/Configs/ExecutionConfigShellExecCallsTest.php
@@ -13,6 +13,7 @@ use Spaze\PHPStan\Rules\Disallowed\Allowed\AllowedPath;
 use Spaze\PHPStan\Rules\Disallowed\Calls\ShellExecCalls;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\Formatter\Formatter;
+use Spaze\PHPStan\Rules\Disallowed\Identifier\Identifier;
 use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
 
@@ -30,7 +31,7 @@ class ExecutionConfigShellExecCallsTest extends RuleTestCase
 		$formatter = new Formatter($normalizer);
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath(new FileHelper(__DIR__)));
 		return new ShellExecCalls(
-			new DisallowedCallsRuleErrors($allowed),
+			new DisallowedCallsRuleErrors($allowed, new Identifier()),
 			new DisallowedCallFactory($formatter, $normalizer, $allowed),
 			$config['parameters']['disallowedFunctionCalls']
 		);

--- a/tests/Configs/InsecureConfigFunctionCallsTest.php
+++ b/tests/Configs/InsecureConfigFunctionCallsTest.php
@@ -13,6 +13,7 @@ use Spaze\PHPStan\Rules\Disallowed\Allowed\AllowedPath;
 use Spaze\PHPStan\Rules\Disallowed\Calls\FunctionCalls;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\Formatter\Formatter;
+use Spaze\PHPStan\Rules\Disallowed\Identifier\Identifier;
 use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
 
@@ -30,7 +31,7 @@ class InsecureConfigFunctionCallsTest extends RuleTestCase
 		$formatter = new Formatter($normalizer);
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath(new FileHelper(__DIR__)));
 		return new FunctionCalls(
-			new DisallowedCallsRuleErrors($allowed),
+			new DisallowedCallsRuleErrors($allowed, new Identifier()),
 			new DisallowedCallFactory($formatter, $normalizer, $allowed),
 			$config['parameters']['disallowedFunctionCalls']
 		);

--- a/tests/Configs/InsecureConfigMethodCallsTest.php
+++ b/tests/Configs/InsecureConfigMethodCallsTest.php
@@ -13,6 +13,7 @@ use Spaze\PHPStan\Rules\Disallowed\Allowed\AllowedPath;
 use Spaze\PHPStan\Rules\Disallowed\Calls\MethodCalls;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\Formatter\Formatter;
+use Spaze\PHPStan\Rules\Disallowed\Identifier\Identifier;
 use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedMethodRuleErrors;
@@ -33,7 +34,7 @@ class InsecureConfigMethodCallsTest extends RuleTestCase
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath(new FileHelper(__DIR__)));
 		return new MethodCalls(
 			new DisallowedMethodRuleErrors(
-				new DisallowedCallsRuleErrors($allowed),
+				new DisallowedCallsRuleErrors($allowed, new Identifier()),
 				new TypeResolver(),
 				$formatter
 			),

--- a/tests/Configs/LooseConfigFunctionCallsTest.php
+++ b/tests/Configs/LooseConfigFunctionCallsTest.php
@@ -13,6 +13,7 @@ use Spaze\PHPStan\Rules\Disallowed\Allowed\AllowedPath;
 use Spaze\PHPStan\Rules\Disallowed\Calls\FunctionCalls;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\Formatter\Formatter;
+use Spaze\PHPStan\Rules\Disallowed\Identifier\Identifier;
 use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
 
@@ -43,7 +44,7 @@ class LooseConfigFunctionCallsTest extends RuleTestCase
 		$formatter = new Formatter($normalizer);
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath(new FileHelper(__DIR__)));
 		return new FunctionCalls(
-			new DisallowedCallsRuleErrors($allowed),
+			new DisallowedCallsRuleErrors($allowed, new Identifier()),
 			new DisallowedCallFactory($formatter, $normalizer, $allowed),
 			$config['parameters']['disallowedFunctionCalls']
 		);

--- a/tests/Identifier/IdentifierTest.php
+++ b/tests/Identifier/IdentifierTest.php
@@ -1,0 +1,61 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Rules\Disallowed\Identifier;
+
+use Generator;
+use PHPStan\Testing\PHPStanTestCase;
+
+class IdentifierTest extends PHPStanTestCase
+{
+
+	/** @var Identifier */
+	private $identifier;
+
+
+	protected function setUp(): void
+	{
+		$this->identifier = new Identifier();
+	}
+
+
+	/**
+	 * @param string $pattern
+	 * @param string $value
+	 * @return void
+	 * @dataProvider matchesProvider
+	 */
+	public function testMatches(string $pattern, string $value): void
+	{
+		$this->assertTrue($this->identifier->matches($pattern, $value));
+	}
+
+
+	/**
+	 * @param string $pattern
+	 * @param string $value
+	 * @return void
+	 * @dataProvider doesNotMatchProvider
+	 */
+	public function testDoesNotMatch(string $pattern, string $value): void
+	{
+		$this->assertFalse($this->identifier->matches($pattern, $value));
+	}
+
+
+	public static function matchesProvider(): Generator
+	{
+		yield ['foo', 'foo'];
+		yield ['foo', 'Foo'];
+		yield ['foo\\bar', 'foo\\bar'];
+		yield ['foo\\*', 'Foo\\Bar'];
+	}
+
+
+	public static function doesNotMatchProvider(): Generator
+	{
+		yield ['foo', 'bar'];
+		yield ['foo\\*', 'Bar\\Foo'];
+	}
+
+}

--- a/tests/Identifier/IdentifierTest.php
+++ b/tests/Identifier/IdentifierTest.php
@@ -22,40 +22,52 @@ class IdentifierTest extends PHPStanTestCase
 	/**
 	 * @param string $pattern
 	 * @param string $value
+	 * @param list<string>|null $excludes
 	 * @return void
 	 * @dataProvider matchesProvider
 	 */
-	public function testMatches(string $pattern, string $value): void
+	public function testMatches(string $pattern, string $value, ?array $excludes): void
 	{
-		$this->assertTrue($this->identifier->matches($pattern, $value));
+		$this->assertTrue($this->identifier->matches($pattern, $value, $excludes));
 	}
 
 
 	/**
 	 * @param string $pattern
 	 * @param string $value
+	 * @param list<string>|null $excludes
 	 * @return void
 	 * @dataProvider doesNotMatchProvider
 	 */
-	public function testDoesNotMatch(string $pattern, string $value): void
+	public function testDoesNotMatch(string $pattern, string $value, ?array $excludes): void
 	{
-		$this->assertFalse($this->identifier->matches($pattern, $value));
+		$this->assertFalse($this->identifier->matches($pattern, $value, $excludes));
 	}
 
 
 	public static function matchesProvider(): Generator
 	{
-		yield ['foo', 'foo'];
-		yield ['foo', 'Foo'];
-		yield ['foo\\bar', 'foo\\bar'];
-		yield ['foo\\*', 'Foo\\Bar'];
+		yield ['foo', 'foo', []];
+		yield ['foo', 'Foo', []];
+		yield ['foo\\*', 'Foo\\Bar', []];
+		yield ['foo\\bar', 'foo\\bar', []];
+		yield ['foo\\bar', 'Foo\\Bar', []];
+		yield ['foo\\bar', 'foo\\bar', ['bar*']];
+		yield ['foo\\bar', 'foo\\bar', ['n*pe', 'bar\\*']];
 	}
 
 
 	public static function doesNotMatchProvider(): Generator
 	{
-		yield ['foo', 'bar'];
-		yield ['foo\\*', 'Bar\\Foo'];
+		yield ['foo', 'bar', []];
+		yield ['foo', 'foo', ['foo']];
+		yield ['foo', 'Foo', ['foo']];
+		yield ['foo', 'Foo', ['fOO']];
+		yield ['foo', 'Foo', ['f*']];
+		yield ['foo', 'Foo', ['F*']];
+		yield ['foo\\*', 'Bar\\Foo', []];
+		yield ['foo\\bar', 'foo\\bar', ['foo*']];
+		yield ['foo\\bar', 'foo\\bar', ['n*pe', 'foo\\*']];
 	}
 
 }

--- a/tests/Usages/AttributeUsagesAllowParamsMultipleTest.php
+++ b/tests/Usages/AttributeUsagesAllowParamsMultipleTest.php
@@ -11,6 +11,7 @@ use Spaze\PHPStan\Rules\Disallowed\Allowed\Allowed;
 use Spaze\PHPStan\Rules\Disallowed\Allowed\AllowedPath;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedAttributeFactory;
 use Spaze\PHPStan\Rules\Disallowed\Formatter\Formatter;
+use Spaze\PHPStan\Rules\Disallowed\Identifier\Identifier;
 use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedAttributeRuleErrors;
 use Waldo\Quux\Blade;
@@ -23,7 +24,7 @@ class AttributeUsagesAllowParamsMultipleTest extends RuleTestCase
 		$normalizer = new Normalizer();
 		$allowed = new Allowed(new Formatter($normalizer), $normalizer, new AllowedPath(new FileHelper(__DIR__)));
 		return new AttributeUsages(
-			new DisallowedAttributeRuleErrors($allowed),
+			new DisallowedAttributeRuleErrors($allowed, new Identifier()),
 			new DisallowedAttributeFactory($allowed, $normalizer),
 			[
 				[

--- a/tests/Usages/AttributeUsagesTest.php
+++ b/tests/Usages/AttributeUsagesTest.php
@@ -11,6 +11,7 @@ use Spaze\PHPStan\Rules\Disallowed\Allowed\Allowed;
 use Spaze\PHPStan\Rules\Disallowed\Allowed\AllowedPath;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedAttributeFactory;
 use Spaze\PHPStan\Rules\Disallowed\Formatter\Formatter;
+use Spaze\PHPStan\Rules\Disallowed\Identifier\Identifier;
 use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedAttributeRuleErrors;
 
@@ -21,7 +22,7 @@ class AttributeUsagesTest extends RuleTestCase
 	{
 		$allowed = new Allowed(new Formatter(new Normalizer()), new Normalizer(), new AllowedPath(new FileHelper(__DIR__)));
 		return new AttributeUsages(
-			new DisallowedAttributeRuleErrors($allowed),
+			new DisallowedAttributeRuleErrors($allowed, new Identifier()),
 			new DisallowedAttributeFactory($allowed, new Normalizer()),
 			[
 				[

--- a/tests/Usages/NamespaceUsagesTest.php
+++ b/tests/Usages/NamespaceUsagesTest.php
@@ -8,6 +8,7 @@ use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\Allowed\AllowedPath;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedNamespaceFactory;
+use Spaze\PHPStan\Rules\Disallowed\Identifier\Identifier;
 use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedNamespaceRuleErrors;
 
@@ -17,7 +18,7 @@ class NamespaceUsagesTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		return new NamespaceUsages(
-			new DisallowedNamespaceRuleErrors(new AllowedPath(new FileHelper(__DIR__))),
+			new DisallowedNamespaceRuleErrors(new AllowedPath(new FileHelper(__DIR__)), new Identifier()),
 			new DisallowedNamespaceFactory(new Normalizer()),
 			new Normalizer(),
 			[

--- a/tests/Usages/NamespaceUsagesTypesTest.php
+++ b/tests/Usages/NamespaceUsagesTypesTest.php
@@ -8,6 +8,7 @@ use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\Allowed\AllowedPath;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedNamespaceFactory;
+use Spaze\PHPStan\Rules\Disallowed\Identifier\Identifier;
 use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedNamespaceRuleErrors;
 
@@ -21,7 +22,7 @@ class NamespaceUsagesTypesTest extends RuleTestCase
 	{
 		$normalizer = new Normalizer();
 		return new NamespaceUsages(
-			new DisallowedNamespaceRuleErrors(new AllowedPath(new FileHelper(__DIR__))),
+			new DisallowedNamespaceRuleErrors(new AllowedPath(new FileHelper(__DIR__)), new Identifier()),
 			new DisallowedNamespaceFactory($normalizer),
 			$normalizer,
 			[

--- a/tests/src/disallowed-allow/functionCalls.php
+++ b/tests/src/disallowed-allow/functionCalls.php
@@ -93,3 +93,6 @@ hash((new stdClass())->property . 'foo', 'NAH');
 \Foo\Bar\Waldo\config('foo', ['key' => 'allow']);
 // allowed by path
 \Foo\Bar\Waldo\config('foo', ['key' => 'disallow']);
+
+// allowed by path
+shell_by();

--- a/tests/src/disallowed/functionCalls.php
+++ b/tests/src/disallowed/functionCalls.php
@@ -93,3 +93,6 @@ hash((new stdClass())->property . 'foo', 'NAH');
 \Foo\Bar\Waldo\config('foo', ['key' => 'allow']);
 // disallowed array param, unsupported type in config
 \Foo\Bar\Waldo\config('foo', ['key' => 'disallow']);
+
+// would match shell_* but is excluded
+shell_by();


### PR DESCRIPTION
Handy when you disallow items with wildcards but there's this one thing you'd like to leave out.

```neon
parameters:
    disallowedFunctionCalls:
        -
            function: 'pcntl_*()'
            exclude:
                - 'pcntl_foo*()'
```