### PR TITLE
`array_merge` arrays only when not empty, this should speed things up a bit

### DIFF
--- a/src/Usages/AttributeUsages.php
+++ b/src/Usages/AttributeUsages.php
@@ -89,10 +89,10 @@ class AttributeUsages implements Rule
 
 		$errors = [];
 		foreach ($this->attributes as $attribute) {
-			$errors = array_merge(
-				$errors,
-				$this->disallowedAttributeRuleErrors->get($attribute, $scope, $this->disallowedAttributes)
-			);
+			$ruleErrors = $this->disallowedAttributeRuleErrors->get($attribute, $scope, $this->disallowedAttributes);
+			if ($ruleErrors) {
+				$errors = array_merge($errors, $ruleErrors);
+			}
 		}
 		return $errors;
 	}

--- a/src/Usages/ClassConstantUsages.php
+++ b/src/Usages/ClassConstantUsages.php
@@ -85,10 +85,10 @@ class ClassConstantUsages implements Rule
 		$type = $scope->getType($node->name);
 		$errors = [];
 		foreach ($type->getConstantStrings() as $constantString) {
-			$errors = array_merge(
-				$errors,
-				$this->getConstantRuleErrors($scope, $constantString->getValue(), $this->typeResolver->getType($node->class, $scope))
-			);
+			$ruleErrors = $this->getConstantRuleErrors($scope, $constantString->getValue(), $this->typeResolver->getType($node->class, $scope));
+			if ($ruleErrors) {
+				$errors = array_merge($errors, $ruleErrors);
+			}
 		}
 		return $errors;
 	}

--- a/src/Usages/NamespaceUsages.php
+++ b/src/Usages/NamespaceUsages.php
@@ -125,16 +125,16 @@ class NamespaceUsages implements Rule
 
 		$errors = [];
 		foreach ($namespaces as $namespace) {
-			$errors = array_merge(
-				$errors,
-				$this->disallowedNamespaceRuleErrors->getDisallowedMessage(
-					$this->normalizer->normalizeNamespace($namespace),
-					$description ?? 'Namespace',
-					$scope,
-					$this->disallowedNamespace,
-					$identifier ?? $identifier = ErrorIdentifiers::DISALLOWED_NAMESPACE
-				)
+			$ruleErrors = $this->disallowedNamespaceRuleErrors->getDisallowedMessage(
+				$this->normalizer->normalizeNamespace($namespace),
+				$description ?? 'Namespace',
+				$scope,
+				$this->disallowedNamespace,
+				$identifier ?? $identifier = ErrorIdentifiers::DISALLOWED_NAMESPACE
 			);
+			if ($ruleErrors) {
+				$errors = array_merge($errors, $ruleErrors);
+			}
 		}
 
 		return $errors;


### PR DESCRIPTION
Most of the time there are no errors generated for that particular call or usage, so makes little sense to merge empty array.

See my comment https://github.com/spaze/phpstan-disallowed-calls/pull/280#issuecomment-2565480229