### PR TITLE
Remove "because reasons", because reasons

### DIFF
--- a/src/Calls/ShellExecCalls.php
+++ b/src/Calls/ShellExecCalls.php
@@ -69,7 +69,7 @@ class ShellExecCalls implements Rule
 			null,
 			null,
 			$this->disallowedCalls,
-			'Using the backtick operator (`...`) is forbidden because shell_exec() is forbidden, %2$s%3$s'
+			'Using the backtick operator (`...`) is forbidden because shell_exec() is forbidden%2$s%3$s'
 		);
 	}
 

--- a/src/DisallowedAttribute.php
+++ b/src/DisallowedAttribute.php
@@ -67,9 +67,9 @@ class DisallowedAttribute implements DisallowedWithParams
 	}
 
 
-	public function getMessage(): string
+	public function getMessage(): ?string
 	{
-		return $this->message ?? 'because reasons';
+		return $this->message;
 	}
 
 

--- a/src/DisallowedCall.php
+++ b/src/DisallowedCall.php
@@ -82,9 +82,9 @@ class DisallowedCall implements DisallowedWithParams
 	}
 
 
-	public function getMessage(): string
+	public function getMessage(): ?string
 	{
-		return $this->message ?? 'because reasons';
+		return $this->message;
 	}
 
 

--- a/src/DisallowedConstant.php
+++ b/src/DisallowedConstant.php
@@ -58,9 +58,9 @@ class DisallowedConstant implements Disallowed
 	}
 
 
-	public function getMessage(): string
+	public function getMessage(): ?string
 	{
-		return $this->message ?? 'because reasons';
+		return $this->message;
 	}
 
 

--- a/src/DisallowedNamespace.php
+++ b/src/DisallowedNamespace.php
@@ -73,9 +73,9 @@ class DisallowedNamespace implements Disallowed
 	}
 
 
-	public function getMessage(): string
+	public function getMessage(): ?string
 	{
-		return $this->message ?? 'because reasons';
+		return $this->message;
 	}
 
 

--- a/src/Formatter/Formatter.php
+++ b/src/Formatter/Formatter.php
@@ -41,4 +41,16 @@ class Formatter
 		}
 	}
 
+
+	public function formatDisallowedMessage(?string $message): string
+	{
+		if (!$message) {
+			return '.';
+		}
+		if ($message[-1] !== '?' && $message[-1] !== '!') {
+			$message = rtrim($message, '.') . '.';
+		}
+		return ', ' . $message;
+	}
+
 }

--- a/src/RuleErrors/DisallowedAttributeRuleErrors.php
+++ b/src/RuleErrors/DisallowedAttributeRuleErrors.php
@@ -9,6 +9,7 @@ use PHPStan\Rules\RuleError;
 use PHPStan\Rules\RuleErrorBuilder;
 use Spaze\PHPStan\Rules\Disallowed\Allowed\Allowed;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedAttribute;
+use Spaze\PHPStan\Rules\Disallowed\Formatter\Formatter;
 use Spaze\PHPStan\Rules\Disallowed\Identifier\Identifier;
 
 class DisallowedAttributeRuleErrors
@@ -20,11 +21,15 @@ class DisallowedAttributeRuleErrors
 	/** @var Identifier */
 	private $identifier;
 
+	/** @var Formatter */
+	private $formatter;
 
-	public function __construct(Allowed $allowed, Identifier $identifier)
+
+	public function __construct(Allowed $allowed, Identifier $identifier, Formatter $formatter)
 	{
 		$this->allowed = $allowed;
 		$this->identifier = $identifier;
+		$this->formatter = $formatter;
 	}
 
 
@@ -46,9 +51,9 @@ class DisallowedAttributeRuleErrors
 			}
 
 			$errorBuilder = RuleErrorBuilder::message(sprintf(
-				'Attribute %s is forbidden, %s%s',
+				'Attribute %s is forbidden%s%s',
 				$attributeName,
-				$disallowedAttribute->getMessage(),
+				$this->formatter->formatDisallowedMessage($disallowedAttribute->getMessage()),
 				$disallowedAttribute->getAttribute() !== $attributeName ? " [{$attributeName} matches {$disallowedAttribute->getAttribute()}]" : ''
 			));
 			if ($disallowedAttribute->getErrorIdentifier()) {

--- a/src/RuleErrors/DisallowedCallsRuleErrors.php
+++ b/src/RuleErrors/DisallowedCallsRuleErrors.php
@@ -11,6 +11,7 @@ use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\Allowed\Allowed;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCall;
 use Spaze\PHPStan\Rules\Disallowed\File\FilePath;
+use Spaze\PHPStan\Rules\Disallowed\Formatter\Formatter;
 use Spaze\PHPStan\Rules\Disallowed\Identifier\Identifier;
 
 class DisallowedCallsRuleErrors
@@ -25,12 +26,16 @@ class DisallowedCallsRuleErrors
 	/** @var FilePath */
 	private $filePath;
 
+	/** @var Formatter */
+	private $formatter;
 
-	public function __construct(Allowed $allowed, Identifier $identifier, FilePath $filePath)
+
+	public function __construct(Allowed $allowed, Identifier $identifier, FilePath $filePath, Formatter $formatter)
 	{
 		$this->allowed = $allowed;
 		$this->identifier = $identifier;
 		$this->filePath = $filePath;
+		$this->formatter = $formatter;
 	}
 
 
@@ -54,9 +59,9 @@ class DisallowedCallsRuleErrors
 				&& !$this->allowed->isAllowed($scope, isset($node) ? $node->getArgs() : null, $disallowedCall)
 			) {
 				$errorBuilder = RuleErrorBuilder::message(sprintf(
-					$message ?? 'Calling %s is forbidden, %s%s',
+					$message ?? 'Calling %s is forbidden%s%s',
 					($displayName && $displayName !== $name) ? "{$name}() (as {$displayName}())" : "{$name}()",
-					$disallowedCall->getMessage(),
+					$this->formatter->formatDisallowedMessage($disallowedCall->getMessage()),
 					$disallowedCall->getCall() !== $name ? " [{$name}() matches {$disallowedCall->getCall()}()]" : ''
 				));
 				if ($disallowedCall->getErrorIdentifier()) {

--- a/src/RuleErrors/DisallowedConstantRuleErrors.php
+++ b/src/RuleErrors/DisallowedConstantRuleErrors.php
@@ -9,6 +9,7 @@ use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\Allowed\AllowedPath;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedConstant;
+use Spaze\PHPStan\Rules\Disallowed\Formatter\Formatter;
 
 class DisallowedConstantRuleErrors
 {
@@ -17,10 +18,14 @@ class DisallowedConstantRuleErrors
 	/** @var AllowedPath */
 	private $allowedPath;
 
+	/** @var Formatter */
+	private $formatter;
 
-	public function __construct(AllowedPath $allowedPath)
+
+	public function __construct(AllowedPath $allowedPath, Formatter $formatter)
 	{
 		$this->allowedPath = $allowedPath;
+		$this->formatter = $formatter;
 	}
 
 
@@ -37,10 +42,10 @@ class DisallowedConstantRuleErrors
 		foreach ($disallowedConstants as $disallowedConstant) {
 			if ($disallowedConstant->getConstant() === $constant && !$this->allowedPath->isAllowedPath($scope, $disallowedConstant)) {
 				$errorBuilder = RuleErrorBuilder::message(sprintf(
-					'Using %s%s is forbidden, %s',
+					'Using %s%s is forbidden%s',
 					$disallowedConstant->getConstant(),
 					$displayName && $displayName !== $disallowedConstant->getConstant() ? ' (as ' . $displayName . ')' : '',
-					$disallowedConstant->getMessage()
+					$this->formatter->formatDisallowedMessage($disallowedConstant->getMessage())
 				));
 				if ($disallowedConstant->getErrorIdentifier()) {
 					$errorBuilder->identifier($disallowedConstant->getErrorIdentifier());

--- a/src/RuleErrors/DisallowedNamespaceRuleErrors.php
+++ b/src/RuleErrors/DisallowedNamespaceRuleErrors.php
@@ -8,6 +8,7 @@ use PHPStan\Rules\RuleError;
 use PHPStan\Rules\RuleErrorBuilder;
 use Spaze\PHPStan\Rules\Disallowed\Allowed\AllowedPath;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedNamespace;
+use Spaze\PHPStan\Rules\Disallowed\Formatter\Formatter;
 use Spaze\PHPStan\Rules\Disallowed\Identifier\Identifier;
 
 class DisallowedNamespaceRuleErrors
@@ -19,11 +20,15 @@ class DisallowedNamespaceRuleErrors
 	/** @var Identifier */
 	private $identifier;
 
+	/** @var Formatter */
+	private $formatter;
 
-	public function __construct(AllowedPath $allowedPath, Identifier $identifier)
+
+	public function __construct(AllowedPath $allowedPath, Identifier $identifier, Formatter $formatter)
 	{
 		$this->allowedPath = $allowedPath;
 		$this->identifier = $identifier;
+		$this->formatter = $formatter;
 	}
 
 
@@ -46,10 +51,10 @@ class DisallowedNamespaceRuleErrors
 			}
 
 			$errorBuilder = RuleErrorBuilder::message(sprintf(
-				'%s %s is forbidden, %s%s',
+				'%s %s is forbidden%s%s',
 				$description,
 				$namespace,
-				$disallowedNamespace->getMessage(),
+				$this->formatter->formatDisallowedMessage($disallowedNamespace->getMessage()),
 				$disallowedNamespace->getNamespace() !== $namespace ? " [{$namespace} matches {$disallowedNamespace->getNamespace()}]" : ''
 			));
 			if ($disallowedNamespace->getErrorIdentifier()) {

--- a/src/RuleErrors/DisallowedVariableRuleErrors.php
+++ b/src/RuleErrors/DisallowedVariableRuleErrors.php
@@ -9,6 +9,7 @@ use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\Allowed\AllowedPath;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedVariable;
+use Spaze\PHPStan\Rules\Disallowed\Formatter\Formatter;
 
 class DisallowedVariableRuleErrors
 {
@@ -16,10 +17,14 @@ class DisallowedVariableRuleErrors
 	/** @var AllowedPath */
 	private $allowedPath;
 
+	/** @var Formatter */
+	private $formatter;
 
-	public function __construct(AllowedPath $allowedPath)
+
+	public function __construct(AllowedPath $allowedPath, Formatter $formatter)
 	{
 		$this->allowedPath = $allowedPath;
+		$this->formatter = $formatter;
 	}
 
 
@@ -35,9 +40,9 @@ class DisallowedVariableRuleErrors
 		foreach ($disallowedVariables as $disallowedVariable) {
 			if ($disallowedVariable->getVariable() === $variable && !$this->allowedPath->isAllowedPath($scope, $disallowedVariable)) {
 				$errorBuilder = RuleErrorBuilder::message(sprintf(
-					'Using %s is forbidden, %s',
+					'Using %s is forbidden%s',
 					$disallowedVariable->getVariable(),
-					$disallowedVariable->getMessage()
+					$this->formatter->formatDisallowedMessage($disallowedVariable->getMessage())
 				));
 				if ($disallowedVariable->getErrorIdentifier()) {
 					$errorBuilder->identifier($disallowedVariable->getErrorIdentifier());

--- a/src/Usages/ClassConstantUsages.php
+++ b/src/Usages/ClassConstantUsages.php
@@ -105,7 +105,7 @@ class ClassConstantUsages implements Rule
 			} elseif ($type->hasConstant($constant)->no()) {
 				return [
 					RuleErrorBuilder::message(sprintf(
-						'Cannot access constant %s on %s',
+						'Cannot access constant %s on %s.',
 						$constant,
 						$type->describe(VerbosityLevel::getRecommendedLevelByType($type))
 					))->build(),

--- a/tests/Calls/EchoCallsTest.php
+++ b/tests/Calls/EchoCallsTest.php
@@ -29,7 +29,7 @@ class EchoCallsTest extends RuleTestCase
 		$filePath = new FilePath(new FileHelper(__DIR__));
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath($filePath));
 		return new EchoCalls(
-			new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath),
+			new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath, $formatter),
 			new DisallowedCallFactory($formatter, $normalizer, $allowed),
 			[
 				[
@@ -49,7 +49,7 @@ class EchoCallsTest extends RuleTestCase
 		// Based on the configuration above, in this file:
 		$this->analyse([__DIR__ . '/../src/disallowed/functionCalls.php'], [
 			[
-				'Calling echo() is forbidden, because reasons',
+				'Calling echo() is forbidden.',
 				42,
 			],
 		]);

--- a/tests/Calls/EmptyCallsTest.php
+++ b/tests/Calls/EmptyCallsTest.php
@@ -29,7 +29,7 @@ class EmptyCallsTest extends RuleTestCase
 		$filePath = new FilePath(new FileHelper(__DIR__));
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath($filePath));
 		return new EmptyCalls(
-			new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath),
+			new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath, $formatter),
 			new DisallowedCallFactory($formatter, $normalizer, $allowed),
 			[
 				[
@@ -49,7 +49,7 @@ class EmptyCallsTest extends RuleTestCase
 		// Based on the configuration above, in this file:
 		$this->analyse([__DIR__ . '/../src/disallowed/functionCalls.php'], [
 			[
-				'Calling empty() is forbidden, because reasons',
+				'Calling empty() is forbidden.',
 				41,
 			],
 		]);

--- a/tests/Calls/EvalCallsTest.php
+++ b/tests/Calls/EvalCallsTest.php
@@ -29,7 +29,7 @@ class EvalCallsTest extends RuleTestCase
 		$filePath = new FilePath(new FileHelper(__DIR__));
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath($filePath));
 		return new EvalCalls(
-			new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath),
+			new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath, $formatter),
 			new DisallowedCallFactory($formatter, $normalizer, $allowed),
 			[
 				[
@@ -49,7 +49,7 @@ class EvalCallsTest extends RuleTestCase
 		// Based on the configuration above, in this file:
 		$this->analyse([__DIR__ . '/../src/disallowed/functionCalls.php'], [
 			[
-				'Calling eval() is forbidden, because reasons',
+				'Calling eval() is forbidden.',
 				28,
 			],
 		]);

--- a/tests/Calls/ExitDieCallsTest.php
+++ b/tests/Calls/ExitDieCallsTest.php
@@ -29,7 +29,7 @@ class ExitDieCallsTest extends RuleTestCase
 		$filePath = new FilePath(new FileHelper(__DIR__));
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath($filePath));
 		return new ExitDieCalls(
-			new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath),
+			new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath, $formatter),
 			new DisallowedCallFactory($formatter, $normalizer, $allowed),
 			[
 				[
@@ -52,19 +52,19 @@ class ExitDieCallsTest extends RuleTestCase
 		// Based on the configuration above, in this file:
 		$this->analyse([__DIR__ . '/../src/disallowed/functionCalls.php'], [
 			[
-				'Calling die() is forbidden, because reasons',
+				'Calling die() is forbidden.',
 				30,
 			],
 			[
-				'Calling die() is forbidden, because reasons',
+				'Calling die() is forbidden.',
 				33,
 			],
 			[
-				'Calling exit() is forbidden, because reasons',
+				'Calling exit() is forbidden.',
 				36,
 			],
 			[
-				'Calling exit() is forbidden, because reasons',
+				'Calling exit() is forbidden.',
 				39,
 			],
 		]);

--- a/tests/Calls/FunctionCallsAllowInFunctionsTest.php
+++ b/tests/Calls/FunctionCallsAllowInFunctionsTest.php
@@ -29,7 +29,7 @@ class FunctionCallsAllowInFunctionsTest extends RuleTestCase
 		$filePath = new FilePath(new FileHelper(__DIR__));
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath($filePath));
 		return new FunctionCalls(
-			new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath),
+			new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath, $formatter),
 			new DisallowedCallFactory($formatter, $normalizer, $allowed),
 			$this->createReflectionProvider(),
 			[
@@ -56,7 +56,7 @@ class FunctionCallsAllowInFunctionsTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/../libs/Functions.php'], [
 			[
 				// expect this error message:
-				'Calling sha1() is forbidden, because reasons [sha1() matches sha*()]',
+				'Calling sha1() is forbidden. [sha1() matches sha*()]',
 				// on this line:
 				15,
 			],

--- a/tests/Calls/FunctionCallsAllowInMethodsTest.php
+++ b/tests/Calls/FunctionCallsAllowInMethodsTest.php
@@ -29,7 +29,7 @@ class FunctionCallsAllowInMethodsTest extends RuleTestCase
 		$filePath = new FilePath(new FileHelper(__DIR__));
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath($filePath));
 		return new FunctionCalls(
-			new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath),
+			new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath, $formatter),
 			new DisallowedCallFactory($formatter, $normalizer, $allowed),
 			$this->createReflectionProvider(),
 			[
@@ -65,7 +65,7 @@ class FunctionCallsAllowInMethodsTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/../libs/Royale.php'], [
 			[
 				// expect this error message:
-				'Calling sha1() is forbidden, because reasons',
+				'Calling sha1() is forbidden.',
 				// on this line:
 				11,
 			],

--- a/tests/Calls/FunctionCallsDefinedInTest.php
+++ b/tests/Calls/FunctionCallsDefinedInTest.php
@@ -29,7 +29,7 @@ class FunctionCallsDefinedInTest extends RuleTestCase
 		$filePath = new FilePath(new FileHelper(__DIR__), __DIR__);
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath($filePath));
 		return new FunctionCalls(
-			new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath),
+			new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath, $formatter),
 			new DisallowedCallFactory($formatter, $normalizer, $allowed),
 			$this->createReflectionProvider(),
 			[
@@ -67,16 +67,16 @@ class FunctionCallsDefinedInTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/../src/disallowed/functionCallsDefinedIn.php'], [
 			[
 				// expect this error message:
-				'Calling Foo\Bar\Waldo\fred() is forbidden, because reasons [Foo\Bar\Waldo\fred() matches Foo\Bar\Waldo\f*()]',
+				'Calling Foo\Bar\Waldo\fred() is forbidden. [Foo\Bar\Waldo\fred() matches Foo\Bar\Waldo\f*()]',
 				// on this line:
 				5,
 			],
 			[
-				'Calling Foo\Bar\Waldo\foo() is forbidden, because reasons [Foo\Bar\Waldo\foo() matches Foo\Bar\Waldo\f*()]',
+				'Calling Foo\Bar\Waldo\foo() is forbidden. [Foo\Bar\Waldo\foo() matches Foo\Bar\Waldo\f*()]',
 				6,
 			],
 			[
-				'Calling Foo\Bar\Waldo\quux() is forbidden, because reasons [Foo\Bar\Waldo\quux() matches Foo\Bar\Waldo\q*x()]',
+				'Calling Foo\Bar\Waldo\quux() is forbidden. [Foo\Bar\Waldo\quux() matches Foo\Bar\Waldo\q*x()]',
 				13,
 			],
 		]);

--- a/tests/Calls/FunctionCallsInMultipleNamespacesTest.php
+++ b/tests/Calls/FunctionCallsInMultipleNamespacesTest.php
@@ -29,7 +29,7 @@ class FunctionCallsInMultipleNamespacesTest extends RuleTestCase
 		$filePath = new FilePath(new FileHelper(__DIR__));
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath($filePath));
 		return new FunctionCalls(
-			new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath),
+			new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath, $formatter),
 			new DisallowedCallFactory($formatter, $normalizer, $allowed),
 			$this->createReflectionProvider(),
 			[
@@ -55,32 +55,32 @@ class FunctionCallsInMultipleNamespacesTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/../src/FunctionInMultipleNamespaces.php'], [
 			[
 				// expect this error message:
-				'Calling __() (as alias()) is forbidden, use MyNamespace\__ instead',
+				'Calling __() (as alias()) is forbidden, use MyNamespace\__ instead.',
 				// on this line:
 				20,
 			],
 			[
-				'Calling MyNamespace\__() (as __()) is forbidden, ha ha ha nope',
+				'Calling MyNamespace\__() (as __()) is forbidden, ha ha ha nope.',
 				26,
 			],
 			[
-				'Calling printf() is forbidden, because reasons',
+				'Calling printf() is forbidden.',
 				30,
 			],
 			[
-				'Calling printf() is forbidden, because reasons',
+				'Calling printf() is forbidden.',
 				31,
 			],
 			[
-				'Calling MyNamespace\__() (as alias()) is forbidden, ha ha ha nope',
+				'Calling MyNamespace\__() (as alias()) is forbidden, ha ha ha nope.',
 				39,
 			],
 			[
-				'Calling printf() is forbidden, because reasons',
+				'Calling printf() is forbidden.',
 				40,
 			],
 			[
-				'Calling printf() is forbidden, because reasons',
+				'Calling printf() is forbidden.',
 				41,
 			],
 		]);

--- a/tests/Calls/FunctionCallsNamedParamsTest.php
+++ b/tests/Calls/FunctionCallsNamedParamsTest.php
@@ -32,7 +32,7 @@ class FunctionCallsNamedParamsTest extends RuleTestCase
 		$filePath = new FilePath(new FileHelper(__DIR__));
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath($filePath));
 		return new FunctionCalls(
-			new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath),
+			new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath, $formatter),
 			new DisallowedCallFactory($formatter, $normalizer, $allowed),
 			$this->createReflectionProvider(),
 			[
@@ -99,110 +99,110 @@ class FunctionCallsNamedParamsTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/../src/disallowed/functionCallsNamedParams.php'], [
 			[
 				// expect this error message:
-				'Calling Foo\Bar\Waldo\foo() (as foo()) is forbidden, because reasons',
+				'Calling Foo\Bar\Waldo\foo() (as foo()) is forbidden.',
 				// on this line:
 				12,
 			],
 			[
 				// no required param
-				'Calling Foo\Bar\Waldo\bar() (as bar()) is forbidden, because reasons',
+				'Calling Foo\Bar\Waldo\bar() (as bar()) is forbidden.',
 				19,
 			],
 			[
 				// missing $name + second param + $path
-				'Calling Foo\Bar\Waldo\bar() (as bar()) is forbidden, because reasons',
+				'Calling Foo\Bar\Waldo\bar() (as bar()) is forbidden.',
 				20,
 			],
 			[
 				// missing $name + second param + $path
-				'Calling Foo\Bar\Waldo\bar() (as bar()) is forbidden, because reasons',
+				'Calling Foo\Bar\Waldo\bar() (as bar()) is forbidden.',
 				21,
 			],
 			[
 				// missing $name + $path
-				'Calling Foo\Bar\Waldo\bar() (as bar()) is forbidden, because reasons',
+				'Calling Foo\Bar\Waldo\bar() (as bar()) is forbidden.',
 				22,
 			],
 			[
 				// missing $name + $path
-				'Calling Foo\Bar\Waldo\bar() (as bar()) is forbidden, because reasons',
+				'Calling Foo\Bar\Waldo\bar() (as bar()) is forbidden.',
 				23,
 			],
 			[
 				// missing $name
-				'Calling Foo\Bar\Waldo\bar() (as bar()) is forbidden, because reasons',
+				'Calling Foo\Bar\Waldo\bar() (as bar()) is forbidden.',
 				24,
 			],
 			[
-				'Calling Foo\Bar\Waldo\baz() (as baz()) is forbidden, because reasons',
+				'Calling Foo\Bar\Waldo\baz() (as baz()) is forbidden.',
 				29,
 			],
 			[
-				'Calling Foo\Bar\Waldo\baz() (as baz()) is forbidden, because reasons',
+				'Calling Foo\Bar\Waldo\baz() (as baz()) is forbidden.',
 				30,
 			],
 			[
-				'Calling Foo\Bar\Waldo\baz() (as baz()) is forbidden, because reasons',
+				'Calling Foo\Bar\Waldo\baz() (as baz()) is forbidden.',
 				31,
 			],
 			[
-				'Calling Foo\Bar\Waldo\baz() (as baz()) is forbidden, because reasons',
+				'Calling Foo\Bar\Waldo\baz() (as baz()) is forbidden.',
 				32,
 			],
 			[
-				'Calling Foo\Bar\Waldo\waldo() (as waldo()) is forbidden, because reasons',
+				'Calling Foo\Bar\Waldo\waldo() (as waldo()) is forbidden.',
 				35,
 			],
 			[
-				'Calling Foo\Bar\Waldo\waldo() (as waldo()) is forbidden, because reasons',
+				'Calling Foo\Bar\Waldo\waldo() (as waldo()) is forbidden.',
 				36,
 			],
 			[
-				'Calling Foo\Bar\Waldo\waldo() (as waldo()) is forbidden, because reasons',
+				'Calling Foo\Bar\Waldo\waldo() (as waldo()) is forbidden.',
 				37,
 			],
 			[
-				'Calling Foo\Bar\Waldo\waldo() (as waldo()) is forbidden, because reasons',
+				'Calling Foo\Bar\Waldo\waldo() (as waldo()) is forbidden.',
 				38,
 			],
 		]);
 		// Based on the configuration above, no errors in this file:
 		$this->analyse([__DIR__ . '/../src/disallowed-allow/functionCallsNamedParams.php'], [
 			[
-				'Calling Foo\Bar\Waldo\foo() (as foo()) is forbidden, because reasons',
+				'Calling Foo\Bar\Waldo\foo() (as foo()) is forbidden.',
 				12,
 			],
 			[
-				'Calling Foo\Bar\Waldo\foo() (as foo()) is forbidden, because reasons',
+				'Calling Foo\Bar\Waldo\foo() (as foo()) is forbidden.',
 				13,
 			],
 			[
-				'Calling Foo\Bar\Waldo\foo() (as foo()) is forbidden, because reasons',
+				'Calling Foo\Bar\Waldo\foo() (as foo()) is forbidden.',
 				14,
 			],
 			[
 				// second param not 'VALUE'
-				'Calling Foo\Bar\Waldo\baz() (as baz()) is forbidden, because reasons',
+				'Calling Foo\Bar\Waldo\baz() (as baz()) is forbidden.',
 				29,
 			],
 			[
 				// second param not 'VALUE'
-				'Calling Foo\Bar\Waldo\baz() (as baz()) is forbidden, because reasons',
+				'Calling Foo\Bar\Waldo\baz() (as baz()) is forbidden.',
 				31,
 			],
 			[
 				// not $value param
-				'Calling Foo\Bar\Waldo\waldo() (as waldo()) is forbidden, because reasons',
+				'Calling Foo\Bar\Waldo\waldo() (as waldo()) is forbidden.',
 				35,
 			],
 			[
 				// not $value param
-				'Calling Foo\Bar\Waldo\waldo() (as waldo()) is forbidden, because reasons',
+				'Calling Foo\Bar\Waldo\waldo() (as waldo()) is forbidden.',
 				36,
 			],
 			[
 				// $value is not 'VALUE'
-				'Calling Foo\Bar\Waldo\waldo() (as waldo()) is forbidden, because reasons',
+				'Calling Foo\Bar\Waldo\waldo() (as waldo()) is forbidden.',
 				37,
 			],
 		]);

--- a/tests/Calls/FunctionCallsTest.php
+++ b/tests/Calls/FunctionCallsTest.php
@@ -30,7 +30,7 @@ class FunctionCallsTest extends RuleTestCase
 		$filePath = new FilePath(new FileHelper(__DIR__));
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath($filePath));
 		return new FunctionCalls(
-			new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath),
+			new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath, $formatter),
 			new DisallowedCallFactory($formatter, $normalizer, $allowed),
 			$this->createReflectionProvider(),
 			[
@@ -221,85 +221,85 @@ class FunctionCallsTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/../src/disallowed/functionCalls.php'], [
 			[
 				// expect this error message:
-				'Calling var_dump() is forbidden, use logger instead',
+				'Calling var_dump() is forbidden, use logger instead.',
 				// on this line:
 				7,
 				'See docs',
 			],
 			[
-				'Calling print_R() is forbidden, nope [print_R() matches print_r()]',
+				'Calling print_R() is forbidden, nope. [print_R() matches print_r()]',
 				8,
 			],
 			[
-				'Calling printf() is forbidden, because reasons',
+				'Calling printf() is forbidden.',
 				9,
 			],
 			[
-				'Calling Foo\Bar\waldo() is forbidden, whoa, a namespace',
+				'Calling Foo\Bar\waldo() is forbidden, whoa, a namespace.',
 				10,
 			],
 			[
-				'Calling Foo\Bar\waldo() (as waldo()) is forbidden, whoa, a namespace',
+				'Calling Foo\Bar\waldo() (as waldo()) is forbidden, whoa, a namespace.',
 				11,
 			],
 			[
-				'Calling shell_exec() is forbidden, because reasons [shell_exec() matches shell_*()]',
+				'Calling shell_exec() is forbidden. [shell_exec() matches shell_*()]',
 				12,
 			],
 			[
-				'Calling exec() is forbidden, because reasons [exec() matches exe*()]',
+				'Calling exec() is forbidden. [exec() matches exe*()]',
 				13,
 			],
 			[
-				'Calling print_r() is forbidden, nope',
+				'Calling print_r() is forbidden, nope.',
 				25,
 			],
 			[
-				'Calling hash() is forbidden, MD4 very bad',
+				'Calling hash() is forbidden, MD4 very bad.',
 				49,
 			],
 			[
-				'Calling hash() is forbidden, MD5 bad',
+				'Calling hash() is forbidden, MD5 bad.',
 				50,
 			],
 			[
-				'Calling hash() is forbidden, MD5 bad',
+				'Calling hash() is forbidden, MD5 bad.',
 				51,
 			],
 			[
-				'Calling hash() is forbidden, SHA-1 bad soon™',
+				'Calling hash() is forbidden, SHA-1 bad soon™.',
 				52,
 			],
 			[
-				'Calling hash() is forbidden, SHA-1 bad SOON™',
+				'Calling hash() is forbidden, SHA-1 bad SOON™.',
 				53,
 			],
 			[
-				'Calling setcookie() is forbidden, because reasons',
+				'Calling setcookie() is forbidden.',
 				59,
 			],
 			[
-				'Calling header() is forbidden, because reasons',
+				'Calling header() is forbidden.',
 				64,
 			],
 			[
-				'Calling htmlspecialchars() is forbidden, because reasons',
+				'Calling htmlspecialchars() is forbidden.',
 				69,
 			],
 			[
-				'Calling htmlspecialchars() is forbidden, because reasons',
+				'Calling htmlspecialchars() is forbidden.',
 				70,
 			],
 			[
-				'Calling htmlspecialchars() is forbidden, because reasons',
+				'Calling htmlspecialchars() is forbidden.',
 				71,
 			],
 			[
-				'Calling htmlspecialchars() is forbidden, because reasons',
+				'Calling htmlspecialchars() is forbidden.',
 				72,
 			],
 			[
-				'Calling htmlspecialchars() is forbidden, because reasons',
+				'Calling htmlspecialchars() is forbidden.',
 				73,
 			],
 			[
@@ -311,38 +311,38 @@ class FunctionCallsTest extends RuleTestCase
 				83,
 			],
 			[
-				'Calling Foo\Bar\Waldo\config() is forbidden, because reasons',
+				'Calling Foo\Bar\Waldo\config() is forbidden.',
 				91,
 			],
 		]);
 		// Based on the configuration above, no errors in this file:
 		$this->analyse([__DIR__ . '/../src/disallowed-allow/functionCalls.php'], [
 			[
-				'Calling Foo\Bar\waldo() (as waldo()) is forbidden, whoa, a namespace',
+				'Calling Foo\Bar\waldo() (as waldo()) is forbidden, whoa, a namespace.',
 				11,
 			],
 			[
-				'Calling setcookie() is forbidden, because reasons',
+				'Calling setcookie() is forbidden.',
 				59,
 			],
 			[
-				'Calling setcookie() is forbidden, because reasons',
+				'Calling setcookie() is forbidden.',
 				60,
 			],
 			[
-				'Calling header() is forbidden, because reasons',
+				'Calling header() is forbidden.',
 				64,
 			],
 			[
-				'Calling header() is forbidden, because reasons',
+				'Calling header() is forbidden.',
 				65,
 			],
 			[
-				'Calling htmlspecialchars() is forbidden, because reasons',
+				'Calling htmlspecialchars() is forbidden.',
 				69,
 			],
 			[
-				'Calling htmlspecialchars() is forbidden, because reasons',
+				'Calling htmlspecialchars() is forbidden.',
 				70,
 			],
 		]);

--- a/tests/Calls/FunctionCallsUnsupportedParamConfigTest.php
+++ b/tests/Calls/FunctionCallsUnsupportedParamConfigTest.php
@@ -30,7 +30,7 @@ class FunctionCallsUnsupportedParamConfigTest extends PHPStanTestCase
 		$filePath = new FilePath(new FileHelper(__DIR__));
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath($filePath));
 		new FunctionCalls(
-			new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath),
+			new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath, $formatter),
 			new DisallowedCallFactory($formatter, $normalizer, $allowed),
 			$this->createReflectionProvider(),
 			[

--- a/tests/Calls/MethodCallsDefinedInTest.php
+++ b/tests/Calls/MethodCallsDefinedInTest.php
@@ -32,7 +32,7 @@ class MethodCallsDefinedInTest extends RuleTestCase
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath($filePath));
 		return new MethodCalls(
 			new DisallowedMethodRuleErrors(
-				new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath),
+				new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath, $formatter),
 				new TypeResolver(),
 				$formatter
 			),
@@ -57,12 +57,12 @@ class MethodCallsDefinedInTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/../src/disallowed/methodCallsDefinedIn.php'], [
 			[
 				// expect this error message:
-				'Calling Waldo\Quux\Blade::andSorcery() is forbidden, because reasons [Waldo\Quux\Blade::andSorcery() matches *()]',
+				'Calling Waldo\Quux\Blade::andSorcery() is forbidden. [Waldo\Quux\Blade::andSorcery() matches *()]',
 				// on this line:
 				10,
 			],
 			[
-				'Calling Waldo\Quux\Blade::server() is forbidden, because reasons [Waldo\Quux\Blade::server() matches *()]',
+				'Calling Waldo\Quux\Blade::server() is forbidden. [Waldo\Quux\Blade::server() matches *()]',
 				11,
 			],
 		]);

--- a/tests/Calls/MethodCallsTest.php
+++ b/tests/Calls/MethodCallsTest.php
@@ -32,7 +32,7 @@ class MethodCallsTest extends RuleTestCase
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath($filePath));
 		return new MethodCalls(
 			new DisallowedMethodRuleErrors(
-				new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath),
+				new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath, $formatter),
 				new TypeResolver(),
 				$formatter
 			),
@@ -156,87 +156,87 @@ class MethodCallsTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/../src/disallowed/methodCalls.php'], [
 			[
 				// expect this error message:
-				"Calling Waldo\Quux\Blade::runner() is forbidden, I've seen tests you people wouldn't believe [Waldo\Quux\Blade::runner() matches Waldo\Quux\Blade::run*()]",
+				"Calling Waldo\Quux\Blade::runner() is forbidden, I've seen tests you people wouldn't believe. [Waldo\Quux\Blade::runner() matches Waldo\Quux\Blade::run*()]",
 				// on this line:
 				10,
 			],
 			[
-				"Calling Waldo\Quux\Blade::runner() is forbidden, I've seen tests you people wouldn't believe [Waldo\Quux\Blade::runner() matches Waldo\Quux\Blade::run*()]",
+				"Calling Waldo\Quux\Blade::runner() is forbidden, I've seen tests you people wouldn't believe. [Waldo\Quux\Blade::runner() matches Waldo\Quux\Blade::run*()]",
 				11,
 			],
 			[
-				"Calling Waldo\Quux\Blade::runner() is forbidden, I've seen tests you people wouldn't believe [Waldo\Quux\Blade::runner() matches Waldo\Quux\Blade::run*()]",
+				"Calling Waldo\Quux\Blade::runner() is forbidden, I've seen tests you people wouldn't believe. [Waldo\Quux\Blade::runner() matches Waldo\Quux\Blade::run*()]",
 				14,
 			],
 			[
-				'Calling Inheritance\Base::x() (as Inheritance\Sub::x()) is forbidden, Base::x*() methods are dangerous [Inheritance\Base::x() matches Inheritance\Base::x*()]',
+				'Calling Inheritance\Base::x() (as Inheritance\Sub::x()) is forbidden, Base::x*() methods are dangerous. [Inheritance\Base::x() matches Inheritance\Base::x*()]',
 				22,
 			],
 			[
-				'Calling Traits\TestTrait::x() (as Traits\TestClass::x()) is forbidden, all TestTrait methods are dangerous [Traits\TestTrait::x() matches Traits\TestTrait::*()]',
+				'Calling Traits\TestTrait::x() (as Traits\TestClass::x()) is forbidden, all TestTrait methods are dangerous. [Traits\TestTrait::x() matches Traits\TestTrait::*()]',
 				26,
 			],
 			[
-				'Calling Traits\TestTrait::y() (as Traits\AnotherTestClass::y()) is forbidden, all TestTrait methods are dangerous [Traits\TestTrait::y() matches Traits\TestTrait::*()]',
+				'Calling Traits\TestTrait::y() (as Traits\AnotherTestClass::y()) is forbidden, all TestTrait methods are dangerous. [Traits\TestTrait::y() matches Traits\TestTrait::*()]',
 				28,
 			],
 			[
-				'Calling Traits\AnotherTestClass::zzTop() is forbidden, method AnotherTestClass::zzTop() is dangerous',
+				'Calling Traits\AnotherTestClass::zzTop() is forbidden, method AnotherTestClass::zzTop() is dangerous.',
 				29,
 			],
 			[
-				'Calling PhpOption\None::getIterator() is forbidden, no PhpOption',
+				'Calling PhpOption\None::getIterator() is forbidden, no PhpOption.',
 				46,
 			],
 			[
-				'Calling PhpOption\Some::getIterator() is forbidden, no PhpOption',
+				'Calling PhpOption\Some::getIterator() is forbidden, no PhpOption.',
 				52,
 			],
 			[
-				'Calling DateTime::format() is forbidden, why too kay',
+				'Calling DateTime::format() is forbidden, why too kay.',
 				55,
 				'2038 is approaching fast',
 			],
 			[
-				'Calling Waldo\Quux\Blade::movie() is forbidden, was good',
+				'Calling Waldo\Quux\Blade::movie() is forbidden, was good.',
 				60,
 			],
 			[
-				'Calling Waldo\Quux\Blade::movie() is forbidden, was good',
+				'Calling Waldo\Quux\Blade::movie() is forbidden, was good.',
 				61,
 			],
 			[
-				'Calling Waldo\Quux\Blade::Sequel() is forbidden, too [Waldo\Quux\Blade::Sequel() matches Waldo\Quux\Blade::sequel()]',
+				'Calling Waldo\Quux\Blade::Sequel() is forbidden, too. [Waldo\Quux\Blade::Sequel() matches Waldo\Quux\Blade::sequel()]',
 				62,
 			],
 			[
-				'Calling Waldo\Quux\Blade::Sequel() is forbidden, too [Waldo\Quux\Blade::Sequel() matches Waldo\Quux\Blade::sequel()]',
+				'Calling Waldo\Quux\Blade::Sequel() is forbidden, too. [Waldo\Quux\Blade::Sequel() matches Waldo\Quux\Blade::sequel()]',
 				63,
 			],
 			[
-				'Calling Waldo\Quux\Blade::trinity() is forbidden, holy trinity [Waldo\Quux\Blade::trinity() matches Waldo\Quux\Blade::Trinity()]',
+				'Calling Waldo\Quux\Blade::trinity() is forbidden, holy trinity. [Waldo\Quux\Blade::trinity() matches Waldo\Quux\Blade::Trinity()]',
 				64,
 			],
 			[
-				'Calling Waldo\Quux\Blade::trinity() is forbidden, holy trinity [Waldo\Quux\Blade::trinity() matches Waldo\Quux\Blade::Trinity()]',
+				'Calling Waldo\Quux\Blade::trinity() is forbidden, holy trinity. [Waldo\Quux\Blade::trinity() matches Waldo\Quux\Blade::Trinity()]',
 				65,
 			],
 			[
-				'Calling Waldo\Quux\Blade::andSorcery() is forbidden, use magic',
+				'Calling Waldo\Quux\Blade::andSorcery() is forbidden, use magic.',
 				68,
 			],
 			[
-				'Calling Interfaces\BaseInterface::x() (as Interfaces\Implementation::x()) is forbidden, BaseInterface::x*() methods are dangerous [Interfaces\BaseInterface::x() matches Interfaces\BaseInterface::x*()]',
+				'Calling Interfaces\BaseInterface::x() (as Interfaces\Implementation::x()) is forbidden, BaseInterface::x*() methods are dangerous. [Interfaces\BaseInterface::x() matches Interfaces\BaseInterface::x*()]',
 				74,
 			],
 		]);
 		$this->analyse([__DIR__ . '/../src/disallowed-allow/methodCalls.php'], [
 			[
-				"Calling Waldo\Quux\Blade::runner() is forbidden, I've seen tests you people wouldn't believe [Waldo\Quux\Blade::runner() matches Waldo\Quux\Blade::run*()]",
+				"Calling Waldo\Quux\Blade::runner() is forbidden, I've seen tests you people wouldn't believe. [Waldo\Quux\Blade::runner() matches Waldo\Quux\Blade::run*()]",
 				10,
 			],
 			[
-				"Calling Waldo\Quux\Blade::runner() is forbidden, I've seen tests you people wouldn't believe [Waldo\Quux\Blade::runner() matches Waldo\Quux\Blade::run*()]",
+				"Calling Waldo\Quux\Blade::runner() is forbidden, I've seen tests you people wouldn't believe. [Waldo\Quux\Blade::runner() matches Waldo\Quux\Blade::run*()]",
 				11,
 			],
 		]);

--- a/tests/Calls/NewCallsDefinedInTest.php
+++ b/tests/Calls/NewCallsDefinedInTest.php
@@ -29,7 +29,7 @@ class NewCallsDefinedInTest extends RuleTestCase
 		$filePath = new FilePath(new FileHelper(__DIR__), __DIR__ . '/..');
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath($filePath));
 		return new NewCalls(
-			new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath),
+			new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath, $formatter),
 			new DisallowedCallFactory($formatter, $normalizer, $allowed),
 			[
 				[
@@ -51,7 +51,7 @@ class NewCallsDefinedInTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/../src/disallowed/methodCallsDefinedIn.php'], [
 			[
 				// expect this error message:
-				'Calling Waldo\Quux\Blade::__construct() is forbidden, because reasons [Waldo\Quux\Blade::__construct() matches *()]',
+				'Calling Waldo\Quux\Blade::__construct() is forbidden. [Waldo\Quux\Blade::__construct() matches *()]',
 				// on this line:
 				9,
 			],

--- a/tests/Calls/NewCallsTest.php
+++ b/tests/Calls/NewCallsTest.php
@@ -29,7 +29,7 @@ class NewCallsTest extends RuleTestCase
 		$filePath = new FilePath(new FileHelper(__DIR__));
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath($filePath));
 		return new NewCalls(
-			new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath),
+			new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath, $formatter),
 			new DisallowedCallFactory($formatter, $normalizer, $allowed),
 			[
 				[
@@ -77,23 +77,23 @@ class NewCallsTest extends RuleTestCase
 		// Based on the configuration above, in this file:
 		$this->analyse([__DIR__ . '/../src/disallowed/methodCalls.php'], [
 			[
-				'Calling Inheritance\Base::__construct() (as Inheritance\Sub::__construct()) is forbidden, all your base are belong to us',
+				'Calling Inheritance\Base::__construct() (as Inheritance\Sub::__construct()) is forbidden, all your base are belong to us.',
 				19,
 			],
 			[
-				'Calling Constructor\ClassWithConstructor::__construct() is forbidden, class ClassWithConstructor should not be created',
+				'Calling Constructor\ClassWithConstructor::__construct() is forbidden, class ClassWithConstructor should not be created.',
 				32,
 			],
 			[
-				'Calling Constructor\ClassWithoutConstructor::__construct() is forbidden, class ClassWithoutConstructor should not be created',
+				'Calling Constructor\ClassWithoutConstructor::__construct() is forbidden, class ClassWithoutConstructor should not be created.',
 				34,
 			],
 			[
-				'Calling Constructor\ClassWithoutConstructor::__construct() is forbidden, class ClassWithoutConstructor should not be created',
+				'Calling Constructor\ClassWithoutConstructor::__construct() is forbidden, class ClassWithoutConstructor should not be created.',
 				36,
 			],
 			[
-				'Calling DateTime::__construct() is forbidden, no future',
+				'Calling DateTime::__construct() is forbidden, no future.',
 				57,
 			],
 		]);

--- a/tests/Calls/PrintCallsTest.php
+++ b/tests/Calls/PrintCallsTest.php
@@ -29,7 +29,7 @@ class PrintCallsTest extends RuleTestCase
 		$filePath = new FilePath(new FileHelper(__DIR__));
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath($filePath));
 		return new PrintCalls(
-			new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath),
+			new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath, $formatter),
 			new DisallowedCallFactory($formatter, $normalizer, $allowed),
 			[
 				[
@@ -49,7 +49,7 @@ class PrintCallsTest extends RuleTestCase
 		// Based on the configuration above, in this file:
 		$this->analyse([__DIR__ . '/../src/disallowed/functionCalls.php'], [
 			[
-				'Calling print() is forbidden, because reasons',
+				'Calling print() is forbidden.',
 				43,
 			],
 		]);

--- a/tests/Calls/ShellExecCallsTest.php
+++ b/tests/Calls/ShellExecCallsTest.php
@@ -29,7 +29,7 @@ class ShellExecCallsTest extends RuleTestCase
 		$filePath = new FilePath(new FileHelper(__DIR__));
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath($filePath));
 		return new ShellExecCalls(
-			new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath),
+			new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath, $formatter),
 			new DisallowedCallFactory($formatter, $normalizer, $allowed),
 			[
 				[
@@ -49,7 +49,7 @@ class ShellExecCallsTest extends RuleTestCase
 		// Based on the configuration above, in this file:
 		$this->analyse([__DIR__ . '/../src/disallowed/functionCalls.php'], [
 			[
-				'Using the backtick operator (`...`) is forbidden because shell_exec() is forbidden, because reasons [shell_exec() matches shell_*()]',
+				'Using the backtick operator (`...`) is forbidden because shell_exec() is forbidden. [shell_exec() matches shell_*()]',
 				46,
 			],
 		]);

--- a/tests/Calls/StaticCallsTest.php
+++ b/tests/Calls/StaticCallsTest.php
@@ -32,7 +32,7 @@ class StaticCallsTest extends RuleTestCase
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath($filePath));
 		return new StaticCalls(
 			new DisallowedMethodRuleErrors(
-				new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath),
+				new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath, $formatter),
 				new TypeResolver(),
 				$formatter
 			),
@@ -58,7 +58,7 @@ class StaticCallsTest extends RuleTestCase
 				],
 				[
 					'method' => 'Fiction\Pulp\Royale::WithoutCheese',
-					'message' => 'a Quarter Pounder without Cheese?',
+					'message' => 'a Quarter Pounder without Cheese!',
 					'allowIn' => [
 						'../src/disallowed-allow/*.php',
 						'../src/*-allow/*.*',
@@ -154,53 +154,53 @@ class StaticCallsTest extends RuleTestCase
 				9,
 			],
 			[
-				'Calling Fiction\Pulp\Royale::withoutCheese() is forbidden, a Quarter Pounder without Cheese? [Fiction\Pulp\Royale::withoutCheese() matches Fiction\Pulp\Royale::WithoutCheese()]',
+				'Calling Fiction\Pulp\Royale::withoutCheese() is forbidden, a Quarter Pounder without Cheese! [Fiction\Pulp\Royale::withoutCheese() matches Fiction\Pulp\Royale::WithoutCheese()]',
 				12,
 			],
 			[
-				'Calling Fiction\Pulp\Royale::withoutCheese() is forbidden, a Quarter Pounder without Cheese? [Fiction\Pulp\Royale::withoutCheese() matches Fiction\Pulp\Royale::WithoutCheese()]',
+				'Calling Fiction\Pulp\Royale::withoutCheese() is forbidden, a Quarter Pounder without Cheese! [Fiction\Pulp\Royale::withoutCheese() matches Fiction\Pulp\Royale::WithoutCheese()]',
 				14,
 			],
 			[
-				'Calling Fiction\Pulp\Royale::withoutCheese() is forbidden, a Quarter Pounder without Cheese? [Fiction\Pulp\Royale::withoutCheese() matches Fiction\Pulp\Royale::WithoutCheese()]',
+				'Calling Fiction\Pulp\Royale::withoutCheese() is forbidden, a Quarter Pounder without Cheese! [Fiction\Pulp\Royale::withoutCheese() matches Fiction\Pulp\Royale::WithoutCheese()]',
 				18,
 			],
 			[
-				'Calling Inheritance\Base::woofer() (as Inheritance\Sub::woofer()) is forbidden, method Base::woofer() is dangerous [Inheritance\Base::woofer() matches Inheritance\Base::w*f*r()]',
+				'Calling Inheritance\Base::woofer() (as Inheritance\Sub::woofer()) is forbidden, method Base::woofer() is dangerous. [Inheritance\Base::woofer() matches Inheritance\Base::w*f*r()]',
 				28,
 			],
 			[
-				'Calling Traits\TestTrait::z() (as Traits\TestClass::z()) is forbidden, method TestTrait::z() is dangerous',
+				'Calling Traits\TestTrait::z() (as Traits\TestClass::z()) is forbidden, method TestTrait::z() is dangerous.',
 				31,
 			],
 			[
-				'Calling Traits\AnotherTestClass::zz() is forbidden, method AnotherTestClass::zz() is dangerous',
+				'Calling Traits\AnotherTestClass::zz() is forbidden, method AnotherTestClass::zz() is dangerous.',
 				32,
 			],
 			[
-				'Calling PhpOption\Option::fromArraysValue() is forbidden, do not use PhpOption [PhpOption\Option::fromArraysValue() matches PhpOption\Option::*()]',
+				'Calling PhpOption\Option::fromArraysValue() is forbidden, do not use PhpOption. [PhpOption\Option::fromArraysValue() matches PhpOption\Option::*()]',
 				35,
 			],
 			[
-				'Calling PhpOption\None::create() is forbidden, do not use PhpOption [PhpOption\None::create() matches PhpOption\None::*()]',
+				'Calling PhpOption\None::create() is forbidden, do not use PhpOption. [PhpOption\None::create() matches PhpOption\None::*()]',
 				36,
 			],
 			[
-				'Calling PhpOption\Some::create() is forbidden, do not use PhpOption',
+				'Calling PhpOption\Some::create() is forbidden, do not use PhpOption.',
 				37,
 			],
 			[
-				'Calling Interfaces\BaseInterface::y() (as Interfaces\Implementation::y()) is forbidden, method BaseInterface::y() is dangerous [Interfaces\BaseInterface::y() matches Interfaces\BaseInterface::y*()]',
+				'Calling Interfaces\BaseInterface::y() (as Interfaces\Implementation::y()) is forbidden, method BaseInterface::y() is dangerous. [Interfaces\BaseInterface::y() matches Interfaces\BaseInterface::y*()]',
 				40,
 			],
 		]);
 		$this->analyse([__DIR__ . '/../src/disallowed-allow/staticCalls.php'], [
 			[
-				'Calling Fiction\Pulp\Royale::withoutCheese() is forbidden, a Quarter Pounder without Cheese? [Fiction\Pulp\Royale::withoutCheese() matches Fiction\Pulp\Royale::WithoutCheese()]',
+				'Calling Fiction\Pulp\Royale::withoutCheese() is forbidden, a Quarter Pounder without Cheese! [Fiction\Pulp\Royale::withoutCheese() matches Fiction\Pulp\Royale::WithoutCheese()]',
 				18,
 			],
 			[
-				'Calling Fiction\Pulp\Royale::withoutCheese() is forbidden, a Quarter Pounder without Cheese? [Fiction\Pulp\Royale::withoutCheese() matches Fiction\Pulp\Royale::WithoutCheese()]',
+				'Calling Fiction\Pulp\Royale::withoutCheese() is forbidden, a Quarter Pounder without Cheese! [Fiction\Pulp\Royale::withoutCheese() matches Fiction\Pulp\Royale::WithoutCheese()]',
 				21,
 			],
 		]);

--- a/tests/Configs/DangerousConfigEvalCallsTest.php
+++ b/tests/Configs/DangerousConfigEvalCallsTest.php
@@ -33,7 +33,7 @@ class DangerousConfigEvalCallsTest extends RuleTestCase
 		$filePath = new FilePath(new FileHelper(__DIR__));
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath($filePath));
 		return new EvalCalls(
-			new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath),
+			new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath, $formatter),
 			new DisallowedCallFactory($formatter, $normalizer, $allowed),
 			$config['parameters']['disallowedFunctionCalls']
 		);
@@ -45,7 +45,7 @@ class DangerousConfigEvalCallsTest extends RuleTestCase
 		// Based on the configuration above, in this file:
 		$this->analyse([__DIR__ . '/../src/configs/dangerousCalls.php'], [
 			// expect these error messages, on these lines:
-			['Calling eval() is forbidden, eval is evil, please write more code and do not use eval()', 6],
+			['Calling eval() is forbidden, eval is evil, please write more code and do not use eval().', 6],
 		]);
 	}
 

--- a/tests/Configs/DangerousConfigFunctionCallsTest.php
+++ b/tests/Configs/DangerousConfigFunctionCallsTest.php
@@ -33,7 +33,7 @@ class DangerousConfigFunctionCallsTest extends RuleTestCase
 		$filePath = new FilePath(new FileHelper(__DIR__));
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath($filePath));
 		return new FunctionCalls(
-			new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath),
+			new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath, $formatter),
 			new DisallowedCallFactory($formatter, $normalizer, $allowed),
 			$this->createReflectionProvider(),
 			$config['parameters']['disallowedFunctionCalls']
@@ -46,25 +46,25 @@ class DangerousConfigFunctionCallsTest extends RuleTestCase
 		// Based on the configuration above, in this file:
 		$this->analyse([__DIR__ . '/../src/configs/dangerousCalls.php'], [
 			// expect these error messages, on these lines:
-			['Calling apache_setenv() is forbidden, might overwrite existing variables', 4],
-			['Calling dl() is forbidden, removed from most SAPIs, might load untrusted code', 5],
-			['Calling extract() is forbidden, do not use extract() and especially not on untrusted data', 7],
-			['Calling posix_getpwuid() is forbidden, might reveal system user information', 8],
-			['Calling posix_kill() is forbidden, do not send signals to processes from the script', 9],
-			['Calling posix_mkfifo() is forbidden, do not create named pipes in the script', 10],
-			['Calling posix_mknod() is forbidden, do not create special files in the script', 11],
-			['Calling highlight_file() is forbidden, might reveal source code or config files', 12],
-			['Calling show_source() is forbidden, might reveal source code or config files (alias of highlight_file())', 13],
-			['Calling pfsockopen() is forbidden, use fsockopen() to create non-persistent socket connections', 14],
-			['Calling print_r() is forbidden, use some logger instead', 15],
-			['Calling print_r() is forbidden, use some logger instead', 17],
-			['Calling proc_nice() is forbidden, changes the priority of the current process', 18],
-			['Calling putenv() is forbidden, might overwrite existing variables', 19],
-			['Calling socket_create_listen() is forbidden, do not accept new socket connections in the PHP script', 20],
-			['Calling socket_listen() is forbidden, do not accept new socket connections in the PHP script', 21],
-			['Calling var_dump() is forbidden, use some logger instead', 22],
-			['Calling var_export() is forbidden, use some logger instead', 23],
-			['Calling var_export() is forbidden, use some logger instead', 25],
+			['Calling apache_setenv() is forbidden, might overwrite existing variables.', 4],
+			['Calling dl() is forbidden, removed from most SAPIs, might load untrusted code.', 5],
+			['Calling extract() is forbidden, do not use extract() and especially not on untrusted data.', 7],
+			['Calling posix_getpwuid() is forbidden, might reveal system user information.', 8],
+			['Calling posix_kill() is forbidden, do not send signals to processes from the script.', 9],
+			['Calling posix_mkfifo() is forbidden, do not create named pipes in the script.', 10],
+			['Calling posix_mknod() is forbidden, do not create special files in the script.', 11],
+			['Calling highlight_file() is forbidden, might reveal source code or config files.', 12],
+			['Calling show_source() is forbidden, might reveal source code or config files (alias of highlight_file()).', 13],
+			['Calling pfsockopen() is forbidden, use fsockopen() to create non-persistent socket connections.', 14],
+			['Calling print_r() is forbidden, use some logger instead.', 15],
+			['Calling print_r() is forbidden, use some logger instead.', 17],
+			['Calling proc_nice() is forbidden, changes the priority of the current process.', 18],
+			['Calling putenv() is forbidden, might overwrite existing variables.', 19],
+			['Calling socket_create_listen() is forbidden, do not accept new socket connections in the PHP script.', 20],
+			['Calling socket_listen() is forbidden, do not accept new socket connections in the PHP script.', 21],
+			['Calling var_dump() is forbidden, use some logger instead.', 22],
+			['Calling var_export() is forbidden, use some logger instead.', 23],
+			['Calling var_export() is forbidden, use some logger instead.', 25],
 		]);
 	}
 

--- a/tests/Configs/ExecutionConfigFunctionCallsTest.php
+++ b/tests/Configs/ExecutionConfigFunctionCallsTest.php
@@ -33,7 +33,7 @@ class ExecutionConfigFunctionCallsTest extends RuleTestCase
 		$filePath = new FilePath(new FileHelper(__DIR__));
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath($filePath));
 		return new FunctionCalls(
-			new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath),
+			new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath, $formatter),
 			new DisallowedCallFactory($formatter, $normalizer, $allowed),
 			$this->createReflectionProvider(),
 			$config['parameters']['disallowedFunctionCalls']
@@ -46,13 +46,13 @@ class ExecutionConfigFunctionCallsTest extends RuleTestCase
 		// Based on the configuration above, in this file:
 		$this->analyse([__DIR__ . '/../src/configs/executionCalls.php'], [
 			// expect these error messages, on these lines:
-			['Calling exec() is forbidden, because reasons', 4],
-			['Calling passthru() is forbidden, because reasons', 5],
-			['Calling proc_open() is forbidden, because reasons', 7],
-			['Calling shell_exec() is forbidden, because reasons', 8],
-			['Calling system() is forbidden, because reasons', 10],
-			['Calling pcntl_exec() is forbidden, because reasons', 11],
-			['Calling popen() is forbidden, because reasons', 12],
+			['Calling exec() is forbidden.', 4],
+			['Calling passthru() is forbidden.', 5],
+			['Calling proc_open() is forbidden.', 7],
+			['Calling shell_exec() is forbidden.', 8],
+			['Calling system() is forbidden.', 10],
+			['Calling pcntl_exec() is forbidden.', 11],
+			['Calling popen() is forbidden.', 12],
 		]);
 	}
 

--- a/tests/Configs/ExecutionConfigShellExecCallsTest.php
+++ b/tests/Configs/ExecutionConfigShellExecCallsTest.php
@@ -33,7 +33,7 @@ class ExecutionConfigShellExecCallsTest extends RuleTestCase
 		$filePath = new FilePath(new FileHelper(__DIR__));
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath($filePath));
 		return new ShellExecCalls(
-			new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath),
+			new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath, $formatter),
 			new DisallowedCallFactory($formatter, $normalizer, $allowed),
 			$config['parameters']['disallowedFunctionCalls']
 		);
@@ -45,7 +45,7 @@ class ExecutionConfigShellExecCallsTest extends RuleTestCase
 		// Based on the configuration above, in this file:
 		$this->analyse([__DIR__ . '/../src/configs/executionCalls.php'], [
 			// expect these error messages, on these lines:
-			['Using the backtick operator (`...`) is forbidden because shell_exec() is forbidden, because reasons', 9],
+			['Using the backtick operator (`...`) is forbidden because shell_exec() is forbidden.', 9],
 		]);
 	}
 

--- a/tests/Configs/InsecureConfigFunctionCallsTest.php
+++ b/tests/Configs/InsecureConfigFunctionCallsTest.php
@@ -33,7 +33,7 @@ class InsecureConfigFunctionCallsTest extends RuleTestCase
 		$filePath = new FilePath(new FileHelper(__DIR__));
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath($filePath));
 		return new FunctionCalls(
-			new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath),
+			new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath, $formatter),
 			new DisallowedCallFactory($formatter, $normalizer, $allowed),
 			$this->createReflectionProvider(),
 			$config['parameters']['disallowedFunctionCalls']
@@ -46,25 +46,25 @@ class InsecureConfigFunctionCallsTest extends RuleTestCase
 		// Based on the configuration above, in this file:
 		$this->analyse([__DIR__ . '/../src/configs/insecureCalls.php'], [
 			// expect these error messages, on these lines:
-			['Calling md5() is forbidden, use hash() with at least SHA-256 for secure hash, or password_hash() for passwords', 4],
-			['Calling sha1() is forbidden, use hash() with at least SHA-256 for secure hash, or password_hash() for passwords', 5],
-			['Calling md5_file() is forbidden, use hash_file() with at least SHA-256 for secure hash', 6],
-			['Calling sha1_file() is forbidden, use hash_file() with at least SHA-256 for secure hash', 7],
-			['Calling hash() is forbidden, use hash() with at least SHA-256 for secure hash, or password_hash() for passwords', 8],
-			['Calling hash() is forbidden, use hash() with at least SHA-256 for secure hash, or password_hash() for passwords', 9],
-			['Calling hash_file() is forbidden, use hash_file() with at least SHA-256 for secure hash, or password_hash() for passwords', 11],
-			['Calling hash_file() is forbidden, use hash_file() with at least SHA-256 for secure hash, or password_hash() for passwords', 12],
-			['Calling hash_init() is forbidden, use hash_init() with at least SHA-256 for secure hash, or password_hash() for passwords', 14],
-			['Calling hash_init() is forbidden, use hash_init() with at least SHA-256 for secure hash, or password_hash() for passwords', 15],
-			['Calling mysql_query() is forbidden, use PDO::prepare() with variable binding/parametrized queries to prevent SQL Injection vulnerability', 17],
-			['Calling mysql_unbuffered_query() is forbidden, use PDO::prepare() with variable binding/parametrized queries to prevent SQL Injection vulnerability', 18],
-			['Calling mysqli_query() is forbidden, use PDO::prepare() with variable binding/parametrized queries to prevent SQL Injection vulnerability', 19],
-			['Calling mysqli_multi_query() is forbidden, use PDO::prepare() with variable binding/parametrized queries to prevent SQL Injection vulnerability', 20],
-			['Calling mysqli_real_query() is forbidden, use PDO::prepare() with variable binding/parametrized queries to prevent SQL Injection vulnerability', 21],
-			['Calling rand() is forbidden, it is not a cryptographically secure generator, use random_int() instead', 27],
-			['Calling mt_rand() is forbidden, it is not a cryptographically secure generator, use random_int() instead', 28],
-			['Calling lcg_value() is forbidden, it is not a cryptographically secure generator, use random_int() instead', 29],
-			['Calling uniqid() is forbidden, it is not a cryptographically secure generator, use random_bytes() instead', 30],
+			['Calling md5() is forbidden, use hash() with at least SHA-256 for secure hash, or password_hash() for passwords.', 4],
+			['Calling sha1() is forbidden, use hash() with at least SHA-256 for secure hash, or password_hash() for passwords.', 5],
+			['Calling md5_file() is forbidden, use hash_file() with at least SHA-256 for secure hash.', 6],
+			['Calling sha1_file() is forbidden, use hash_file() with at least SHA-256 for secure hash.', 7],
+			['Calling hash() is forbidden, use hash() with at least SHA-256 for secure hash, or password_hash() for passwords.', 8],
+			['Calling hash() is forbidden, use hash() with at least SHA-256 for secure hash, or password_hash() for passwords.', 9],
+			['Calling hash_file() is forbidden, use hash_file() with at least SHA-256 for secure hash, or password_hash() for passwords.', 11],
+			['Calling hash_file() is forbidden, use hash_file() with at least SHA-256 for secure hash, or password_hash() for passwords.', 12],
+			['Calling hash_init() is forbidden, use hash_init() with at least SHA-256 for secure hash, or password_hash() for passwords.', 14],
+			['Calling hash_init() is forbidden, use hash_init() with at least SHA-256 for secure hash, or password_hash() for passwords.', 15],
+			['Calling mysql_query() is forbidden, use PDO::prepare() with variable binding/parametrized queries to prevent SQL Injection vulnerability.', 17],
+			['Calling mysql_unbuffered_query() is forbidden, use PDO::prepare() with variable binding/parametrized queries to prevent SQL Injection vulnerability.', 18],
+			['Calling mysqli_query() is forbidden, use PDO::prepare() with variable binding/parametrized queries to prevent SQL Injection vulnerability.', 19],
+			['Calling mysqli_multi_query() is forbidden, use PDO::prepare() with variable binding/parametrized queries to prevent SQL Injection vulnerability.', 20],
+			['Calling mysqli_real_query() is forbidden, use PDO::prepare() with variable binding/parametrized queries to prevent SQL Injection vulnerability.', 21],
+			['Calling rand() is forbidden, it is not a cryptographically secure generator, use random_int() instead.', 27],
+			['Calling mt_rand() is forbidden, it is not a cryptographically secure generator, use random_int() instead.', 28],
+			['Calling lcg_value() is forbidden, it is not a cryptographically secure generator, use random_int() instead.', 29],
+			['Calling uniqid() is forbidden, it is not a cryptographically secure generator, use random_bytes() instead.', 30],
 		]);
 	}
 

--- a/tests/Configs/InsecureConfigMethodCallsTest.php
+++ b/tests/Configs/InsecureConfigMethodCallsTest.php
@@ -36,7 +36,7 @@ class InsecureConfigMethodCallsTest extends RuleTestCase
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath($filePath));
 		return new MethodCalls(
 			new DisallowedMethodRuleErrors(
-				new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath),
+				new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath, $formatter),
 				new TypeResolver(),
 				$formatter
 			),
@@ -51,9 +51,9 @@ class InsecureConfigMethodCallsTest extends RuleTestCase
 		// Based on the configuration above, in this file:
 		$this->analyse([__DIR__ . '/../src/configs/insecureCalls.php'], [
 			// expect these error messages, on these lines:
-			['Calling mysqli::query() is forbidden, use PDO::prepare() with variable binding/parametrized queries to prevent SQL Injection vulnerability', 23],
-			['Calling mysqli::multi_query() is forbidden, use PDO::prepare() with variable binding/parametrized queries to prevent SQL Injection vulnerability', 24],
-			['Calling mysqli::real_query() is forbidden, use PDO::prepare() with variable binding/parametrized queries to prevent SQL Injection vulnerability', 25],
+			['Calling mysqli::query() is forbidden, use PDO::prepare() with variable binding/parametrized queries to prevent SQL Injection vulnerability.', 23],
+			['Calling mysqli::multi_query() is forbidden, use PDO::prepare() with variable binding/parametrized queries to prevent SQL Injection vulnerability.', 24],
+			['Calling mysqli::real_query() is forbidden, use PDO::prepare() with variable binding/parametrized queries to prevent SQL Injection vulnerability.', 25],
 		]);
 	}
 

--- a/tests/Configs/LooseConfigFunctionCallsTest.php
+++ b/tests/Configs/LooseConfigFunctionCallsTest.php
@@ -46,7 +46,7 @@ class LooseConfigFunctionCallsTest extends RuleTestCase
 		$filePath = new FilePath(new FileHelper(__DIR__));
 		$allowed = new Allowed($formatter, $normalizer, new AllowedPath($filePath));
 		return new FunctionCalls(
-			new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath),
+			new DisallowedCallsRuleErrors($allowed, new Identifier(), $filePath, $formatter),
 			new DisallowedCallFactory($formatter, $normalizer, $allowed),
 			$this->createReflectionProvider(),
 			$config['parameters']['disallowedFunctionCalls']
@@ -59,11 +59,11 @@ class LooseConfigFunctionCallsTest extends RuleTestCase
 		// Based on the configuration above, in this file:
 		$this->analyse([__DIR__ . '/../src/configs/looseCalls.php'], [
 			// expect these error messages, on these lines:
-			['Calling in_array() is forbidden, set the third parameter $strict to `true` to also check the types to prevent type juggling bugs', 4],
-			['Calling in_array() is forbidden, set the third parameter $strict to `true` to also check the types to prevent type juggling bugs', 6],
-			['Calling htmlspecialchars() is forbidden, set the $flags parameter to `ENT_QUOTES` to also convert single quotes to entities to prevent some HTML injection bugs', 7],
-			['Calling htmlspecialchars() is forbidden, set the $flags parameter to `ENT_QUOTES` to also convert single quotes to entities to prevent some HTML injection bugs', 12],
-			['Calling htmlspecialchars() is forbidden, set the $flags parameter to `ENT_QUOTES` to also convert single quotes to entities to prevent some HTML injection bugs', 13],
+			['Calling in_array() is forbidden, set the third parameter $strict to `true` to also check the types to prevent type juggling bugs.', 4],
+			['Calling in_array() is forbidden, set the third parameter $strict to `true` to also check the types to prevent type juggling bugs.', 6],
+			['Calling htmlspecialchars() is forbidden, set the $flags parameter to `ENT_QUOTES` to also convert single quotes to entities to prevent some HTML injection bugs.', 7],
+			['Calling htmlspecialchars() is forbidden, set the $flags parameter to `ENT_QUOTES` to also convert single quotes to entities to prevent some HTML injection bugs.', 12],
+			['Calling htmlspecialchars() is forbidden, set the $flags parameter to `ENT_QUOTES` to also convert single quotes to entities to prevent some HTML injection bugs.', 13],
 		]);
 	}
 

--- a/tests/Usages/AttributeUsagesAllowParamsMultipleTest.php
+++ b/tests/Usages/AttributeUsagesAllowParamsMultipleTest.php
@@ -23,9 +23,10 @@ class AttributeUsagesAllowParamsMultipleTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		$normalizer = new Normalizer();
-		$allowed = new Allowed(new Formatter($normalizer), $normalizer, new AllowedPath(new FilePath(new FileHelper(__DIR__))));
+		$formatter = new Formatter($normalizer);
+		$allowed = new Allowed($formatter, $normalizer, new AllowedPath(new FilePath(new FileHelper(__DIR__))));
 		return new AttributeUsages(
-			new DisallowedAttributeRuleErrors($allowed, new Identifier()),
+			new DisallowedAttributeRuleErrors($allowed, new Identifier(), $formatter),
 			new DisallowedAttributeFactory($allowed, $normalizer),
 			[
 				[
@@ -66,26 +67,26 @@ class AttributeUsagesAllowParamsMultipleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/../src/disallowed/ClassWithAttributes.php'], [
 			[
 				// expect this error message:
-				'Attribute Attributes\AttributeEntity is forbidden, because reasons',
+				'Attribute Attributes\AttributeEntity is forbidden.',
 				// on this line:
 				8,
 			],
 			[
-				'Attribute Attributes\AttributeClass is forbidden, because reasons',
+				'Attribute Attributes\AttributeClass is forbidden.',
 				30,
 			],
 		]);
 		$this->analyse([__DIR__ . '/../src/disallowed-allow/ClassWithAttributesAllow.php'], [
 			[
-				'Attribute Attributes\AttributeEntity is forbidden, because reasons',
+				'Attribute Attributes\AttributeEntity is forbidden.',
 				8,
 			],
 			[
-				'Attribute Attributes\AttributeEntity is forbidden, because reasons',
+				'Attribute Attributes\AttributeEntity is forbidden.',
 				12,
 			],
 			[
-				'Attribute Attributes\AttributeEntity is forbidden, because reasons',
+				'Attribute Attributes\AttributeEntity is forbidden.',
 				18,
 			],
 		]);

--- a/tests/Usages/AttributeUsagesTest.php
+++ b/tests/Usages/AttributeUsagesTest.php
@@ -22,9 +22,10 @@ class AttributeUsagesTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		$normalizer = new Normalizer();
-		$allowed = new Allowed(new Formatter($normalizer), $normalizer, new AllowedPath(new FilePath(new FileHelper(__DIR__))));
+		$formatter = new Formatter($normalizer);
+		$allowed = new Allowed($formatter, $normalizer, new AllowedPath(new FilePath(new FileHelper(__DIR__))));
 		return new AttributeUsages(
-			new DisallowedAttributeRuleErrors($allowed, new Identifier()),
+			new DisallowedAttributeRuleErrors($allowed, new Identifier(), $formatter),
 			new DisallowedAttributeFactory($allowed, $normalizer),
 			[
 				[
@@ -58,12 +59,12 @@ class AttributeUsagesTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/../src/disallowed/ClassWithAttributes.php'], [
 			[
 				// expect this error message:
-				'Attribute Attributes\AttributeEntity is forbidden, because reasons',
+				'Attribute Attributes\AttributeEntity is forbidden.',
 				// on this line:
 				8,
 			],
 			[
-				'Attribute Attributes\AttributeClass is forbidden, because reasons',
+				'Attribute Attributes\AttributeClass is forbidden.',
 				30,
 			],
 		]);

--- a/tests/Usages/ClassConstantInvalidUsagesTest.php
+++ b/tests/Usages/ClassConstantInvalidUsagesTest.php
@@ -24,11 +24,15 @@ class ClassConstantInvalidUsagesTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		$normalizer = new Normalizer();
+		$formatter = new Formatter($normalizer);
 		return new ClassConstantUsages(
-			new DisallowedConstantRuleErrors(new AllowedPath(new FilePath(new FileHelper(__DIR__)))),
+			new DisallowedConstantRuleErrors(
+				new AllowedPath(new FilePath(new FileHelper(__DIR__))),
+				$formatter
+			),
 			new DisallowedConstantFactory($normalizer),
 			new TypeResolver(),
-			new Formatter($normalizer),
+			$formatter,
 			[]
 		);
 	}
@@ -40,20 +44,20 @@ class ClassConstantInvalidUsagesTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/../src/invalid/constantUsages.php'], [
 			[
 				// expect this error message:
-				'Cannot access constant GLITTER on string',
+				'Cannot access constant GLITTER on string.',
 				// on this line:
 				6,
 			],
 			[
-				'Cannot access constant COOKIE on string',
+				'Cannot access constant COOKIE on string.',
 				10,
 			],
 			[
-				'Cannot access constant COOKIE on class-string',
+				'Cannot access constant COOKIE on class-string.',
 				14,
 			],
 			[
-				'Cannot access constant FTC on class-string<DateTimeZone>',
+				'Cannot access constant FTC on class-string<DateTimeZone>.',
 				24,
 			],
 		]);

--- a/tests/Usages/ClassConstantUsagesTest.php
+++ b/tests/Usages/ClassConstantUsagesTest.php
@@ -24,11 +24,15 @@ class ClassConstantUsagesTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		$normalizer = new Normalizer();
+		$formatter = new Formatter($normalizer);
 		return new ClassConstantUsages(
-			new DisallowedConstantRuleErrors(new AllowedPath(new FilePath(new FileHelper(__DIR__)))),
+			new DisallowedConstantRuleErrors(
+				new AllowedPath(new FilePath(new FileHelper(__DIR__))),
+				$formatter
+			),
 			new DisallowedConstantFactory($normalizer),
 			new TypeResolver(),
-			new Formatter($normalizer),
+			$formatter,
 			[
 				[
 					'class' => '\Inheritance\Base',
@@ -104,40 +108,40 @@ class ClassConstantUsagesTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/../src/disallowed/constantUsages.php'], [
 			[
 				// expect this error message:
-				'Using Inheritance\Base::BELONG (as Inheritance\Sub::BELONG) is forbidden, belong to us',
+				'Using Inheritance\Base::BELONG (as Inheritance\Sub::BELONG) is forbidden, belong to us.',
 				// on this line:
 				11,
 			],
 			[
-				'Using Inheritance\Base::BELONG is forbidden, belong to us',
+				'Using Inheritance\Base::BELONG is forbidden, belong to us.',
 				12,
 			],
 			[
-				'Using Inheritance\Base::BELONG is forbidden, belong to us',
+				'Using Inheritance\Base::BELONG is forbidden, belong to us.',
 				13,
 			],
 			[
-				'Using Waldo\Quux\Blade::RUNNER is forbidden, not a replicant',
+				'Using Waldo\Quux\Blade::RUNNER is forbidden, not a replicant.',
 				14,
 			],
 			[
-				'Using Waldo\Quux\Blade::RUNNER is forbidden, not a replicant',
+				'Using Waldo\Quux\Blade::RUNNER is forbidden, not a replicant.',
 				15,
 			],
 			[
-				'Using Waldo\Quux\Blade::DECKARD is forbidden, maybe a replicant',
+				'Using Waldo\Quux\Blade::DECKARD is forbidden, maybe a replicant.',
 				19,
 			],
 			[
-				'Using Waldo\Quux\Blade::DECKARD is forbidden, maybe a replicant',
+				'Using Waldo\Quux\Blade::DECKARD is forbidden, maybe a replicant.',
 				22,
 			],
 			[
-				'Using Waldo\Quux\Blade::WESLEY is forbidden, not a replicant',
+				'Using Waldo\Quux\Blade::WESLEY is forbidden, not a replicant.',
 				23,
 			],
 			[
-				'Using PhpOption\Option::NAME (as PhpOption\None::NAME) is forbidden, no PhpOption',
+				'Using PhpOption\Option::NAME (as PhpOption\None::NAME) is forbidden, no PhpOption.',
 				37,
 			],
 		]);

--- a/tests/Usages/ConstantUsagesTest.php
+++ b/tests/Usages/ConstantUsagesTest.php
@@ -10,6 +10,7 @@ use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\Allowed\AllowedPath;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedConstantFactory;
 use Spaze\PHPStan\Rules\Disallowed\File\FilePath;
+use Spaze\PHPStan\Rules\Disallowed\Formatter\Formatter;
 use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedConstantRuleErrors;
 
@@ -21,9 +22,13 @@ class ConstantUsagesTest extends RuleTestCase
 	 */
 	protected function getRule(): Rule
 	{
+		$normalizer = new Normalizer();
 		return new ConstantUsages(
-			new DisallowedConstantRuleErrors(new AllowedPath(new FilePath(new FileHelper(__DIR__)))),
-			new DisallowedConstantFactory(new Normalizer()),
+			new DisallowedConstantRuleErrors(
+				new AllowedPath(new FilePath(new FileHelper(__DIR__))),
+				new Formatter($normalizer)
+			),
+			new DisallowedConstantFactory($normalizer),
 			[
 				[
 					'constant' => [
@@ -63,22 +68,22 @@ class ConstantUsagesTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/../src/disallowed/constantUsages.php'], [
 			[
 				// expect this error message:
-				'Using FILTER_FLAG_NO_PRIV_RANGE is forbidden, the cake is a lie',
+				'Using FILTER_FLAG_NO_PRIV_RANGE is forbidden, the cake is a lie.',
 				// on this line:
 				8,
 				'Use https://github.com/mlocati/ip-lib instead',
 			],
 			[
-				'Using FILTER_FLAG_NO_PRIV_RANGE is forbidden, the cake is a lie',
+				'Using FILTER_FLAG_NO_PRIV_RANGE is forbidden, the cake is a lie.',
 				9,
 				'Use https://github.com/mlocati/ip-lib instead',
 			],
 			[
-				'Using FILTER_FLAG_NO_RES_RANGE is forbidden, the cake is a lie',
+				'Using FILTER_FLAG_NO_RES_RANGE is forbidden, the cake is a lie.',
 				10,
 			],
 			[
-				'Using PHP_EOL is forbidden, because reasons',
+				'Using PHP_EOL is forbidden.',
 				40,
 			],
 		]);

--- a/tests/Usages/NamespaceUsagesTest.php
+++ b/tests/Usages/NamespaceUsagesTest.php
@@ -9,6 +9,7 @@ use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\Allowed\AllowedPath;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedNamespaceFactory;
 use Spaze\PHPStan\Rules\Disallowed\File\FilePath;
+use Spaze\PHPStan\Rules\Disallowed\Formatter\Formatter;
 use Spaze\PHPStan\Rules\Disallowed\Identifier\Identifier;
 use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedNamespaceRuleErrors;
@@ -18,10 +19,15 @@ class NamespaceUsagesTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
+		$normalizer = new Normalizer();
 		return new NamespaceUsages(
-			new DisallowedNamespaceRuleErrors(new AllowedPath(new FilePath(new FileHelper(__DIR__))), new Identifier()),
-			new DisallowedNamespaceFactory(new Normalizer()),
-			new Normalizer(),
+			new DisallowedNamespaceRuleErrors(
+				new AllowedPath(new FilePath(new FileHelper(__DIR__))),
+				new Identifier(),
+				new Formatter($normalizer)
+			),
+			new DisallowedNamespaceFactory($normalizer),
+			$normalizer,
 			[
 				[
 					'namespace' => 'Framew*rk\Some*',
@@ -86,66 +92,66 @@ class NamespaceUsagesTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/../src/disallowed/namespaceUsages.php'], [
 			[
 				// expect this error message:
-				'Namespace Framework\SomeInterface is forbidden, no framework some [Framework\SomeInterface matches Framew*rk\Some*]',
+				'Namespace Framework\SomeInterface is forbidden, no framework some. [Framework\SomeInterface matches Framew*rk\Some*]',
 				// on this line:
 				6,
 				'Work more on your frames',
 			],
 			[
-				'Namespace Inheritance\Base is forbidden, no inheritance sub base',
+				'Namespace Inheritance\Base is forbidden, no inheritance sub base.',
 				7,
 			],
 			[
-				'Namespace Inheritance\Sub is forbidden, no inheritance sub base',
+				'Namespace Inheritance\Sub is forbidden, no inheritance sub base.',
 				8,
 			],
 			[
-				'Namespace Traits\TestTrait is forbidden, no TestTrait',
+				'Namespace Traits\TestTrait is forbidden, no TestTrait.',
 				9,
 			],
 			[
-				'Namespace Waldo\Foo\Bar is forbidden, no FooBar [Waldo\Foo\Bar matches Waldo\Foo\bar]',
+				'Namespace Waldo\Foo\Bar is forbidden, no FooBar. [Waldo\Foo\Bar matches Waldo\Foo\bar]',
 				10,
 			],
 			[
-				'Namespace Waldo\Quux\blade is forbidden, no blade [Waldo\Quux\blade matches Waldo\Quux\Blade]',
+				'Namespace Waldo\Quux\blade is forbidden, no blade. [Waldo\Quux\blade matches Waldo\Quux\Blade]',
 				11,
 			],
 			[
-				'Namespace ZipArchive is forbidden, use clippy instead of zippy',
+				'Namespace ZipArchive is forbidden, use clippy instead of zippy.',
 				12,
 			],
 			[
-				'Namespace Inheritance\Base is forbidden, no inheritance sub base',
+				'Namespace Inheritance\Base is forbidden, no inheritance sub base.',
 				14,
 			],
 			[
-				'Namespace Framework\SomeInterface is forbidden, no framework some [Framework\SomeInterface matches Framew*rk\Some*]',
+				'Namespace Framework\SomeInterface is forbidden, no framework some. [Framework\SomeInterface matches Framew*rk\Some*]',
 				14,
 				'Work more on your frames',
 			],
 			[
-				'Trait Traits\TestTrait is forbidden, no TestTrait',
+				'Trait Traits\TestTrait is forbidden, no TestTrait.',
 				17,
 			],
 			[
-				'Class Waldo\Quux\blade is forbidden, no blade [Waldo\Quux\blade matches Waldo\Quux\Blade]',
+				'Class Waldo\Quux\blade is forbidden, no blade. [Waldo\Quux\blade matches Waldo\Quux\Blade]',
 				24,
 			],
 			[
-				'Namespace Inheritance\Sub is forbidden, no inheritance sub base',
+				'Namespace Inheritance\Sub is forbidden, no inheritance sub base.',
 				32,
 			],
 			[
-				'Class Waldo\Foo\Bar is forbidden, no FooBar [Waldo\Foo\Bar matches Waldo\Foo\bar]',
+				'Class Waldo\Foo\Bar is forbidden, no FooBar. [Waldo\Foo\Bar matches Waldo\Foo\bar]',
 				38,
 			],
 			[
-				'Class Waldo\Foo\Bar is forbidden, no FooBar [Waldo\Foo\Bar matches Waldo\Foo\bar]',
+				'Class Waldo\Foo\Bar is forbidden, no FooBar. [Waldo\Foo\Bar matches Waldo\Foo\bar]',
 				44,
 			],
 			[
-				'Class ZipArchive is forbidden, use clippy instead of zippy',
+				'Class ZipArchive is forbidden, use clippy instead of zippy.',
 				50,
 			],
 		]);

--- a/tests/Usages/NamespaceUsagesTypesTest.php
+++ b/tests/Usages/NamespaceUsagesTypesTest.php
@@ -9,6 +9,7 @@ use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\Allowed\AllowedPath;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedNamespaceFactory;
 use Spaze\PHPStan\Rules\Disallowed\File\FilePath;
+use Spaze\PHPStan\Rules\Disallowed\Formatter\Formatter;
 use Spaze\PHPStan\Rules\Disallowed\Identifier\Identifier;
 use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedNamespaceRuleErrors;
@@ -23,7 +24,11 @@ class NamespaceUsagesTypesTest extends RuleTestCase
 	{
 		$normalizer = new Normalizer();
 		return new NamespaceUsages(
-			new DisallowedNamespaceRuleErrors(new AllowedPath(new FilePath(new FileHelper(__DIR__))), new Identifier()),
+			new DisallowedNamespaceRuleErrors(
+				new AllowedPath(new FilePath(new FileHelper(__DIR__))),
+				new Identifier(),
+				new Formatter($normalizer)
+			),
 			new DisallowedNamespaceFactory($normalizer),
 			$normalizer,
 			[

--- a/tests/Usages/SuperglobalUsagesTest.php
+++ b/tests/Usages/SuperglobalUsagesTest.php
@@ -10,6 +10,8 @@ use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\Allowed\AllowedPath;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedSuperglobalFactory;
 use Spaze\PHPStan\Rules\Disallowed\File\FilePath;
+use Spaze\PHPStan\Rules\Disallowed\Formatter\Formatter;
+use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedVariableRuleErrors;
 
 class SuperglobalUsagesTest extends RuleTestCase
@@ -21,7 +23,10 @@ class SuperglobalUsagesTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		return new VariableUsages(
-			new DisallowedVariableRuleErrors(new AllowedPath(new FilePath(new FileHelper(__DIR__)))),
+			new DisallowedVariableRuleErrors(
+				new AllowedPath(new FilePath(new FileHelper(__DIR__))),
+				new Formatter(new Normalizer())
+			),
 			(new DisallowedSuperglobalFactory())->getDisallowedVariables([
 				[
 					'superglobal' => '$GLOBALS',
@@ -62,21 +67,21 @@ class SuperglobalUsagesTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/../src/disallowed/superglobalUsages.php'], [
 			[
 				// expect this error message:
-				'Using $GLOBALS is forbidden, the cake is a lie',
+				'Using $GLOBALS is forbidden, the cake is a lie.',
 				// on this line:
 				8,
 				'So long and thanks for all the tips',
 			],
 			[
-				'Using $_GET is forbidden, the cake is a lie',
+				'Using $_GET is forbidden, the cake is a lie.',
 				9,
 			],
 			[
-				'Using $_GET is forbidden, the cake is a lie',
+				'Using $_GET is forbidden, the cake is a lie.',
 				12,
 			],
 			[
-				'Using $_POST is forbidden, the cake is a lie',
+				'Using $_POST is forbidden, the cake is a lie.',
 				13,
 			],
 			[


### PR DESCRIPTION
Was funny back then but maybe it's not anymore. Also it doesn't really indicate that the message could be changed. Always end the message with a `.`, unless it ends with `?` or `!` already.

Close #220