### PR TITLE
Method calls from interface implementations are not detected

### DIFF
--- a/tests/Calls/MethodCallsTest.php
+++ b/tests/Calls/MethodCallsTest.php
@@ -85,6 +85,14 @@ class MethodCallsTest extends RuleTestCase
 					],
 				],
 				[
+					'method' => 'Interfaces\BaseInterface::x*()',
+					'message' => 'BaseInterface::x*() methods are dangerous',
+					'allowIn' => [
+						'../src/disallowed-allow/*.php',
+						'../src/*-allow/*.*',
+					],
+				],
+				[
 					'method' => 'Traits\TestTrait::*',
 					'message' => 'all TestTrait methods are dangerous',
 					'allowIn' => [
@@ -216,6 +224,10 @@ class MethodCallsTest extends RuleTestCase
 			[
 				'Calling Waldo\Quux\Blade::andSorcery() is forbidden, use magic',
 				68,
+			],
+			[
+				'Calling Interfaces\BaseInterface::x() (as Interfaces\Implementation::x()) is forbidden, BaseInterface::x*() methods are dangerous [Interfaces\BaseInterface::x() matches Interfaces\BaseInterface::x*()]',
+				74,
 			],
 		]);
 		$this->analyse([__DIR__ . '/../src/disallowed-allow/methodCalls.php'], [

--- a/tests/Calls/StaticCallsTest.php
+++ b/tests/Calls/StaticCallsTest.php
@@ -83,6 +83,14 @@ class StaticCallsTest extends RuleTestCase
 					],
 				],
 				[
+					'method' => 'Interfaces\BaseInterface::y*()',
+					'message' => 'method BaseInterface::y() is dangerous',
+					'allowIn' => [
+						'../src/disallowed-allow/*.php',
+						'../src/*-allow/*.*',
+					],
+				],
+				[
 					'method' => 'Traits\TestTrait::z()',
 					'message' => 'method TestTrait::z() is dangerous',
 					'allowIn' => [
@@ -180,6 +188,10 @@ class StaticCallsTest extends RuleTestCase
 			[
 				'Calling PhpOption\Some::create() is forbidden, do not use PhpOption',
 				37,
+			],
+			[
+				'Calling Interfaces\BaseInterface::y() (as Interfaces\Implementation::y()) is forbidden, method BaseInterface::y() is dangerous [Interfaces\BaseInterface::y() matches Interfaces\BaseInterface::y*()]',
+				40,
 			],
 		]);
 		$this->analyse([__DIR__ . '/../src/disallowed-allow/staticCalls.php'], [

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,6 +9,7 @@ require __DIR__ . '/libs/Blade.php';
 require __DIR__ . '/libs/Constructor.php';
 require __DIR__ . '/libs/Functions.php';
 require __DIR__ . '/libs/Inheritance.php';
+require __DIR__ . '/libs/Interfaces.php';
 require __DIR__ . '/libs/Option.php';
 require __DIR__ . '/libs/Royale.php';
 require __DIR__ . '/libs/SomeInterface.php';

--- a/tests/libs/Interfaces.php
+++ b/tests/libs/Interfaces.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types = 1);
+
+namespace Interfaces;
+
+interface BaseInterface
+{
+
+	public function x(): void;
+
+
+	public static function y(): void;
+
+}
+
+
+final class Implementation implements BaseInterface
+{
+
+	public function x(): void
+	{
+	}
+
+
+	public static function y(): void
+	{
+	}
+
+}

--- a/tests/src/disallowed-allow/methodCalls.php
+++ b/tests/src/disallowed-allow/methodCalls.php
@@ -69,3 +69,6 @@ $blade->andSorcery();
 
 // allowed by path
 $blade->runway();
+
+// allowed by path
+(new Interfaces\Implementation())->x();

--- a/tests/src/disallowed-allow/staticCalls.php
+++ b/tests/src/disallowed-allow/staticCalls.php
@@ -35,3 +35,6 @@ Traits\AnotherTestClass::zz();
 PhpOption\Option::fromArraysValue([]);
 PhpOption\None::create();
 PhpOption\Some::create('value');
+
+// interface method allowed by path
+Interfaces\Implementation::y();

--- a/tests/src/disallowed/methodCalls.php
+++ b/tests/src/disallowed/methodCalls.php
@@ -69,3 +69,6 @@ $blade->andSorcery();
 
 // would match run* but is excluded
 $blade->runway();
+
+// disallowed interface method
+(new Interfaces\Implementation())->x();

--- a/tests/src/disallowed/staticCalls.php
+++ b/tests/src/disallowed/staticCalls.php
@@ -35,3 +35,6 @@ Traits\AnotherTestClass::zz();
 PhpOption\Option::fromArraysValue([]);
 PhpOption\None::create();
 PhpOption\Some::create('value');
+
+// disallowed on interface
+Interfaces\Implementation::y();


### PR DESCRIPTION
Similar case as my old PR (https://github.com/spaze/phpstan-disallowed-calls/pull/26) but for interfaces.

Same as before I just added a failing test case. I didn't look for the underlying issue.

-----

Use case: After running into https://github.com/guzzle/psr7/issues/569 I wanted to disallow `Psr\Http\Message\StreamInterface::getContents()` but looks like this isn't supported yet.