### PR TITLE
Test anonymous class-related calls and usages

### DIFF
--- a/src/RuleErrors/DisallowedMethodRuleErrors.php
+++ b/src/RuleErrors/DisallowedMethodRuleErrors.php
@@ -57,7 +57,8 @@ class DisallowedMethodRuleErrors
 		if ($calledOnType->canCallMethods()->yes() && $calledOnType->hasMethod($node->name->name)->yes()) {
 			$method = $calledOnType->getMethod($node->name->name, $scope);
 			$declaringClass = $method->getDeclaringClass();
-			$classNames = $calledOnType->getObjectClassNames();
+			$classes = $calledOnType->getObjectClassReflections();
+			$classNames = array_map(fn($class): string => $class->isAnonymous() ? 'class@anonymous' : $class->getName(), $classes);
 			if (count($classNames) === 0) {
 				$calledAs = null;
 			} else {

--- a/src/Usages/ClassConstantUsages.php
+++ b/src/Usages/ClassConstantUsages.php
@@ -108,7 +108,9 @@ class ClassConstantUsages implements Rule
 		}
 
 		$usedOnType = $type->getObjectTypeOrClassStringObjectType();
-		$displayName = $usedOnType->getObjectClassNames() ? $this->getFullyQualified($usedOnType->getObjectClassNames(), $constant) : null;
+		$classes = $usedOnType->getObjectClassReflections();
+		$classNames = array_map(fn($class): string => $class->isAnonymous() ? 'class@anonymous' : $class->getName(), $classes);
+		$displayName = $classNames ? $this->getFullyQualified($classNames, $constant) : null;
 		if ($usedOnType->getConstantStrings()) {
 			$classNames = array_map(
 				function (ConstantStringType $constantString): string {

--- a/tests/Calls/MethodCallsTest.php
+++ b/tests/Calls/MethodCallsTest.php
@@ -213,6 +213,14 @@ class MethodCallsTest extends RuleTestCase
 				'Calling Interfaces\BaseInterface::x() (as Interfaces\Implementation::x()) is forbidden, BaseInterface::x*() methods are dangerous. [Interfaces\BaseInterface::x() matches Interfaces\BaseInterface::x*()]',
 				74,
 			],
+			[
+				'Calling Interfaces\BaseInterface::x() (as class@anonymous::x()) is forbidden, BaseInterface::x*() methods are dangerous. [Interfaces\BaseInterface::x() matches Interfaces\BaseInterface::x*()]',
+				87,
+			],
+			[
+				'Calling Inheritance\Base::x() (as class@anonymous::x()) is forbidden, Base::x*() methods are dangerous. [Inheritance\Base::x() matches Inheritance\Base::x*()]',
+				91,
+			],
 		]);
 		$this->analyse([__DIR__ . '/../src/disallowed-allow/methodCalls.php'], [
 			[

--- a/tests/Calls/StaticCallsTest.php
+++ b/tests/Calls/StaticCallsTest.php
@@ -177,6 +177,14 @@ class StaticCallsTest extends RuleTestCase
 				'Calling Interfaces\BaseInterface::y() (as Interfaces\Implementation::y()) is forbidden, method BaseInterface::y() is dangerous. [Interfaces\BaseInterface::y() matches Interfaces\BaseInterface::y*()]',
 				40,
 			],
+			[
+				'Calling Interfaces\BaseInterface::y() (as class@anonymous::y()) is forbidden, method BaseInterface::y() is dangerous. [Interfaces\BaseInterface::y() matches Interfaces\BaseInterface::y*()]',
+				53,
+			],
+			[
+				'Calling Inheritance\Base::woofer() (as class@anonymous::woofer()) is forbidden, method Base::woofer() is dangerous. [Inheritance\Base::woofer() matches Inheritance\Base::w*f*r()]',
+				57,
+			],
 		]);
 		$this->analyse([__DIR__ . '/../src/disallowed-allow/staticCalls.php'], [
 			[

--- a/tests/Usages/ClassConstantUsagesTest.php
+++ b/tests/Usages/ClassConstantUsagesTest.php
@@ -136,6 +136,10 @@ class ClassConstantUsagesTest extends RuleTestCase
 				'Using PhpOption\Option::NAME (as PhpOption\None::NAME) is forbidden, no PhpOption.',
 				37,
 			],
+			[
+				'Using Inheritance\Base::BELONG (as class@anonymous::BELONG) is forbidden, belong to us.',
+				44,
+			],
 		]);
 		$this->analyse([__DIR__ . '/../src/disallowed-allow/constantUsages.php'], []);
 	}

--- a/tests/Usages/NamespaceUsagesTest.php
+++ b/tests/Usages/NamespaceUsagesTest.php
@@ -145,6 +145,10 @@ class NamespaceUsagesTest extends RuleTestCase
 				'Class ZipArchive is forbidden, use clippy instead of zippy.',
 				50,
 			],
+			[
+				'Namespace Inheritance\Base is forbidden, no inheritance sub base.',
+				56,
+			],
 		]);
 		$this->analyse([__DIR__ . '/../src/disallowed-allow/namespaceUsages.php'], []);
 	}

--- a/tests/src/disallowed-allow/constantUsages.php
+++ b/tests/src/disallowed-allow/constantUsages.php
@@ -38,3 +38,7 @@ $none::NAME;
 
 // not disallowed by path
 PHP_EOL;
+
+// allowed by path
+$foo = new class extends Base {};
+$foo::BELONG;

--- a/tests/src/disallowed-allow/methodCalls.php
+++ b/tests/src/disallowed-allow/methodCalls.php
@@ -72,3 +72,20 @@ $blade->runway();
 
 // allowed by path
 (new Interfaces\Implementation())->x();
+$foo = new class implements Interfaces\BaseInterface {
+
+	public function x(): void
+	{
+	}
+
+
+	public static function y(): void
+	{
+	}
+
+};
+$foo->x();
+
+// allowed by path
+$foo = new class extends Inheritance\Base {};
+$foo->x();

--- a/tests/src/disallowed-allow/namespaceUsages.php
+++ b/tests/src/disallowed-allow/namespaceUsages.php
@@ -9,6 +9,7 @@ use Inheritance\Sub;
 use Traits\TestTrait;
 use Waldo\Foo\Bar;
 use Waldo\Quux\blade;
+use ZipArchive;
 
 class Service extends Base implements SomeInterface
 {
@@ -35,6 +36,18 @@ class Service extends Base implements SomeInterface
 	public function callConstant()
 	{
 		return Bar::NAME;
+	}
+
+
+	public function callNew()
+	{
+		return new Bar();
+	}
+
+
+	public function disallowedByPath()
+	{
+		return ZipArchive::EM_TRAD_PKWARE;
 	}
 
 }

--- a/tests/src/disallowed-allow/namespaceUsages.php
+++ b/tests/src/disallowed-allow/namespaceUsages.php
@@ -50,4 +50,10 @@ class Service extends Base implements SomeInterface
 		return ZipArchive::EM_TRAD_PKWARE;
 	}
 
+
+	public function anonymousClass()
+	{
+		return new class extends Base {};
+	}
+
 }

--- a/tests/src/disallowed-allow/staticCalls.php
+++ b/tests/src/disallowed-allow/staticCalls.php
@@ -38,3 +38,20 @@ PhpOption\Some::create('value');
 
 // interface method allowed by path
 Interfaces\Implementation::y();
+$foo = new class implements Interfaces\BaseInterface {
+
+	public function x(): void
+	{
+	}
+
+
+	public static function y(): void
+	{
+	}
+
+};
+$foo::y();
+
+// allowed by path
+$foo = new class extends Inheritance\Base {};
+$foo::woofer();

--- a/tests/src/disallowed/constantUsages.php
+++ b/tests/src/disallowed/constantUsages.php
@@ -38,3 +38,7 @@ $none::NAME;
 
 // disallowed by path
 PHP_EOL;
+
+// disallowed
+$foo = new class extends Base {};
+$foo::BELONG;

--- a/tests/src/disallowed/methodCalls.php
+++ b/tests/src/disallowed/methodCalls.php
@@ -72,3 +72,20 @@ $blade->runway();
 
 // disallowed interface method
 (new Interfaces\Implementation())->x();
+$foo = new class implements Interfaces\BaseInterface {
+
+	public function x(): void
+	{
+	}
+
+
+	public static function y(): void
+	{
+	}
+
+};
+$foo->x();
+
+// disallowed parent method
+$foo = new class extends Inheritance\Base {};
+$foo->x();

--- a/tests/src/disallowed/namespaceUsages.php
+++ b/tests/src/disallowed/namespaceUsages.php
@@ -50,4 +50,10 @@ class Service extends Base implements SomeInterface
 		return ZipArchive::EM_TRAD_PKWARE;
 	}
 
+
+	public function anonymousClass()
+	{
+		return new class extends Base {};
+	}
+
 }

--- a/tests/src/disallowed/staticCalls.php
+++ b/tests/src/disallowed/staticCalls.php
@@ -38,3 +38,20 @@ PhpOption\Some::create('value');
 
 // disallowed on interface
 Interfaces\Implementation::y();
+$foo = new class implements Interfaces\BaseInterface {
+
+	public function x(): void
+	{
+	}
+
+
+	public static function y(): void
+	{
+	}
+
+};
+$foo::y();
+
+// disallowed parent method
+$foo = new class extends Inheritance\Base {};
+$foo::woofer();


### PR DESCRIPTION
The things were already detected and now there's a test for them as well. Anonymous classes are displayed as `class@anonymous` similar to what `get_class(new class {})` would return.

- Test disallowed constants on anonymous child classes
- Test disallowed method calls on anonymous classes
- Test anonymous class inheriting from a disallowed class

Ref #275