### PR TITLE
It's already a list, no need to call `array_values()`

### DIFF
--- a/src/DisallowedCallFactory.php
+++ b/src/DisallowedCallFactory.php
@@ -50,7 +50,7 @@ class DisallowedCallFactory
 			foreach ((array)($disallowed['exclude'] ?? []) as $exclude) {
 				$excludes[] = $this->normalizer->normalizeCall($exclude);
 			}
-			$calls = array_values((array)$calls);
+			$calls = (array)$calls;
 			try {
 				foreach ($calls as $call) {
 					$disallowedCall = new DisallowedCall(


### PR DESCRIPTION
This is a new bleeding edge rule added in PHPStan [1.10.59](https://github.com/phpstan/phpstan/releases/tag/1.10.59) which resulted in "Parameter #1 $array (non-empty-list<string>) of array_values is already a list, call has no effect."