### PR TITLE
Test on `>=` 8.0 & 8.1, not just `>`

### DIFF
--- a/tests/Calls/FunctionCallsNamedParamsTest.php
+++ b/tests/Calls/FunctionCallsNamedParamsTest.php
@@ -10,7 +10,7 @@ use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
 
 /**
- * @requires PHP > 8.0
+ * @requires PHP >= 8.0
  */
 class FunctionCallsNamedParamsTest extends RuleTestCase
 {

--- a/tests/Usages/NamespaceUsagesTypesTest.php
+++ b/tests/Usages/NamespaceUsagesTypesTest.php
@@ -10,7 +10,7 @@ use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedNamespaceRuleErrors;
 
 /**
- * @requires PHP > 8.1
+ * @requires PHP >= 8.1
  */
 class NamespaceUsagesTypesTest extends RuleTestCase
 {


### PR DESCRIPTION
Got the version operators wrong in named params and type tests.