### PR TITLE
Add default error identifiers, used if not specified

### DIFF
--- a/docs/custom-rules.md
+++ b/docs/custom-rules.md
@@ -103,6 +103,7 @@ The optional `errorTip` key can be used to show an additional message prefixed w
 ### Error identifiers
 
 The `errorIdentifier` key is optional. It can be used to provide a unique identifier to the PHPStan error.
+If not specified, a default identifier will be used, see the `\Spaze\PHPStan\Rules\Disallowed\RuleErrors\ErrorIdentifiers` class for current list.
 
 ### Wildcards
 

--- a/src/Calls/EchoCalls.php
+++ b/src/Calls/EchoCalls.php
@@ -7,11 +7,11 @@ use PhpParser\Node;
 use PhpParser\Node\Stmt\Echo_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
-use PHPStan\Rules\RuleError;
 use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCall;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\ErrorIdentifiers;
 
 /**
  * Reports on dynamically calling echo().
@@ -51,14 +51,11 @@ class EchoCalls implements Rule
 
 
 	/**
-	 * @param Echo_ $node
-	 * @param Scope $scope
-	 * @return list<RuleError>
 	 * @throws ShouldNotHappenException
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{
-		return $this->disallowedCallsRuleErrors->get(null, $scope, 'echo', 'echo', null, $this->disallowedCalls);
+		return $this->disallowedCallsRuleErrors->get(null, $scope, 'echo', 'echo', null, $this->disallowedCalls, ErrorIdentifiers::DISALLOWED_ECHO);
 	}
 
 }

--- a/src/Calls/EmptyCalls.php
+++ b/src/Calls/EmptyCalls.php
@@ -7,11 +7,11 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\Empty_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
-use PHPStan\Rules\RuleError;
 use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCall;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\ErrorIdentifiers;
 
 /**
  * Reports on dynamically calling empty().
@@ -51,14 +51,11 @@ class EmptyCalls implements Rule
 
 
 	/**
-	 * @param Empty_ $node
-	 * @param Scope $scope
-	 * @return list<RuleError>
 	 * @throws ShouldNotHappenException
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{
-		return $this->disallowedCallsRuleErrors->get(null, $scope, 'empty', 'empty', null, $this->disallowedCalls);
+		return $this->disallowedCallsRuleErrors->get(null, $scope, 'empty', 'empty', null, $this->disallowedCalls, ErrorIdentifiers::DISALLOWED_EMPTY);
 	}
 
 }

--- a/src/Calls/EvalCalls.php
+++ b/src/Calls/EvalCalls.php
@@ -7,11 +7,11 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\Eval_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
-use PHPStan\Rules\RuleError;
 use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCall;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\ErrorIdentifiers;
 
 /**
  * Reports on dynamically calling eval().
@@ -51,14 +51,11 @@ class EvalCalls implements Rule
 
 
 	/**
-	 * @param Eval_ $node
-	 * @param Scope $scope
-	 * @return list<RuleError>
 	 * @throws ShouldNotHappenException
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{
-		return $this->disallowedCallsRuleErrors->get(null, $scope, 'eval', 'eval', null, $this->disallowedCalls);
+		return $this->disallowedCallsRuleErrors->get(null, $scope, 'eval', 'eval', null, $this->disallowedCalls, ErrorIdentifiers::DISALLOWED_EVAL);
 	}
 
 }

--- a/src/Calls/ExitDieCalls.php
+++ b/src/Calls/ExitDieCalls.php
@@ -7,11 +7,11 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\Exit_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
-use PHPStan\Rules\RuleError;
 use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCall;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\ErrorIdentifiers;
 
 /**
  * Reports on dynamically calling exit() & die().
@@ -51,15 +51,12 @@ class ExitDieCalls implements Rule
 
 
 	/**
-	 * @param Exit_ $node
-	 * @param Scope $scope
-	 * @return list<RuleError>
 	 * @throws ShouldNotHappenException
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{
 		$kind = $node->getAttribute('kind', Exit_::KIND_DIE) === Exit_::KIND_EXIT ? 'exit' : 'die';
-		return $this->disallowedCallsRuleErrors->get(null, $scope, $kind, $kind, null, $this->disallowedCalls);
+		return $this->disallowedCallsRuleErrors->get(null, $scope, $kind, $kind, null, $this->disallowedCalls, $kind === 'exit' ? ErrorIdentifiers::DISALLOWED_EXIT : ErrorIdentifiers::DISALLOWED_DIE);
 	}
 
 }

--- a/src/Calls/FunctionCalls.php
+++ b/src/Calls/FunctionCalls.php
@@ -8,12 +8,13 @@ use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\Rule;
-use PHPStan\Rules\RuleError;
 use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCall;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\ErrorIdentifiers;
 
 /**
  * Reports on dynamically calling a disallowed function.
@@ -60,7 +61,7 @@ class FunctionCalls implements Rule
 	/**
 	 * @param FuncCall $node
 	 * @param Scope $scope
-	 * @return list<RuleError>
+	 * @return list<IdentifierRuleError>
 	 * @throws ShouldNotHappenException
 	 */
 	public function processNode(Node $node, Scope $scope): array
@@ -83,7 +84,7 @@ class FunctionCalls implements Rule
 			} else {
 				$definedIn = null;
 			}
-			$message = $this->disallowedCallsRuleErrors->get($node, $scope, (string)$name, (string)($displayName ?? $node->name), $definedIn, $this->disallowedCalls);
+			$message = $this->disallowedCallsRuleErrors->get($node, $scope, (string)$name, (string)($displayName ?? $node->name), $definedIn, $this->disallowedCalls, ErrorIdentifiers::DISALLOWED_FUNCTION);
 			if ($message) {
 				return $message;
 			}

--- a/src/Calls/NewCalls.php
+++ b/src/Calls/NewCalls.php
@@ -14,6 +14,7 @@ use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCall;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\ErrorIdentifiers;
 
 /**
  * Reports on creating objects (calling constructors).
@@ -92,7 +93,7 @@ class NewCalls implements Rule
 				$name .= self::CONSTRUCT;
 				$errors = array_merge(
 					$errors,
-					$this->disallowedCallsRuleErrors->get($node, $scope, $name, $type->getClassName() . self::CONSTRUCT, $definedIn, $this->disallowedCalls)
+					$this->disallowedCallsRuleErrors->get($node, $scope, $name, $type->getClassName() . self::CONSTRUCT, $definedIn, $this->disallowedCalls, ErrorIdentifiers::DISALLOWED_NEW)
 				);
 			}
 		}

--- a/src/Calls/PrintCalls.php
+++ b/src/Calls/PrintCalls.php
@@ -7,11 +7,11 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\Print_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
-use PHPStan\Rules\RuleError;
 use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCall;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\ErrorIdentifiers;
 
 /**
  * Reports on dynamically calling print().
@@ -51,14 +51,11 @@ class PrintCalls implements Rule
 
 
 	/**
-	 * @param Print_ $node
-	 * @param Scope $scope
-	 * @return list<RuleError>
 	 * @throws ShouldNotHappenException
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{
-		return $this->disallowedCallsRuleErrors->get(null, $scope, 'print', 'print', null, $this->disallowedCalls);
+		return $this->disallowedCallsRuleErrors->get(null, $scope, 'print', 'print', null, $this->disallowedCalls, ErrorIdentifiers::DISALLOWED_PRINT);
 	}
 
 }

--- a/src/Calls/ShellExecCalls.php
+++ b/src/Calls/ShellExecCalls.php
@@ -7,11 +7,11 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\ShellExec;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
-use PHPStan\Rules\RuleError;
 use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCall;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\ErrorIdentifiers;
 
 /**
  * Reports on dynamically using the execution backtick operator (<code>`ls`</code>).
@@ -55,9 +55,6 @@ class ShellExecCalls implements Rule
 
 
 	/**
-	 * @param ShellExec $node
-	 * @param Scope $scope
-	 * @return list<RuleError>
 	 * @throws ShouldNotHappenException
 	 */
 	public function processNode(Node $node, Scope $scope): array
@@ -69,6 +66,7 @@ class ShellExecCalls implements Rule
 			null,
 			null,
 			$this->disallowedCalls,
+			ErrorIdentifiers::DISALLOWED_BACKTICK,
 			'Using the backtick operator (`...`) is forbidden because shell_exec() is forbidden%2$s%3$s'
 		);
 	}

--- a/src/Calls/StaticCalls.php
+++ b/src/Calls/StaticCalls.php
@@ -60,7 +60,6 @@ class StaticCalls implements Rule
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{
-		/** @var StaticCall $node */
 		return $this->disallowedMethodRuleErrors->get($node->class, $node, $scope, $this->disallowedCalls);
 	}
 

--- a/src/ControlStructures/BreakControlStructure.php
+++ b/src/ControlStructures/BreakControlStructure.php
@@ -11,6 +11,7 @@ use PHPStan\Rules\RuleError;
 use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedControlStructure;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedControlStructureRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\ErrorIdentifiers;
 
 /**
  * Reports on using the break control structure.
@@ -53,7 +54,7 @@ class BreakControlStructure implements Rule
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{
-		return $this->disallowedControlStructureRuleErrors->get($scope, 'break', $this->disallowedControlStructures);
+		return $this->disallowedControlStructureRuleErrors->get($scope, 'break', $this->disallowedControlStructures, ErrorIdentifiers::DISALLOWED_BREAK);
 	}
 
 }

--- a/src/ControlStructures/ContinueControlStructure.php
+++ b/src/ControlStructures/ContinueControlStructure.php
@@ -11,6 +11,7 @@ use PHPStan\Rules\RuleError;
 use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedControlStructure;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedControlStructureRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\ErrorIdentifiers;
 
 /**
  * Reports on using the continue control structure.
@@ -53,7 +54,7 @@ class ContinueControlStructure implements Rule
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{
-		return $this->disallowedControlStructureRuleErrors->get($scope, 'continue', $this->disallowedControlStructures);
+		return $this->disallowedControlStructureRuleErrors->get($scope, 'continue', $this->disallowedControlStructures, ErrorIdentifiers::DISALLOWED_CONTINUE);
 	}
 
 }

--- a/src/ControlStructures/DeclareControlStructure.php
+++ b/src/ControlStructures/DeclareControlStructure.php
@@ -11,6 +11,7 @@ use PHPStan\Rules\RuleError;
 use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedControlStructure;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedControlStructureRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\ErrorIdentifiers;
 
 /**
  * Reports on using the declare control structure.
@@ -53,7 +54,7 @@ class DeclareControlStructure implements Rule
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{
-		return $this->disallowedControlStructureRuleErrors->get($scope, 'declare', $this->disallowedControlStructures);
+		return $this->disallowedControlStructureRuleErrors->get($scope, 'declare', $this->disallowedControlStructures, ErrorIdentifiers::DISALLOWED_DECLARE);
 	}
 
 }

--- a/src/ControlStructures/DoWhileControlStructure.php
+++ b/src/ControlStructures/DoWhileControlStructure.php
@@ -11,6 +11,7 @@ use PHPStan\Rules\RuleError;
 use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedControlStructure;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedControlStructureRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\ErrorIdentifiers;
 
 /**
  * Reports on using the do-while loop.
@@ -53,7 +54,7 @@ class DoWhileControlStructure implements Rule
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{
-		return $this->disallowedControlStructureRuleErrors->get($scope, 'do-while', $this->disallowedControlStructures);
+		return $this->disallowedControlStructureRuleErrors->get($scope, 'do-while', $this->disallowedControlStructures, ErrorIdentifiers::DISALLOWED_DO_WHILE);
 	}
 
 }

--- a/src/ControlStructures/ElseControlStructure.php
+++ b/src/ControlStructures/ElseControlStructure.php
@@ -11,6 +11,7 @@ use PHPStan\Rules\RuleError;
 use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedControlStructure;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedControlStructureRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\ErrorIdentifiers;
 
 /**
  * Reports on using the else control structure.
@@ -53,7 +54,7 @@ class ElseControlStructure implements Rule
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{
-		return $this->disallowedControlStructureRuleErrors->get($scope, 'else', $this->disallowedControlStructures);
+		return $this->disallowedControlStructureRuleErrors->get($scope, 'else', $this->disallowedControlStructures, ErrorIdentifiers::DISALLOWED_ELSE);
 	}
 
 }

--- a/src/ControlStructures/ElseIfControlStructure.php
+++ b/src/ControlStructures/ElseIfControlStructure.php
@@ -11,6 +11,7 @@ use PHPStan\Rules\RuleError;
 use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedControlStructure;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedControlStructureRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\ErrorIdentifiers;
 
 /**
  * Reports on using the elseif control structure.
@@ -54,7 +55,7 @@ class ElseIfControlStructure implements Rule
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{
-		return $this->disallowedControlStructureRuleErrors->get($scope, 'elseif', $this->disallowedControlStructures);
+		return $this->disallowedControlStructureRuleErrors->get($scope, 'elseif', $this->disallowedControlStructures, ErrorIdentifiers::DISALLOWED_ELSE_IF);
 	}
 
 }

--- a/src/ControlStructures/ForControlStructure.php
+++ b/src/ControlStructures/ForControlStructure.php
@@ -11,6 +11,7 @@ use PHPStan\Rules\RuleError;
 use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedControlStructure;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedControlStructureRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\ErrorIdentifiers;
 
 /**
  * Reports on using the for loop.
@@ -53,7 +54,7 @@ class ForControlStructure implements Rule
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{
-		return $this->disallowedControlStructureRuleErrors->get($scope, 'for', $this->disallowedControlStructures);
+		return $this->disallowedControlStructureRuleErrors->get($scope, 'for', $this->disallowedControlStructures, ErrorIdentifiers::DISALLOWED_FOR);
 	}
 
 }

--- a/src/ControlStructures/ForeachControlStructure.php
+++ b/src/ControlStructures/ForeachControlStructure.php
@@ -11,6 +11,7 @@ use PHPStan\Rules\RuleError;
 use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedControlStructure;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedControlStructureRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\ErrorIdentifiers;
 
 /**
  * Reports on using the foreach loop.
@@ -53,7 +54,7 @@ class ForeachControlStructure implements Rule
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{
-		return $this->disallowedControlStructureRuleErrors->get($scope, 'foreach', $this->disallowedControlStructures);
+		return $this->disallowedControlStructureRuleErrors->get($scope, 'foreach', $this->disallowedControlStructures, ErrorIdentifiers::DISALLOWED_FOREACH);
 	}
 
 }

--- a/src/ControlStructures/GotoControlStructure.php
+++ b/src/ControlStructures/GotoControlStructure.php
@@ -11,6 +11,7 @@ use PHPStan\Rules\RuleError;
 use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedControlStructure;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedControlStructureRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\ErrorIdentifiers;
 
 /**
  * Reports on using the goto control structure.
@@ -53,7 +54,7 @@ class GotoControlStructure implements Rule
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{
-		return $this->disallowedControlStructureRuleErrors->get($scope, 'goto', $this->disallowedControlStructures);
+		return $this->disallowedControlStructureRuleErrors->get($scope, 'goto', $this->disallowedControlStructures, ErrorIdentifiers::DISALLOWED_GOTO);
 	}
 
 }

--- a/src/ControlStructures/IfControlStructure.php
+++ b/src/ControlStructures/IfControlStructure.php
@@ -11,6 +11,7 @@ use PHPStan\Rules\RuleError;
 use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedControlStructure;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedControlStructureRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\ErrorIdentifiers;
 
 /**
  * Reports on using the if control structure.
@@ -53,7 +54,7 @@ class IfControlStructure implements Rule
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{
-		return $this->disallowedControlStructureRuleErrors->get($scope, 'if', $this->disallowedControlStructures);
+		return $this->disallowedControlStructureRuleErrors->get($scope, 'if', $this->disallowedControlStructures, ErrorIdentifiers::DISALLOWED_IF);
 	}
 
 }

--- a/src/ControlStructures/MatchControlStructure.php
+++ b/src/ControlStructures/MatchControlStructure.php
@@ -11,6 +11,7 @@ use PHPStan\Rules\RuleError;
 use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedControlStructure;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedControlStructureRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\ErrorIdentifiers;
 
 /**
  * Reports on using the match control structure.
@@ -53,7 +54,7 @@ class MatchControlStructure implements Rule
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{
-		return $this->disallowedControlStructureRuleErrors->get($scope, 'match', $this->disallowedControlStructures);
+		return $this->disallowedControlStructureRuleErrors->get($scope, 'match', $this->disallowedControlStructures, ErrorIdentifiers::DISALLOWED_MATCH);
 	}
 
 }

--- a/src/ControlStructures/RequireIncludeControlStructure.php
+++ b/src/ControlStructures/RequireIncludeControlStructure.php
@@ -11,6 +11,7 @@ use PHPStan\Rules\RuleError;
 use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedControlStructure;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedControlStructureRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\ErrorIdentifiers;
 
 /**
  * Reports on using the foreach loop.
@@ -53,25 +54,29 @@ class RequireIncludeControlStructure implements Rule
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{
-		$type = null;
+		$type = $identifier = null;
 		switch ($node->type) {
 			case Include_::TYPE_INCLUDE:
 				$type = 'include';
+				$identifier = ErrorIdentifiers::DISALLOWED_INCLUDE;
 				break;
 			case Include_::TYPE_REQUIRE:
 				$type = 'require';
+				$identifier = ErrorIdentifiers::DISALLOWED_REQUIRE;
 				break;
 			case Include_::TYPE_INCLUDE_ONCE:
 				$type = 'include_once';
+				$identifier = ErrorIdentifiers::DISALLOWED_INCLUDE_ONCE;
 				break;
 			case Include_::TYPE_REQUIRE_ONCE:
 				$type = 'require_once';
+				$identifier = ErrorIdentifiers::DISALLOWED_REQUIRE_ONCE;
 				break;
 		}
 		if ($type === null) {
 			return [];
 		}
-		return $this->disallowedControlStructureRuleErrors->get($scope, $type, $this->disallowedControlStructures);
+		return $this->disallowedControlStructureRuleErrors->get($scope, $type, $this->disallowedControlStructures, $identifier);
 	}
 
 }

--- a/src/ControlStructures/ReturnControlStructure.php
+++ b/src/ControlStructures/ReturnControlStructure.php
@@ -11,6 +11,7 @@ use PHPStan\Rules\RuleError;
 use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedControlStructure;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedControlStructureRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\ErrorIdentifiers;
 
 /**
  * Reports on using the return control structure.
@@ -53,7 +54,7 @@ class ReturnControlStructure implements Rule
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{
-		return $this->disallowedControlStructureRuleErrors->get($scope, 'return', $this->disallowedControlStructures);
+		return $this->disallowedControlStructureRuleErrors->get($scope, 'return', $this->disallowedControlStructures, ErrorIdentifiers::DISALLOWED_RETURN);
 	}
 
 }

--- a/src/ControlStructures/SwitchControlStructure.php
+++ b/src/ControlStructures/SwitchControlStructure.php
@@ -11,6 +11,7 @@ use PHPStan\Rules\RuleError;
 use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedControlStructure;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedControlStructureRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\ErrorIdentifiers;
 
 /**
  * Reports on using the switch control structure.
@@ -53,7 +54,7 @@ class SwitchControlStructure implements Rule
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{
-		return $this->disallowedControlStructureRuleErrors->get($scope, 'switch', $this->disallowedControlStructures);
+		return $this->disallowedControlStructureRuleErrors->get($scope, 'switch', $this->disallowedControlStructures, ErrorIdentifiers::DISALLOWED_SWITCH);
 	}
 
 }

--- a/src/ControlStructures/WhileControlStructure.php
+++ b/src/ControlStructures/WhileControlStructure.php
@@ -11,6 +11,7 @@ use PHPStan\Rules\RuleError;
 use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedControlStructure;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedControlStructureRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\ErrorIdentifiers;
 
 /**
  * Reports on using the while loop.
@@ -53,7 +54,7 @@ class WhileControlStructure implements Rule
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{
-		return $this->disallowedControlStructureRuleErrors->get($scope, 'while', $this->disallowedControlStructures);
+		return $this->disallowedControlStructureRuleErrors->get($scope, 'while', $this->disallowedControlStructures, ErrorIdentifiers::DISALLOWED_WHILE);
 	}
 
 }

--- a/src/RuleErrors/DisallowedAttributeRuleErrors.php
+++ b/src/RuleErrors/DisallowedAttributeRuleErrors.php
@@ -5,7 +5,7 @@ namespace Spaze\PHPStan\Rules\Disallowed\RuleErrors;
 
 use PhpParser\Node\Attribute;
 use PHPStan\Analyser\Scope;
-use PHPStan\Rules\RuleError;
+use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\RuleErrorBuilder;
 use Spaze\PHPStan\Rules\Disallowed\Allowed\Allowed;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedAttribute;
@@ -37,7 +37,7 @@ class DisallowedAttributeRuleErrors
 	 * @param Attribute $attribute
 	 * @param Scope $scope
 	 * @param list<DisallowedAttribute> $disallowedAttributes
-	 * @return list<RuleError>
+	 * @return list<IdentifierRuleError>
 	 */
 	public function get(Attribute $attribute, Scope $scope, array $disallowedAttributes): array
 	{
@@ -56,9 +56,7 @@ class DisallowedAttributeRuleErrors
 				$this->formatter->formatDisallowedMessage($disallowedAttribute->getMessage()),
 				$disallowedAttribute->getAttribute() !== $attributeName ? " [{$attributeName} matches {$disallowedAttribute->getAttribute()}]" : ''
 			));
-			if ($disallowedAttribute->getErrorIdentifier()) {
-				$errorBuilder->identifier($disallowedAttribute->getErrorIdentifier());
-			}
+			$errorBuilder->identifier($disallowedAttribute->getErrorIdentifier() ?? ErrorIdentifiers::DISALLOWED_ATTRIBUTE);
 			if ($disallowedAttribute->getErrorTip()) {
 				$errorBuilder->tip($disallowedAttribute->getErrorTip());
 			}

--- a/src/RuleErrors/DisallowedCallsRuleErrors.php
+++ b/src/RuleErrors/DisallowedCallsRuleErrors.php
@@ -5,7 +5,7 @@ namespace Spaze\PHPStan\Rules\Disallowed\RuleErrors;
 
 use PhpParser\Node\Expr\CallLike;
 use PHPStan\Analyser\Scope;
-use PHPStan\Rules\RuleError;
+use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\Allowed\Allowed;
@@ -46,11 +46,12 @@ class DisallowedCallsRuleErrors
 	 * @param string|null $displayName
 	 * @param string|null $definedIn
 	 * @param list<DisallowedCall> $disallowedCalls
+	 * @param string $identifier
 	 * @param string|null $message
-	 * @return list<RuleError>
+	 * @return list<IdentifierRuleError>
 	 * @throws ShouldNotHappenException
 	 */
-	public function get(?CallLike $node, Scope $scope, string $name, ?string $displayName, ?string $definedIn, array $disallowedCalls, ?string $message = null): array
+	public function get(?CallLike $node, Scope $scope, string $name, ?string $displayName, ?string $definedIn, array $disallowedCalls, string $identifier, ?string $message = null): array
 	{
 		foreach ($disallowedCalls as $disallowedCall) {
 			if (
@@ -64,9 +65,7 @@ class DisallowedCallsRuleErrors
 					$this->formatter->formatDisallowedMessage($disallowedCall->getMessage()),
 					$disallowedCall->getCall() !== $name ? " [{$name}() matches {$disallowedCall->getCall()}()]" : ''
 				));
-				if ($disallowedCall->getErrorIdentifier()) {
-					$errorBuilder->identifier($disallowedCall->getErrorIdentifier());
-				}
+				$errorBuilder->identifier($disallowedCall->getErrorIdentifier() ?? $identifier);
 				if ($disallowedCall->getErrorTip()) {
 					$errorBuilder->tip($disallowedCall->getErrorTip());
 				}

--- a/src/RuleErrors/DisallowedConstantRuleErrors.php
+++ b/src/RuleErrors/DisallowedConstantRuleErrors.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 namespace Spaze\PHPStan\Rules\Disallowed\RuleErrors;
 
 use PHPStan\Analyser\Scope;
-use PHPStan\Rules\RuleError;
+use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\Allowed\AllowedPath;
@@ -34,10 +34,11 @@ class DisallowedConstantRuleErrors
 	 * @param Scope $scope
 	 * @param string|null $displayName
 	 * @param list<DisallowedConstant> $disallowedConstants
-	 * @return list<RuleError>
+	 * @param string $identifier
+	 * @return list<IdentifierRuleError>
 	 * @throws ShouldNotHappenException
 	 */
-	public function get(string $constant, Scope $scope, ?string $displayName, array $disallowedConstants): array
+	public function get(string $constant, Scope $scope, ?string $displayName, array $disallowedConstants, string $identifier): array
 	{
 		foreach ($disallowedConstants as $disallowedConstant) {
 			if ($disallowedConstant->getConstant() === $constant && !$this->allowedPath->isAllowedPath($scope, $disallowedConstant)) {
@@ -47,9 +48,7 @@ class DisallowedConstantRuleErrors
 					$displayName && $displayName !== $disallowedConstant->getConstant() ? ' (as ' . $displayName . ')' : '',
 					$this->formatter->formatDisallowedMessage($disallowedConstant->getMessage())
 				));
-				if ($disallowedConstant->getErrorIdentifier()) {
-					$errorBuilder->identifier($disallowedConstant->getErrorIdentifier());
-				}
+				$errorBuilder->identifier($disallowedConstant->getErrorIdentifier() ?? $identifier);
 				if ($disallowedConstant->getErrorTip()) {
 					$errorBuilder->tip($disallowedConstant->getErrorTip());
 				}

--- a/src/RuleErrors/DisallowedControlStructureRuleErrors.php
+++ b/src/RuleErrors/DisallowedControlStructureRuleErrors.php
@@ -32,10 +32,11 @@ class DisallowedControlStructureRuleErrors
 	 * @param Scope $scope
 	 * @param string $controlStructure
 	 * @param list<DisallowedControlStructure> $disallowedControlStructures
+	 * @param string $identifier
 	 * @return list<RuleError>
 	 * @throws ShouldNotHappenException
 	 */
-	public function get(Scope $scope, string $controlStructure, array $disallowedControlStructures): array
+	public function get(Scope $scope, string $controlStructure, array $disallowedControlStructures, string $identifier): array
 	{
 		foreach ($disallowedControlStructures as $disallowedControlStructure) {
 			if (
@@ -47,9 +48,7 @@ class DisallowedControlStructureRuleErrors
 					$controlStructure,
 					$this->formatter->formatDisallowedMessage($disallowedControlStructure->getMessage())
 				));
-				if ($disallowedControlStructure->getErrorIdentifier()) {
-					$errorBuilder->identifier($disallowedControlStructure->getErrorIdentifier());
-				}
+				$errorBuilder->identifier($disallowedControlStructure->getErrorIdentifier() ?? $identifier);
 				if ($disallowedControlStructure->getErrorTip()) {
 					$errorBuilder->tip($disallowedControlStructure->getErrorTip());
 				}

--- a/src/RuleErrors/DisallowedMethodRuleErrors.php
+++ b/src/RuleErrors/DisallowedMethodRuleErrors.php
@@ -93,7 +93,7 @@ class DisallowedMethodRuleErrors
 		foreach ($classes as $class) {
 			if ($class->hasMethod($method->getName())) {
 				$declaredAs = $this->formatter->getFullyQualified($class->getDisplayName(false), $method);
-				$ruleErrors = $this->disallowedCallsRuleErrors->get($node, $scope, $declaredAs, $calledAs, $class->getFileName(), $disallowedCalls);
+				$ruleErrors = $this->disallowedCallsRuleErrors->get($node, $scope, $declaredAs, $calledAs, $class->getFileName(), $disallowedCalls, ErrorIdentifiers::DISALLOWED_METHOD);
 				if ($ruleErrors) {
 					return $ruleErrors;
 				}

--- a/src/RuleErrors/DisallowedNamespaceRuleErrors.php
+++ b/src/RuleErrors/DisallowedNamespaceRuleErrors.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 namespace Spaze\PHPStan\Rules\Disallowed\RuleErrors;
 
 use PHPStan\Analyser\Scope;
-use PHPStan\Rules\RuleError;
+use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\RuleErrorBuilder;
 use Spaze\PHPStan\Rules\Disallowed\Allowed\AllowedPath;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedNamespace;
@@ -37,9 +37,10 @@ class DisallowedNamespaceRuleErrors
 	 * @param string $description
 	 * @param Scope $scope
 	 * @param list<DisallowedNamespace> $disallowedNamespaces
-	 * @return list<RuleError>
+	 * @param string $identifier
+	 * @return list<IdentifierRuleError>
 	 */
-	public function getDisallowedMessage(string $namespace, string $description, Scope $scope, array $disallowedNamespaces): array
+	public function getDisallowedMessage(string $namespace, string $description, Scope $scope, array $disallowedNamespaces, string $identifier): array
 	{
 		foreach ($disallowedNamespaces as $disallowedNamespace) {
 			if ($this->allowedPath->isAllowedPath($scope, $disallowedNamespace)) {
@@ -57,9 +58,7 @@ class DisallowedNamespaceRuleErrors
 				$this->formatter->formatDisallowedMessage($disallowedNamespace->getMessage()),
 				$disallowedNamespace->getNamespace() !== $namespace ? " [{$namespace} matches {$disallowedNamespace->getNamespace()}]" : ''
 			));
-			if ($disallowedNamespace->getErrorIdentifier()) {
-				$errorBuilder->identifier($disallowedNamespace->getErrorIdentifier());
-			}
+			$errorBuilder->identifier($disallowedNamespace->getErrorIdentifier() ?? $identifier);
 			if ($disallowedNamespace->getErrorTip()) {
 				$errorBuilder->tip($disallowedNamespace->getErrorTip());
 			}

--- a/src/RuleErrors/DisallowedVariableRuleErrors.php
+++ b/src/RuleErrors/DisallowedVariableRuleErrors.php
@@ -44,9 +44,7 @@ class DisallowedVariableRuleErrors
 					$disallowedVariable->getVariable(),
 					$this->formatter->formatDisallowedMessage($disallowedVariable->getMessage())
 				));
-				if ($disallowedVariable->getErrorIdentifier()) {
-					$errorBuilder->identifier($disallowedVariable->getErrorIdentifier());
-				}
+				$errorBuilder->identifier($disallowedVariable->getErrorIdentifier() ?? ErrorIdentifiers::DISALLOWED_VARIABLE);
 				if ($disallowedVariable->getErrorTip()) {
 					$errorBuilder->tip($disallowedVariable->getErrorTip());
 				}

--- a/src/RuleErrors/ErrorIdentifiers.php
+++ b/src/RuleErrors/ErrorIdentifiers.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Rules\Disallowed\RuleErrors;
+
+class ErrorIdentifiers
+{
+
+	public const DISALLOWED_ATTRIBUTE = 'disallowed.attribute';
+	public const DISALLOWED_BACKTICK = 'disallowed.backtick';
+	public const DISALLOWED_BREAK = 'disallowed.break';
+	public const DISALLOWED_CLASS = 'disallowed.class';
+	public const DISALLOWED_CLASS_CONSTANT = 'disallowed.classConstant';
+	public const DISALLOWED_CONSTANT = 'disallowed.constant';
+	public const DISALLOWED_CONTINUE = 'disallowed.continue';
+	public const DISALLOWED_DECLARE = 'disallowed.declare';
+	public const DISALLOWED_DIE = 'disallowed.die';
+	public const DISALLOWED_DO_WHILE = 'disallowed.doWhile';
+	public const DISALLOWED_ECHO = 'disallowed.echo';
+	public const DISALLOWED_ELSE = 'disallowed.else';
+	public const DISALLOWED_ELSE_IF = 'disallowed.elseIf';
+	public const DISALLOWED_EMPTY = 'disallowed.empty';
+	public const DISALLOWED_ENUM = 'disallowed.enum';
+	public const DISALLOWED_EVAL = 'disallowed.eval';
+	public const DISALLOWED_EXIT = 'disallowed.exit';
+	public const DISALLOWED_FOR = 'disallowed.for';
+	public const DISALLOWED_FOREACH = 'disallowed.foreach';
+	public const DISALLOWED_FUNCTION = 'disallowed.function';
+	public const DISALLOWED_GOTO = 'disallowed.goto';
+	public const DISALLOWED_IF = 'disallowed.if';
+	public const DISALLOWED_INCLUDE = 'disallowed.include';
+	public const DISALLOWED_INCLUDE_ONCE = 'disallowed.includeOnce';
+	public const DISALLOWED_MATCH = 'disallowed.match';
+	public const DISALLOWED_METHOD = 'disallowed.method';
+	public const DISALLOWED_NAMESPACE = 'disallowed.namespace';
+	public const DISALLOWED_NEW = 'disallowed.new';
+	public const DISALLOWED_PRINT = 'disallowed.print';
+	public const DISALLOWED_REQUIRE = 'disallowed.require';
+	public const DISALLOWED_REQUIRE_ONCE = 'disallowed.requireOnce';
+	public const DISALLOWED_RETURN = 'disallowed.return';
+	public const DISALLOWED_SWITCH = 'disallowed.switch';
+	public const DISALLOWED_TRAIT = 'disallowed.trait';
+	public const DISALLOWED_VARIABLE = 'disallowed.variable';
+	public const DISALLOWED_WHILE = 'disallowed.while';
+
+}

--- a/src/Usages/ClassConstantUsages.php
+++ b/src/Usages/ClassConstantUsages.php
@@ -18,6 +18,7 @@ use Spaze\PHPStan\Rules\Disallowed\DisallowedConstant;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedConstantFactory;
 use Spaze\PHPStan\Rules\Disallowed\Formatter\Formatter;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedConstantRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\ErrorIdentifiers;
 use Spaze\PHPStan\Rules\Disallowed\Type\TypeResolver;
 
 /**
@@ -133,7 +134,7 @@ class ClassConstantUsages implements Rule
 				return [];
 			}
 		}
-		return $this->disallowedConstantRuleErrors->get($this->getFullyQualified($classNames, $constant), $scope, $displayName, $this->disallowedConstants);
+		return $this->disallowedConstantRuleErrors->get($this->getFullyQualified($classNames, $constant), $scope, $displayName, $this->disallowedConstants, ErrorIdentifiers::DISALLOWED_CLASS_CONSTANT);
 	}
 
 

--- a/src/Usages/ConstantUsages.php
+++ b/src/Usages/ConstantUsages.php
@@ -12,6 +12,7 @@ use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedConstant;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedConstantFactory;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedConstantRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\ErrorIdentifiers;
 
 /**
  * Reports on constant usage.
@@ -57,7 +58,7 @@ class ConstantUsages implements Rule
 	public function processNode(Node $node, Scope $scope): array
 	{
 		/** @var ConstFetch $node */
-		return $this->disallowedConstantRuleError->get((string)$node->name, $scope, null, $this->disallowedConstants);
+		return $this->disallowedConstantRuleError->get((string)$node->name, $scope, null, $this->disallowedConstants, ErrorIdentifiers::DISALLOWED_CONSTANT);
 	}
 
 }


### PR DESCRIPTION
https://phpstan.org/blog/phpstan-1-11-errors-identifiers-phpstan-pro-reboot#error-identifiers

Original support for optional identifiers added in #97, this adds a default one which you can still override as before. Previously, the identifier would be added, now it would override the default one.