### PR TITLE
Detect dynamic function calls

### DIFF
--- a/tests/Calls/FunctionCallsAllowInFunctionsTest.php
+++ b/tests/Calls/FunctionCallsAllowInFunctionsTest.php
@@ -7,6 +7,7 @@ use PHPStan\Rules\Rule;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
+use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
 
 class FunctionCallsAllowInFunctionsTest extends RuleTestCase
@@ -22,6 +23,7 @@ class FunctionCallsAllowInFunctionsTest extends RuleTestCase
 			$container->getByType(DisallowedCallsRuleErrors::class),
 			$container->getByType(DisallowedCallFactory::class),
 			$this->createReflectionProvider(),
+			$container->getByType(Normalizer::class),
 			[
 				[
 					'function' => 'md*()',

--- a/tests/Calls/FunctionCallsAllowInMethodsTest.php
+++ b/tests/Calls/FunctionCallsAllowInMethodsTest.php
@@ -7,6 +7,7 @@ use PHPStan\Rules\Rule;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
+use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
 
 class FunctionCallsAllowInMethodsTest extends RuleTestCase
@@ -22,6 +23,7 @@ class FunctionCallsAllowInMethodsTest extends RuleTestCase
 			$container->getByType(DisallowedCallsRuleErrors::class),
 			$container->getByType(DisallowedCallFactory::class),
 			$this->createReflectionProvider(),
+			$container->getByType(Normalizer::class),
 			[
 				[
 					'function' => 'md5_file()',

--- a/tests/Calls/FunctionCallsDefinedInTest.php
+++ b/tests/Calls/FunctionCallsDefinedInTest.php
@@ -7,6 +7,7 @@ use PHPStan\Rules\Rule;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
+use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
 
 class FunctionCallsDefinedInTest extends RuleTestCase
@@ -22,6 +23,7 @@ class FunctionCallsDefinedInTest extends RuleTestCase
 			$container->getByType(DisallowedCallsRuleErrors::class),
 			$container->getByType(DisallowedCallFactory::class),
 			$this->createReflectionProvider(),
+			$container->getByType(Normalizer::class),
 			[
 				[
 					'function' => '\\Foo\\Bar\\Waldo\\f*()',

--- a/tests/Calls/FunctionCallsInMultipleNamespacesTest.php
+++ b/tests/Calls/FunctionCallsInMultipleNamespacesTest.php
@@ -7,6 +7,7 @@ use PHPStan\Rules\Rule;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
+use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
 
 class FunctionCallsInMultipleNamespacesTest extends RuleTestCase
@@ -22,6 +23,7 @@ class FunctionCallsInMultipleNamespacesTest extends RuleTestCase
 			$container->getByType(DisallowedCallsRuleErrors::class),
 			$container->getByType(DisallowedCallFactory::class),
 			$this->createReflectionProvider(),
+			$container->getByType(Normalizer::class),
 			[
 				[
 					'function' => '__()',

--- a/tests/Calls/FunctionCallsNamedParamsTest.php
+++ b/tests/Calls/FunctionCallsNamedParamsTest.php
@@ -8,6 +8,7 @@ use PHPStan\ShouldNotHappenException;
 use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
+use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
 
 /**
@@ -27,6 +28,7 @@ class FunctionCallsNamedParamsTest extends RuleTestCase
 			$container->getByType(DisallowedCallsRuleErrors::class),
 			$container->getByType(DisallowedCallFactory::class),
 			$this->createReflectionProvider(),
+			$container->getByType(Normalizer::class),
 			[
 				[
 					'function' => 'Foo\Bar\Waldo\foo()',

--- a/tests/Calls/FunctionCallsParamsMessagesTest.php
+++ b/tests/Calls/FunctionCallsParamsMessagesTest.php
@@ -7,6 +7,7 @@ use PHPStan\Rules\Rule;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
+use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
 
 class FunctionCallsParamsMessagesTest extends RuleTestCase
@@ -22,6 +23,7 @@ class FunctionCallsParamsMessagesTest extends RuleTestCase
 			$container->getByType(DisallowedCallsRuleErrors::class),
 			$container->getByType(DisallowedCallFactory::class),
 			$this->createReflectionProvider(),
+			$container->getByType(Normalizer::class),
 			[
 				[
 					'function' => '\Foo\Bar\Waldo\config()',

--- a/tests/Calls/FunctionCallsTest.php
+++ b/tests/Calls/FunctionCallsTest.php
@@ -7,6 +7,7 @@ use PHPStan\Rules\Rule;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
+use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
 use Waldo\Quux\Blade;
 
@@ -23,6 +24,7 @@ class FunctionCallsTest extends RuleTestCase
 			$container->getByType(DisallowedCallsRuleErrors::class),
 			$container->getByType(DisallowedCallFactory::class),
 			$this->createReflectionProvider(),
+			$container->getByType(Normalizer::class),
 			[
 				[
 					'function' => '\var_dump()',
@@ -303,6 +305,38 @@ class FunctionCallsTest extends RuleTestCase
 			[
 				'Calling Foo\Bar\Waldo\config() is forbidden.',
 				91,
+			],
+			[
+				'Calling print_r() is forbidden, nope.',
+				102,
+			],
+			[
+				'Calling print_r() is forbidden, nope.',
+				103,
+			],
+			[
+				'Calling print_r() is forbidden, nope.',
+				106,
+			],
+			[
+				'Calling Print_R() is forbidden, nope. [Print_R() matches print_r()]',
+				107,
+			],
+			[
+				'Calling Foo\Bar\waldo() is forbidden, whoa, a namespace.',
+				110,
+			],
+			[
+				'Calling Foo\Bar\waldo() is forbidden, whoa, a namespace.',
+				111,
+			],
+			[
+				'Calling Foo\Bar\waldo() is forbidden, whoa, a namespace.',
+				114,
+			],
+			[
+				'Calling Foo\Bar\Waldo() is forbidden, whoa, a namespace. [Foo\Bar\Waldo() matches Foo\Bar\waldo()]',
+				115,
 			],
 		]);
 		$this->analyse([__DIR__ . '/../src/disallowed-allow/functionCalls.php'], [

--- a/tests/Calls/FunctionCallsTypeStringParamsInvalidFlagsConfigTest.php
+++ b/tests/Calls/FunctionCallsTypeStringParamsInvalidFlagsConfigTest.php
@@ -6,6 +6,7 @@ namespace Spaze\PHPStan\Rules\Disallowed\Calls;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Testing\PHPStanTestCase;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
+use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
 
 class FunctionCallsTypeStringParamsInvalidFlagsConfigTest extends PHPStanTestCase
@@ -23,6 +24,7 @@ class FunctionCallsTypeStringParamsInvalidFlagsConfigTest extends PHPStanTestCas
 			$container->getByType(DisallowedCallsRuleErrors::class),
 			$container->getByType(DisallowedCallFactory::class),
 			$this->createReflectionProvider(),
+			$container->getByType(Normalizer::class),
 			[
 				[
 					'function' => '\Foo\Bar\Waldo\intParam1()',

--- a/tests/Calls/FunctionCallsTypeStringParamsTest.php
+++ b/tests/Calls/FunctionCallsTypeStringParamsTest.php
@@ -7,6 +7,7 @@ use PHPStan\Rules\Rule;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
+use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
 
 class FunctionCallsTypeStringParamsTest extends RuleTestCase
@@ -22,6 +23,7 @@ class FunctionCallsTypeStringParamsTest extends RuleTestCase
 			$container->getByType(DisallowedCallsRuleErrors::class),
 			$container->getByType(DisallowedCallFactory::class),
 			$this->createReflectionProvider(),
+			$container->getByType(Normalizer::class),
 			[
 				[
 					'function' => '\Foo\Bar\Waldo\config()',

--- a/tests/Calls/FunctionCallsUnsupportedParamConfigTest.php
+++ b/tests/Calls/FunctionCallsUnsupportedParamConfigTest.php
@@ -6,6 +6,7 @@ namespace Spaze\PHPStan\Rules\Disallowed\Calls;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Testing\PHPStanTestCase;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
+use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
 
 class FunctionCallsUnsupportedParamConfigTest extends PHPStanTestCase
@@ -23,6 +24,7 @@ class FunctionCallsUnsupportedParamConfigTest extends PHPStanTestCase
 			$container->getByType(DisallowedCallsRuleErrors::class),
 			$container->getByType(DisallowedCallFactory::class),
 			$this->createReflectionProvider(),
+			$container->getByType(Normalizer::class),
 			[
 				[
 					'function' => [

--- a/tests/src/disallowed-allow/functionCalls.php
+++ b/tests/src/disallowed-allow/functionCalls.php
@@ -96,3 +96,20 @@ hash((new stdClass())->property . 'foo', 'NAH');
 
 // allowed by path
 shell_by();
+
+// allowed by path
+$sneaky = 'print_r';
+$sneaky('foo');
+('print_r')('foo');
+
+$sneaky = '\print_r';
+$sneaky('foo');
+('\Print_R')('foo');
+
+$sneaky = 'Foo\Bar\waldo';
+$sneaky('foo');
+('Foo\Bar\waldo')('foo');
+
+$sneaky = '\Foo\Bar\waldo';
+$sneaky('foo');
+('\Foo\Bar\Waldo')('foo');

--- a/tests/src/disallowed/functionCalls.php
+++ b/tests/src/disallowed/functionCalls.php
@@ -96,3 +96,20 @@ hash((new stdClass())->property . 'foo', 'NAH');
 
 // would match shell_* but is excluded
 shell_by();
+
+// disallowed
+$sneaky = 'print_r';
+$sneaky('foo');
+('print_r')('foo');
+
+$sneaky = '\print_r';
+$sneaky('foo');
+('\Print_R')('foo');
+
+$sneaky = 'Foo\Bar\waldo';
+$sneaky('foo');
+('Foo\Bar\waldo')('foo');
+
+$sneaky = '\Foo\Bar\waldo';
+$sneaky('foo');
+('\Foo\Bar\Waldo')('foo');


### PR DESCRIPTION
For example:
```php
$sneaky = 'print_r';
$sneaky('foo');
```
and
```php
('print_r')('foo');
```

Ref #275