### PR TITLE
Hardcode `ENT_QUOTES` as int `3` in `disallowed-loose-calls.neon` config

### DIFF
--- a/disallowed-loose-calls.neon
+++ b/disallowed-loose-calls.neon
@@ -9,4 +9,4 @@ parameters:
 			function: 'htmlspecialchars()'
 			message: 'set the $flags parameter to `ENT_QUOTES` to also convert single quotes to entities to prevent some HTML injection bugs'
 			allowParamFlagsAnywhere:
-				2: ::constant(ENT_QUOTES)
+				2: 3 # ENT_QUOTES


### PR DESCRIPTION
PHPStan 1.10.58 updated nette/di from v3.1.5 to v3.1.10 and possibly that's the reason why `::constant` is not accepted anymore.
https://github.com/phpstan/phpstan-src/pull/2907

The config file is tested so even if the value of the constant would change, however unlikely, it would be detected by failing tests.

Close #249

Introduced in #222 as a fix for https://github.com/phpstan/phpstan/issues/10223