### PR TITLE
disallowedAttributes: configure errorIdentifier and errorTip as optional

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -200,8 +200,8 @@ parametersSchema:
 			?disallowParamFlags: arrayOf(anyOf(int(), structure([position: int(), ?value: int(), ?name: string()])), anyOf(int(), string())),
 			?allowExceptCaseInsensitiveParams: arrayOf(anyOf(int(), string(), bool(), structure([position: int(), ?value: anyOf(int(), string(), bool()), ?name: string()])), anyOf(int(), string())),
 			?disallowCaseInsensitiveParams: arrayOf(anyOf(int(), string(), bool(), structure([position: int(), ?value: anyOf(int(), string(), bool()), ?name: string()])), anyOf(int(), string())),
-			errorIdentifier: string(),
-			errorTip: string(),
+			?errorIdentifier: string(),
+			?errorTip: string(),
 		])
 	)
 


### PR DESCRIPTION
Gave a test run of some disallowed attributes on properties after #225 , noticed errorIdentifier and errorTip are considered mandatory but I'm guessing it was not intended in #222 

Additionally aligned some comments on recently introduced tests (if I got correctly the meaning)