### PR TITLE
Make the `definedIn` test actually test what it should test

### DIFF
--- a/tests/libs/Bar.php
+++ b/tests/libs/Bar.php
@@ -8,4 +8,14 @@ class Bar
 
 	public const NAME = 'Bar';
 
+
+	public function foo(): void
+	{
+	}
+
+
+	public function bar(): void
+	{
+	}
+
 }

--- a/tests/src/disallowed-allow/methodCallsDefinedIn.php
+++ b/tests/src/disallowed-allow/methodCallsDefinedIn.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types = 1);
 
-use Fiction\Pulp\Royale;
+use Waldo\Foo\Bar;
 use Waldo\Quux\Blade;
 
 // allowed by path
@@ -10,8 +10,9 @@ $blade->andSorcery();
 $blade->server();
 
 // allowed by path
-Royale::withCheese();
-Royale::leBigMac();
+$bar = new Bar();
+$bar->foo();
+$bar->bar();
 
 // allowed because it's a built-in function
 time();

--- a/tests/src/disallowed/methodCallsDefinedIn.php
+++ b/tests/src/disallowed/methodCallsDefinedIn.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types = 1);
 
-use Fiction\Pulp\Royale;
+use Waldo\Foo\Bar;
 use Waldo\Quux\Blade;
 
 // disallowed based on definedIn
@@ -10,8 +10,9 @@ $blade->andSorcery();
 $blade->server();
 
 // allowed because these are defined elsewhere
-Royale::withCheese();
-Royale::leBigMac();
+$bar = new Bar();
+$bar->foo();
+$bar->bar();
 
 // allowed because it's a built-in function
 time();


### PR DESCRIPTION
Static calls like `Royale::withCheese()` would require `return new StaticCalls` instead of `return new MethodCalls` in the test class' `getRule()` method otherwise they're irrelevant.

Follow-up to #198