### PR TITLE
`disallowedConstants`' `constant` field is always present

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -157,7 +157,7 @@ parametersSchema:
 	disallowedConstants: listOf(
 		structure([
 			?class: string(),
-			?constant: anyOf(string(), listOf(string())),
+			constant: anyOf(string(), listOf(string())),
 			?message: string(),
 			?allowIn: listOf(string()),
 			?allowExceptIn: listOf(string()),


### PR DESCRIPTION
The `class` won't be for non-class constants.