### PR TITLE
Detect callables in constructors

### DIFF
--- a/tests/Calls/NewCallsCallableParametersTest.php
+++ b/tests/Calls/NewCallsCallableParametersTest.php
@@ -1,0 +1,184 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Rules\Disallowed\Calls;
+
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PHPStan\ShouldNotHappenException;
+use PHPStan\Testing\RuleTestCase;
+use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallableParameterRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedFunctionRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedMethodRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\Type\TypeResolver;
+
+class NewCallsCallableParametersTest extends RuleTestCase
+{
+
+	/**
+	 * @throws ShouldNotHappenException
+	 */
+	protected function getRule(): Rule
+	{
+		$container = self::getContainer();
+		$disallowedCallableParameterRuleErrors = new DisallowedCallableParameterRuleErrors(
+			$container->getByType(TypeResolver::class),
+			$container->getByType(DisallowedFunctionRuleErrors::class),
+			$container->getByType(DisallowedMethodRuleErrors::class),
+			$container->getByType(DisallowedCallFactory::class),
+			$container->getByType(ReflectionProvider::class),
+			[
+				[
+					'function' => 'var_dump()',
+					'allowIn' => [
+						__DIR__ . '/../src/disallowed-allow/*.php',
+						__DIR__ . '/../src/*-allow/*.*',
+					],
+				],
+			],
+			[
+				[
+					'method' => 'Callbacks::call()',
+					'allowIn' => [
+						__DIR__ . '/../src/disallowed-allow/*.php',
+						__DIR__ . '/../src/*-allow/*.*',
+					],
+				],
+				[
+					'method' => 'CallbacksInterface::interfaceCall()',
+					'allowIn' => [
+						__DIR__ . '/../src/disallowed-allow/*.php',
+						__DIR__ . '/../src/*-allow/*.*',
+					],
+				],
+				[
+					'method' => 'CallbacksTrait::traitCall()',
+					'allowIn' => [
+						__DIR__ . '/../src/disallowed-allow/*.php',
+						__DIR__ . '/../src/*-allow/*.*',
+					],
+				],
+			],
+			[
+				[
+					'method' => 'Callbacks::staticCall()',
+					'allowIn' => [
+						__DIR__ . '/../src/disallowed-allow/*.php',
+						__DIR__ . '/../src/*-allow/*.*',
+					],
+				],
+				[
+					'method' => 'CallbacksInterface::interfaceStaticCall()',
+					'allowIn' => [
+						__DIR__ . '/../src/disallowed-allow/*.php',
+						__DIR__ . '/../src/*-allow/*.*',
+					],
+				],
+				[
+					'method' => 'CallbacksTrait::traitStaticCall()',
+					'allowIn' => [
+						__DIR__ . '/../src/disallowed-allow/*.php',
+						__DIR__ . '/../src/*-allow/*.*',
+					],
+				],
+			],
+		);
+		return new NewCalls(
+			$container->getByType(DisallowedCallsRuleErrors::class),
+			$disallowedCallableParameterRuleErrors,
+			$container->getByType(DisallowedCallFactory::class),
+			[],
+		);
+	}
+
+
+	public function testRule(): void
+	{
+		// Based on the configuration above, in this file:
+		$this->analyse([__DIR__ . '/../src/disallowed/callableParameters.php'], [
+			[
+				// expect this error message:
+				'Calling var_dump() is forbidden.',
+				// on this line:
+				176,
+			],
+			[
+				'Calling var_dump() is forbidden.',
+				177,
+			],
+			[
+				'Calling var_dump() is forbidden.',
+				178,
+			],
+			[
+				'Calling Callbacks::call() is forbidden.',
+				179,
+			],
+			[
+				'Calling Callbacks::call() is forbidden.',
+				180,
+			],
+			[
+				'Calling Callbacks::call() is forbidden.',
+				181,
+			],
+			[
+				'Calling Callbacks::call() (as Callbacks2::call()) is forbidden.',
+				182,
+			],
+			[
+				'Calling Callbacks::call() (as Callbacks2::call()) is forbidden.',
+				183,
+			],
+			[
+				'Calling Callbacks::call() (as Callbacks2::call()) is forbidden.',
+				184,
+			],
+			[
+				'Calling Callbacks::staticCall() is forbidden.',
+				185,
+			],
+			[
+				'Calling Callbacks::staticCall() is forbidden.',
+				186,
+			],
+			[
+				'Calling Callbacks::staticCall() is forbidden.',
+				187,
+			],
+			[
+				'Calling Callbacks::staticCall() is forbidden.',
+				188,
+			],
+			[
+				'Calling Callbacks::staticCall() (as Callbacks2::staticCall()) is forbidden.',
+				189,
+			],
+			[
+				'Calling Callbacks::staticCall() (as Callbacks2::staticCall()) is forbidden.',
+				190,
+			],
+			[
+				'Calling Callbacks::staticCall() (as Callbacks2::staticCall()) is forbidden.',
+				191,
+			],
+			[
+				'Calling Callbacks::staticCall() (as Callbacks2::staticCall()) is forbidden.',
+				192,
+			],
+		]);
+		// Based on the configuration above, no errors in this file:
+		$this->analyse([__DIR__ . '/../src/disallowed-allow/callableParameters.php'], []);
+	}
+
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__ . '/../../extension.neon',
+		];
+	}
+
+}

--- a/tests/Calls/NewCallsDefinedInTest.php
+++ b/tests/Calls/NewCallsDefinedInTest.php
@@ -7,6 +7,7 @@ use PHPStan\Rules\Rule;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallableParameterRuleErrors;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
 
 class NewCallsDefinedInTest extends RuleTestCase
@@ -20,6 +21,7 @@ class NewCallsDefinedInTest extends RuleTestCase
 		$container = self::getContainer();
 		return new NewCalls(
 			$container->getByType(DisallowedCallsRuleErrors::class),
+			$container->getByType(DisallowedCallableParameterRuleErrors::class),
 			$container->getByType(DisallowedCallFactory::class),
 			[
 				[

--- a/tests/Calls/NewCallsTest.php
+++ b/tests/Calls/NewCallsTest.php
@@ -7,6 +7,7 @@ use PHPStan\Rules\Rule;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallableParameterRuleErrors;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
 
 class NewCallsTest extends RuleTestCase
@@ -20,6 +21,7 @@ class NewCallsTest extends RuleTestCase
 		$container = self::getContainer();
 		return new NewCalls(
 			$container->getByType(DisallowedCallsRuleErrors::class),
+			$container->getByType(DisallowedCallableParameterRuleErrors::class),
 			$container->getByType(DisallowedCallFactory::class),
 			[
 				[

--- a/tests/src/disallowed/callableParameters.php
+++ b/tests/src/disallowed/callableParameters.php
@@ -166,3 +166,31 @@ CallableParams::staticCall([$callbacksPlusPlus, 'interfaceCall']);
 CallableParams::staticCall([$callbacksPlusPlus, 'interfaceStaticCall']);
 CallableParams::staticCall([$callbacksPlusPlus, 'traitCall']);
 CallableParams::staticCall([CallbacksPlusPlus::class, 'traitStaticCall']);
+
+class ConstructorCallable
+{
+	public function __construct(?callable $callback, ?string $string = null) {}
+}
+
+// disallowed callable params in constructors
+new ConstructorCallable('var_dump');
+new ConstructorCallable($varDump);
+new ConstructorCallable(string: null, callback: $varDump);
+new ConstructorCallable([$callbacks, 'call']);
+new ConstructorCallable([$callbacks, $call]);
+new ConstructorCallable([new Callbacks, $call]);
+new ConstructorCallable([$callbacks2, 'call']);
+new ConstructorCallable([$callbacks2, $call]);
+new ConstructorCallable([new Callbacks2, $call]);
+new ConstructorCallable(['Callbacks', 'staticCall']);
+new ConstructorCallable(['Callbacks', $staticCall]);
+new ConstructorCallable([Callbacks::class, 'staticCall']);
+new ConstructorCallable([Callbacks::class, $staticCall]);
+new ConstructorCallable(['Callbacks2', 'staticCall']);
+new ConstructorCallable(['Callbacks2', $staticCall]);
+new ConstructorCallable([Callbacks2::class, 'staticCall']);
+new ConstructorCallable([Callbacks2::class, $staticCall]);
+
+// not a callable param
+new ConstructorCallable(null, 'var_dump');
+new ConstructorCallable(string: $varDump, callback: null);


### PR DESCRIPTION
Callables detection added in #281 but I missed callable detection in constructors, e.g.:

```php
new ConstructorCallable('strlen');
new ConstructorCallable([$obj, 'method']);
```

Follow-up to #281
Ref #275