### PR TITLE
Attributes can be specified like `#[\Foo()]`, not just like `Foo`

### DIFF
--- a/src/DisallowedAttributeFactory.php
+++ b/src/DisallowedAttributeFactory.php
@@ -37,11 +37,11 @@ class DisallowedAttributeFactory
 			$attributes = $disallowed['attribute'];
 			$excludes = [];
 			foreach ((array)($disallowed['exclude'] ?? []) as $exclude) {
-				$excludes[] = $this->normalizer->normalizeNamespace($exclude);
+				$excludes[] = $this->normalizer->normalizeAttribute($exclude);
 			}
 			foreach ((array)$attributes as $attribute) {
 				$disallowedAttribute = new DisallowedAttribute(
-					$this->normalizer->normalizeNamespace($attribute),
+					$this->normalizer->normalizeAttribute($attribute),
 					$excludes,
 					$disallowed['message'] ?? null,
 					$this->allowed->getConfig($disallowed),

--- a/src/Normalizer/Normalizer.php
+++ b/src/Normalizer/Normalizer.php
@@ -8,7 +8,7 @@ class Normalizer
 
 	public function normalizeCall(string $call): string
 	{
-		$call = substr($call, -2) === '()' ? substr($call, 0, -2) : $call;
+		$call = $this->removeParentheses($call);
 		return $this->normalizeNamespace($call);
 	}
 
@@ -16,6 +16,21 @@ class Normalizer
 	public function normalizeNamespace(string $namespace): string
 	{
 		return ltrim($namespace, '\\');
+	}
+
+
+	public function normalizeAttribute(string $attribute): string
+	{
+		$attribute = ltrim($attribute, '#[');
+		$attribute = rtrim($attribute, ']');
+		$attribute = $this->removeParentheses($attribute);
+		return $this->normalizeNamespace($attribute);
+	}
+
+
+	private function removeParentheses(string $element): string
+	{
+		return substr($element, -2) === '()' ? substr($element, 0, -2) : $element;
 	}
 
 }

--- a/tests/Normalizer/NormalizerTest.php
+++ b/tests/Normalizer/NormalizerTest.php
@@ -33,4 +33,15 @@ class NormalizerTest extends PHPStanTestCase
 		$this->assertSame('foo\\bar', $this->normalizer->normalizeNamespace('\\foo\\bar'));
 	}
 
+
+	public function testNormalizeAttribute(): void
+	{
+		$this->assertSame('foo', $this->normalizer->normalizeAttribute('foo'));
+		$this->assertSame('foo', $this->normalizer->normalizeAttribute('foo()'));
+		$this->assertSame('foo', $this->normalizer->normalizeAttribute('\\foo()'));
+		$this->assertSame('foo', $this->normalizer->normalizeAttribute('#[\\foo]'));
+		$this->assertSame('foo', $this->normalizer->normalizeAttribute('#[\\foo()]'));
+		$this->assertSame('foo\\bar', $this->normalizer->normalizeAttribute('#[\\foo\\bar()]'));
+	}
+
 }

--- a/tests/Usages/AttributeUsagesAllowParamsMultipleTest.php
+++ b/tests/Usages/AttributeUsagesAllowParamsMultipleTest.php
@@ -49,6 +49,12 @@ class AttributeUsagesAllowParamsMultipleTest extends RuleTestCase
 						],
 					],
 				],
+				[
+					'attribute' => '#[\Attributes\AttributeClass()]',
+					'allowIn' => [
+						'../src/disallowed-allow/ClassWithAttributesAllow.php',
+					],
+				],
 			]
 		);
 	}
@@ -63,6 +69,10 @@ class AttributeUsagesAllowParamsMultipleTest extends RuleTestCase
 				'Attribute Attributes\AttributeEntity is forbidden, because reasons',
 				// on this line:
 				8,
+			],
+			[
+				'Attribute Attributes\AttributeClass is forbidden, because reasons',
+				30,
 			],
 		]);
 		$this->analyse([__DIR__ . '/../src/disallowed-allow/ClassWithAttributesAllow.php'], [

--- a/tests/Usages/AttributeUsagesTest.php
+++ b/tests/Usages/AttributeUsagesTest.php
@@ -41,6 +41,12 @@ class AttributeUsagesTest extends RuleTestCase
 						],
 					],
 				],
+				[
+					'attribute' => '#[\Attributes\AttributeClass()]',
+					'allowIn' => [
+						'../src/disallowed-allow/ClassWithAttributesAllow.php',
+					],
+				],
 			]
 		);
 	}
@@ -55,6 +61,10 @@ class AttributeUsagesTest extends RuleTestCase
 				'Attribute Attributes\AttributeEntity is forbidden, because reasons',
 				// on this line:
 				8,
+			],
+			[
+				'Attribute Attributes\AttributeClass is forbidden, because reasons',
+				30,
 			],
 		]);
 		$this->analyse([__DIR__ . '/../src/disallowed-allow/ClassWithAttributesAllow.php'], []);

--- a/tests/libs/AttributeClass.php
+++ b/tests/libs/AttributeClass.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types = 1);
+
+namespace Attributes;
+
+use Attribute;
+
+#[Attribute]
+class AttributeClass
+{
+}

--- a/tests/src/disallowed-allow/ClassWithAttributesAllow.php
+++ b/tests/src/disallowed-allow/ClassWithAttributesAllow.php
@@ -26,4 +26,10 @@ class ClassWithAttributesAllow
 	{
 	}
 
+
+	#[AttributeClass()] // allowed by path in all tests
+	public function hasPineapple(): bool
+	{
+	}
+
 }

--- a/tests/src/disallowed/ClassWithAttributes.php
+++ b/tests/src/disallowed/ClassWithAttributes.php
@@ -26,4 +26,10 @@ class ClassWithAttributes
 	{
 	}
 
+
+	#[AttributeClass()] // disallowed
+	public function hasPineapple(): bool
+	{
+	}
+
 }


### PR DESCRIPTION
Available options to specify an attribute in the config are:
- `Foo`
- `Foo()`
- `\Foo()`
- `#[\Foo]`
- `#[\Foo()]`
