### PR TITLE
Add `phpinfo()` to dangerous calls config

### DIFF
--- a/disallowed-dangerous-calls.neon
+++ b/disallowed-dangerous-calls.neon
@@ -58,3 +58,7 @@ parameters:
 			message: 'use some logger instead'
 			allowParamsAnywhere:
 				2: true
+		-
+			function: 'phpinfo()'
+			message: 'might reveal session id or other tokens in cookies'
+			errorTip: 'see https://www.michalspacek.com/stealing-session-ids-with-phpinfo-and-how-to-stop-it and use e.g. spaze/phpinfo instead'

--- a/tests/Configs/DangerousConfigFunctionCallsTest.php
+++ b/tests/Configs/DangerousConfigFunctionCallsTest.php
@@ -40,6 +40,7 @@ class DangerousConfigFunctionCallsTest extends RuleTestCase
 			['Calling var_dump() is forbidden, use some logger instead.', 22],
 			['Calling var_export() is forbidden, use some logger instead.', 23],
 			['Calling var_export() is forbidden, use some logger instead.', 25],
+			['Calling phpinfo() is forbidden, might reveal session id or other tokens in cookies.', 26, 'see https://www.michalspacek.com/stealing-session-ids-with-phpinfo-and-how-to-stop-it and use e.g. spaze/phpinfo instead'],
 		]);
 	}
 

--- a/tests/src/configs/dangerousCalls.php
+++ b/tests/src/configs/dangerousCalls.php
@@ -23,3 +23,4 @@ var_dump([]);
 var_export([]);
 var_export([1], true);
 var_export([2], false);
+phpinfo();


### PR DESCRIPTION
See
- https://www.michalspacek.com/stealing-session-ids-with-phpinfo-and-how-to-stop-it
- or https://www.michalspacek.cz/kradeni-session-id-pomoci-phpinfo-a-jak-tomu-zabranit (in Czech)

for reasons why (`phpinfo()` echoes cookie values like the session id, which may then be stolen with XSS for example, bypassing `HttpOnly` cookie flag), and use https://github.com/spaze/phpinfo instead of just calling `phpinfo()`.