### PR TITLE
More dynamic calls

### DIFF
--- a/src/Type/TypeResolver.php
+++ b/src/Type/TypeResolver.php
@@ -4,7 +4,9 @@ declare(strict_types = 1);
 namespace Spaze\PHPStan\Rules\Disallowed\Type;
 
 use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
@@ -20,6 +22,18 @@ class TypeResolver
 	public function getType($class, Scope $scope): Type
 	{
 		return $class instanceof Name ? new ObjectType($scope->resolveName($class)) : $scope->getType($class);
+	}
+
+
+	public function getVariableStringValue(Variable $variable, Scope $scope): ?string
+	{
+		$variableNameNode = $variable->name;
+		$variableName = $variableNameNode instanceof String_ ? $variableNameNode->value : $variableNameNode;
+		if (!is_string($variableName)) {
+			return null;
+		}
+		$value = $scope->getVariableType($variableName)->getConstantScalarValues()[0];
+		return is_string($value) ? $value : null;
 	}
 
 }

--- a/tests/Calls/FunctionCallsAllowInFunctionsTest.php
+++ b/tests/Calls/FunctionCallsAllowInFunctionsTest.php
@@ -9,6 +9,7 @@ use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\Type\TypeResolver;
 
 class FunctionCallsAllowInFunctionsTest extends RuleTestCase
 {
@@ -24,6 +25,7 @@ class FunctionCallsAllowInFunctionsTest extends RuleTestCase
 			$container->getByType(DisallowedCallFactory::class),
 			$this->createReflectionProvider(),
 			$container->getByType(Normalizer::class),
+			$container->getByType(TypeResolver::class),
 			[
 				[
 					'function' => 'md*()',

--- a/tests/Calls/FunctionCallsAllowInMethodsTest.php
+++ b/tests/Calls/FunctionCallsAllowInMethodsTest.php
@@ -9,6 +9,7 @@ use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\Type\TypeResolver;
 
 class FunctionCallsAllowInMethodsTest extends RuleTestCase
 {
@@ -24,6 +25,7 @@ class FunctionCallsAllowInMethodsTest extends RuleTestCase
 			$container->getByType(DisallowedCallFactory::class),
 			$this->createReflectionProvider(),
 			$container->getByType(Normalizer::class),
+			$container->getByType(TypeResolver::class),
 			[
 				[
 					'function' => 'md5_file()',

--- a/tests/Calls/FunctionCallsDefinedInTest.php
+++ b/tests/Calls/FunctionCallsDefinedInTest.php
@@ -9,6 +9,7 @@ use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\Type\TypeResolver;
 
 class FunctionCallsDefinedInTest extends RuleTestCase
 {
@@ -24,6 +25,7 @@ class FunctionCallsDefinedInTest extends RuleTestCase
 			$container->getByType(DisallowedCallFactory::class),
 			$this->createReflectionProvider(),
 			$container->getByType(Normalizer::class),
+			$container->getByType(TypeResolver::class),
 			[
 				[
 					'function' => '\\Foo\\Bar\\Waldo\\f*()',

--- a/tests/Calls/FunctionCallsInMultipleNamespacesTest.php
+++ b/tests/Calls/FunctionCallsInMultipleNamespacesTest.php
@@ -9,6 +9,7 @@ use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\Type\TypeResolver;
 
 class FunctionCallsInMultipleNamespacesTest extends RuleTestCase
 {
@@ -24,6 +25,7 @@ class FunctionCallsInMultipleNamespacesTest extends RuleTestCase
 			$container->getByType(DisallowedCallFactory::class),
 			$this->createReflectionProvider(),
 			$container->getByType(Normalizer::class),
+			$container->getByType(TypeResolver::class),
 			[
 				[
 					'function' => '__()',

--- a/tests/Calls/FunctionCallsNamedParamsTest.php
+++ b/tests/Calls/FunctionCallsNamedParamsTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\Attributes\RequiresPhp;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\Type\TypeResolver;
 
 /**
  * @requires PHP >= 8.0
@@ -29,6 +30,7 @@ class FunctionCallsNamedParamsTest extends RuleTestCase
 			$container->getByType(DisallowedCallFactory::class),
 			$this->createReflectionProvider(),
 			$container->getByType(Normalizer::class),
+			$container->getByType(TypeResolver::class),
 			[
 				[
 					'function' => 'Foo\Bar\Waldo\foo()',

--- a/tests/Calls/FunctionCallsParamsMessagesTest.php
+++ b/tests/Calls/FunctionCallsParamsMessagesTest.php
@@ -9,6 +9,7 @@ use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\Type\TypeResolver;
 
 class FunctionCallsParamsMessagesTest extends RuleTestCase
 {
@@ -24,6 +25,7 @@ class FunctionCallsParamsMessagesTest extends RuleTestCase
 			$container->getByType(DisallowedCallFactory::class),
 			$this->createReflectionProvider(),
 			$container->getByType(Normalizer::class),
+			$container->getByType(TypeResolver::class),
 			[
 				[
 					'function' => '\Foo\Bar\Waldo\config()',

--- a/tests/Calls/FunctionCallsTest.php
+++ b/tests/Calls/FunctionCallsTest.php
@@ -9,6 +9,7 @@ use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\Type\TypeResolver;
 use Waldo\Quux\Blade;
 
 class FunctionCallsTest extends RuleTestCase
@@ -25,6 +26,7 @@ class FunctionCallsTest extends RuleTestCase
 			$container->getByType(DisallowedCallFactory::class),
 			$this->createReflectionProvider(),
 			$container->getByType(Normalizer::class),
+			$container->getByType(TypeResolver::class),
 			[
 				[
 					'function' => '\var_dump()',
@@ -335,8 +337,16 @@ class FunctionCallsTest extends RuleTestCase
 				114,
 			],
 			[
-				'Calling Foo\Bar\Waldo() is forbidden, whoa, a namespace. [Foo\Bar\Waldo() matches Foo\Bar\waldo()]',
+				'Calling Foo\Bar\waldo() is forbidden, whoa, a namespace.',
 				115,
+			],
+			[
+				'Calling Foo\Bar\waldo() is forbidden, whoa, a namespace.',
+				117,
+			],
+			[
+				'Calling Foo\Bar\Waldo() is forbidden, whoa, a namespace. [Foo\Bar\Waldo() matches Foo\Bar\waldo()]',
+				118,
 			],
 		]);
 		$this->analyse([__DIR__ . '/../src/disallowed-allow/functionCalls.php'], [

--- a/tests/Calls/FunctionCallsTypeStringParamsInvalidFlagsConfigTest.php
+++ b/tests/Calls/FunctionCallsTypeStringParamsInvalidFlagsConfigTest.php
@@ -8,6 +8,7 @@ use PHPStan\Testing\PHPStanTestCase;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\Type\TypeResolver;
 
 class FunctionCallsTypeStringParamsInvalidFlagsConfigTest extends PHPStanTestCase
 {
@@ -25,6 +26,7 @@ class FunctionCallsTypeStringParamsInvalidFlagsConfigTest extends PHPStanTestCas
 			$container->getByType(DisallowedCallFactory::class),
 			$this->createReflectionProvider(),
 			$container->getByType(Normalizer::class),
+			$container->getByType(TypeResolver::class),
 			[
 				[
 					'function' => '\Foo\Bar\Waldo\intParam1()',

--- a/tests/Calls/FunctionCallsTypeStringParamsTest.php
+++ b/tests/Calls/FunctionCallsTypeStringParamsTest.php
@@ -9,6 +9,7 @@ use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\Type\TypeResolver;
 
 class FunctionCallsTypeStringParamsTest extends RuleTestCase
 {
@@ -24,6 +25,7 @@ class FunctionCallsTypeStringParamsTest extends RuleTestCase
 			$container->getByType(DisallowedCallFactory::class),
 			$this->createReflectionProvider(),
 			$container->getByType(Normalizer::class),
+			$container->getByType(TypeResolver::class),
 			[
 				[
 					'function' => '\Foo\Bar\Waldo\config()',

--- a/tests/Calls/FunctionCallsUnsupportedParamConfigTest.php
+++ b/tests/Calls/FunctionCallsUnsupportedParamConfigTest.php
@@ -8,6 +8,7 @@ use PHPStan\Testing\PHPStanTestCase;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
 use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\Type\TypeResolver;
 
 class FunctionCallsUnsupportedParamConfigTest extends PHPStanTestCase
 {
@@ -25,6 +26,7 @@ class FunctionCallsUnsupportedParamConfigTest extends PHPStanTestCase
 			$container->getByType(DisallowedCallFactory::class),
 			$this->createReflectionProvider(),
 			$container->getByType(Normalizer::class),
+			$container->getByType(TypeResolver::class),
 			[
 				[
 					'function' => [

--- a/tests/Calls/MethodCallsTest.php
+++ b/tests/Calls/MethodCallsTest.php
@@ -221,6 +221,14 @@ class MethodCallsTest extends RuleTestCase
 				'Calling Inheritance\Base::x() (as class@anonymous::x()) is forbidden, Base::x*() methods are dangerous. [Inheritance\Base::x() matches Inheritance\Base::x*()]',
 				91,
 			],
+			[
+				"Calling Waldo\Quux\Blade::runner() is forbidden, I've seen tests you people wouldn't believe. [Waldo\Quux\Blade::runner() matches Waldo\Quux\Blade::run*()]",
+				95,
+			],
+			[
+				"Calling Waldo\Quux\Blade::runner() is forbidden, I've seen tests you people wouldn't believe. [Waldo\Quux\Blade::runner() matches Waldo\Quux\Blade::run*()]",
+				96,
+			],
 		]);
 		$this->analyse([__DIR__ . '/../src/disallowed-allow/methodCalls.php'], [
 			[

--- a/tests/Calls/StaticCallsTest.php
+++ b/tests/Calls/StaticCallsTest.php
@@ -185,6 +185,14 @@ class StaticCallsTest extends RuleTestCase
 				'Calling Inheritance\Base::woofer() (as class@anonymous::woofer()) is forbidden, method Base::woofer() is dangerous. [Inheritance\Base::woofer() matches Inheritance\Base::w*f*r()]',
 				57,
 			],
+			[
+				'Calling Fiction\Pulp\Royale::withCheese() is forbidden, a Quarter Pounder with Cheese?',
+				60,
+			],
+			[
+				'Calling Fiction\Pulp\Royale::withCheese() is forbidden, a Quarter Pounder with Cheese?',
+				61,
+			],
 		]);
 		$this->analyse([__DIR__ . '/../src/disallowed-allow/staticCalls.php'], [
 			[

--- a/tests/src/disallowed-allow/functionCalls.php
+++ b/tests/src/disallowed-allow/functionCalls.php
@@ -108,8 +108,11 @@ $sneaky('foo');
 
 $sneaky = 'Foo\Bar\waldo';
 $sneaky('foo');
-('Foo\Bar\waldo')('foo');
+${'sneaky'}('foo');
 
 $sneaky = '\Foo\Bar\waldo';
 $sneaky('foo');
+${'sneaky'}('foo');
+
+('Foo\Bar\waldo')('foo');
 ('\Foo\Bar\Waldo')('foo');

--- a/tests/src/disallowed-allow/methodCalls.php
+++ b/tests/src/disallowed-allow/methodCalls.php
@@ -89,3 +89,8 @@ $foo->x();
 // allowed by path
 $foo = new class extends Inheritance\Base {};
 $foo->x();
+
+// dynamic method name allowed by path and only with these params
+$method = 'runner';
+$blade->$method(42, true, '909');
+$blade->${'method'}(42, true, '909');

--- a/tests/src/disallowed-allow/staticCalls.php
+++ b/tests/src/disallowed-allow/staticCalls.php
@@ -55,3 +55,7 @@ $foo::y();
 // allowed by path
 $foo = new class extends Inheritance\Base {};
 $foo::woofer();
+
+$method = 'withCheese';
+Pulp\Royale::$method();
+Pulp\Royale::${'method'}();

--- a/tests/src/disallowed/functionCalls.php
+++ b/tests/src/disallowed/functionCalls.php
@@ -108,8 +108,11 @@ $sneaky('foo');
 
 $sneaky = 'Foo\Bar\waldo';
 $sneaky('foo');
-('Foo\Bar\waldo')('foo');
+${'sneaky'}('foo');
 
 $sneaky = '\Foo\Bar\waldo';
 $sneaky('foo');
+${'sneaky'}('foo');
+
+('Foo\Bar\waldo')('foo');
 ('\Foo\Bar\Waldo')('foo');

--- a/tests/src/disallowed/methodCalls.php
+++ b/tests/src/disallowed/methodCalls.php
@@ -89,3 +89,8 @@ $foo->x();
 // disallowed parent method
 $foo = new class extends Inheritance\Base {};
 $foo->x();
+
+// disallowed dynamic method name
+$method = 'runner';
+$blade->$method(42, true, '909');
+$blade->${'method'}(42, true, '909');

--- a/tests/src/disallowed/staticCalls.php
+++ b/tests/src/disallowed/staticCalls.php
@@ -55,3 +55,7 @@ $foo::y();
 // disallowed parent method
 $foo = new class extends Inheritance\Base {};
 $foo::woofer();
+
+$method = 'withCheese';
+Pulp\Royale::$method();
+Pulp\Royale::${'method'}();


### PR DESCRIPTION
Detect
- `${'variable'}('foo')` dynamic function calls
- `$object->$method()` and `$object->${'method'}()`
- `Class::$method()` and `Class::${'method'}()`

Ref #275
Follow-up to #276