### PR TITLE
Support all Expr nodes when in dynamic constant fetch

### DIFF
--- a/src/Usages/ClassConstantUsages.php
+++ b/src/Usages/ClassConstantUsages.php
@@ -5,7 +5,6 @@ namespace Spaze\PHPStan\Rules\Disallowed\Usages;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\ClassConstFetch;
-use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
@@ -85,18 +84,15 @@ class ClassConstantUsages implements Rule
 		if ($node->name instanceof Identifier) {
 			return $this->getConstantRuleErrors($scope, (string)$node->name, $this->typeResolver->getType($node->class, $scope));
 		}
-		if ($node->name instanceof Variable) {
-			$type = $scope->getType($node->name);
-			$errors = [];
-			foreach ($type->getConstantStrings() as $constantString) {
-				$errors = array_merge(
-					$errors,
-					$this->getConstantRuleErrors($scope, $constantString->getValue(), $this->typeResolver->getType($node->class, $scope))
-				);
-			}
-			return $errors;
+		$type = $scope->getType($node->name);
+		$errors = [];
+		foreach ($type->getConstantStrings() as $constantString) {
+			$errors = array_merge(
+				$errors,
+				$this->getConstantRuleErrors($scope, $constantString->getValue(), $this->typeResolver->getType($node->class, $scope))
+			);
 		}
-		throw new ShouldNotHappenException(sprintf('$node->name should be %s but is %s', Identifier::class, get_class($node->name)));
+		return $errors;
 	}
 
 

--- a/tests/src/Blade.php
+++ b/tests/src/Blade.php
@@ -14,6 +14,10 @@ class Blade
 
 	public const MOVIE = Blade::WESLEY;
 
+	public static $runner = 'RUNNER';
+
+	public $deckard = 'DECKARD';
+
 
 	public function runner(int $everything = 0, bool $yes = false, string $roland = '303'): void
 	{

--- a/tests/src/disallowed/constantDynamicUsages.php
+++ b/tests/src/disallowed/constantDynamicUsages.php
@@ -8,3 +8,8 @@ $kind = 'RUNNER';
 echo Blade::{$kind};
 /** @var 'DECKARD'|'MOVIE'|'RUNNER' $kind2 */
 echo Blade::{$kind2};
+
+$blade = new Blade();
+echo Blade::{Blade::$runner};
+echo Blade::{$blade::$runner};
+echo Blade::{$blade->deckard};


### PR DESCRIPTION
Because besides `Variable`, there's also
- `PropertyFetch` (`Foo::{$this->type}`)
- `StaticPropertyFetch` (`Foo::{Foo::$bar}`)
- and more.

Fix #241, again.