### PR TITLE
Process `ClassConstFetch` where `$class` is `Name` only for enums

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 	},
 	"require": {
 		"php": "^7.2 || ^8.0",
-		"phpstan/phpstan": "^1.10.52"
+		"phpstan/phpstan": "^1.12.6"
 	},
 	"require-dev": {
 		"nette/neon": "^3.2",

--- a/src/Usages/NamespaceUsages.php
+++ b/src/Usages/NamespaceUsages.php
@@ -93,15 +93,13 @@ class NamespaceUsages implements Rule
 		} elseif ($node instanceof StaticCall && $node->class instanceof Name) {
 			$namespaces = [$node->class->toString()];
 		} elseif ($node instanceof ClassConstFetch && $node->class instanceof Name) {
+			$namespaces = [];
 			$classReflection = $scope->resolveTypeByName($node->class)->getClassReflection();
 			if ($classReflection && $classReflection->isEnum()) {
 				$description = 'Enum';
 				$identifier = ErrorIdentifiers::DISALLOWED_ENUM;
-			} else {
-				$description = 'Class';
-				$identifier = ErrorIdentifiers::DISALLOWED_CLASS;
+				$namespaces = [$node->class->toString()];
 			}
-			$namespaces = [$node->class->toString()];
 		} elseif ($node instanceof Class_ && ($node->extends !== null || count($node->implements) > 0)) {
 			$namespaces = [];
 


### PR DESCRIPTION
PHPStan 1.12.6 started "Process[ing] ClassConstFetch::$class when it's a Name node" (phpstan/phpstan-src@712c33e) and that now duplicates findings by the `FullyQualified` check above on class constants.

https://github.com/phpstan/phpstan/releases/tag/1.12.6