### PR TITLE
Make sure `new` calls are also filtered by definedIn

### DIFF
--- a/src/Calls/NewCalls.php
+++ b/src/Calls/NewCalls.php
@@ -88,10 +88,12 @@ class NewCalls implements Rule
 			}
 
 			foreach ($names as $name) {
+				$classRef = $type->getClassReflection();
+				$definedIn = $classRef ? $classRef->getFileName() : null;
 				$name .= self::CONSTRUCT;
 				$errors = array_merge(
 					$errors,
-					$this->disallowedCallsRuleErrors->get($node, $scope, $name, $type->getClassName() . self::CONSTRUCT, null, $this->disallowedCalls)
+					$this->disallowedCallsRuleErrors->get($node, $scope, $name, $type->getClassName() . self::CONSTRUCT, $definedIn, $this->disallowedCalls)
 				);
 			}
 		}

--- a/tests/Calls/NewCallsDefinedInTest.php
+++ b/tests/Calls/NewCallsDefinedInTest.php
@@ -15,10 +15,8 @@ use Spaze\PHPStan\Rules\Disallowed\Formatter\Formatter;
 use Spaze\PHPStan\Rules\Disallowed\Identifier\Identifier;
 use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
-use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedMethodRuleErrors;
-use Spaze\PHPStan\Rules\Disallowed\Type\TypeResolver;
 
-class MethodCallsDefinedInTest extends RuleTestCase
+class NewCallsDefinedInTest extends RuleTestCase
 {
 
 	/**
@@ -30,12 +28,8 @@ class MethodCallsDefinedInTest extends RuleTestCase
 		$formatter = new Formatter($normalizer);
 		$filePath = new FilePath(new FileHelper(__DIR__), __DIR__ . '/..');
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath($filePath));
-		return new MethodCalls(
-			new DisallowedMethodRuleErrors(
-				new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath),
-				new TypeResolver(),
-				$formatter
-			),
+		return new NewCalls(
+			new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath),
 			new DisallowedCallFactory($formatter, $normalizer, $allowed),
 			[
 				[
@@ -57,13 +51,9 @@ class MethodCallsDefinedInTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/../src/disallowed/methodCallsDefinedIn.php'], [
 			[
 				// expect this error message:
-				'Calling Waldo\Quux\Blade::andSorcery() is forbidden, because reasons [Waldo\Quux\Blade::andSorcery() matches *()]',
+				'Calling Waldo\Quux\Blade::__construct() is forbidden, because reasons [Waldo\Quux\Blade::__construct() matches *()]',
 				// on this line:
-				10,
-			],
-			[
-				'Calling Waldo\Quux\Blade::server() is forbidden, because reasons [Waldo\Quux\Blade::server() matches *()]',
-				11,
+				9,
 			],
 		]);
 		// Based on the configuration above, no errors in this file:

--- a/tests/libs/Option.php
+++ b/tests/libs/Option.php
@@ -7,6 +7,7 @@ use ArrayAccess;
 use EmptyIterator;
 use IteratorAggregate;
 use ArrayIterator;
+use Traversable;
 
 /**
  * @template T
@@ -62,7 +63,7 @@ final class None extends Option
 		return self::$instance;
 	}
 
-	public function getIterator()
+	public function getIterator(): Traversable
 	{
 		return new EmptyIterator();
 	}
@@ -104,7 +105,7 @@ final class Some extends Option
 	}
 
 
-	public function getIterator()
+	public function getIterator(): Traversable
 	{
 		return new ArrayIterator([$this->value]);
 	}

--- a/tests/libs/TestException.php
+++ b/tests/libs/TestException.php
@@ -1,0 +1,8 @@
+<?php
+declare(strict_types = 1);
+
+namespace Exceptions;
+
+class TestException extends \Exception
+{
+}

--- a/tests/src/disallowed/methodCallsDefinedIn.php
+++ b/tests/src/disallowed/methodCallsDefinedIn.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types = 1);
 
+use Exceptions\TestException;
 use Waldo\Foo\Bar;
 use Waldo\Quux\Blade;
 
@@ -16,3 +17,13 @@ $bar->bar();
 
 // allowed because it's a built-in function
 time();
+
+// allowed because it's a built-in class
+$exception = new Exception();
+$exception->getMessage();
+$exception->getPrevious();
+
+// allowed because it's defined elsewhere
+$testException = new TestException();
+$testException->getMessage();
+$testException->getPrevious();


### PR DESCRIPTION
Ran into some issues with the new `definedIn`, where it would report all `new` calls, to built in classes, as it had no
definedIn, and since it wasn't passed along.

