### PR TITLE
Bump actions/checkout to v4

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -40,7 +40,7 @@ jobs:
             run: composer lint-8.0
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: OS info
       run: cat /etc/os-release
@@ -75,7 +75,7 @@ jobs:
           - "8.3"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: "Install PHP"
         uses: shivammathur/setup-php@v2
@@ -112,7 +112,7 @@ jobs:
           - windows-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: "Install PHP"
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
Not sure why my dear Dependabot haven't done that yet but I'm all for helping out our future overlords before it's too late.

Did you know you can use @dependabot to update your actions, not just your code? I've updated my article which mentions Dependabot https://www.michalspacek.com/dont-let-security-bugs-catch-you-off-guard#github-dependabot
