### PR TITLE
You can now disallow `unset`, too

### DIFF
--- a/docs/custom-rules.md
+++ b/docs/custom-rules.md
@@ -165,6 +165,7 @@ You can treat some language constructs as functions and disallow it in `disallow
 - `exit()`
 - `isset()`
 - `print()`
+- `unset()`
 
 To disallow naive object creation (`new ClassName()` or `new $classname`), disallow `NameSpace\ClassName::__construct` in `disallowedMethodCalls`. Works even when there's no constructor defined in that class.
 

--- a/extension.neon
+++ b/extension.neon
@@ -302,6 +302,10 @@ services:
 		tags:
 			- phpstan.rules.rule
 	-
+		factory: Spaze\PHPStan\Rules\Disallowed\Calls\UnsetCalls(forbiddenCalls: %disallowedFunctionCalls%)
+		tags:
+			- phpstan.rules.rule
+	-
 		factory: Spaze\PHPStan\Rules\Disallowed\Calls\ExitDieCalls(forbiddenCalls: %disallowedFunctionCalls%)
 		tags:
 			- phpstan.rules.rule

--- a/src/Calls/UnsetCalls.php
+++ b/src/Calls/UnsetCalls.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Rules\Disallowed\Calls;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Unset_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\ShouldNotHappenException;
+use Spaze\PHPStan\Rules\Disallowed\DisallowedCall;
+use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\ErrorIdentifiers;
+
+/**
+ * Reports on dynamically calling unset().
+ *
+ * @package Spaze\PHPStan\Rules\Disallowed
+ * @implements Rule<Unset_>
+ */
+class UnsetCalls implements Rule
+{
+
+	private DisallowedCallsRuleErrors $disallowedCallsRuleErrors;
+
+	/** @var list<DisallowedCall> */
+	private array $disallowedCalls;
+
+
+	/**
+	 * @param DisallowedCallsRuleErrors $disallowedCallsRuleErrors
+	 * @param DisallowedCallFactory $disallowedCallFactory
+	 * @param array $forbiddenCalls
+	 * @phpstan-param ForbiddenCallsConfig $forbiddenCalls
+	 * @noinspection PhpUndefinedClassInspection ForbiddenCallsConfig is a type alias defined in PHPStan config
+	 * @throws ShouldNotHappenException
+	 */
+	public function __construct(DisallowedCallsRuleErrors $disallowedCallsRuleErrors, DisallowedCallFactory $disallowedCallFactory, array $forbiddenCalls)
+	{
+		$this->disallowedCallsRuleErrors = $disallowedCallsRuleErrors;
+		$this->disallowedCalls = $disallowedCallFactory->createFromConfig($forbiddenCalls);
+	}
+
+
+	public function getNodeType(): string
+	{
+		return Unset_::class;
+	}
+
+
+	/**
+	 * @throws ShouldNotHappenException
+	 */
+	public function processNode(Node $node, Scope $scope): array
+	{
+		return $this->disallowedCallsRuleErrors->get(null, $scope, 'unset', 'unset', null, $this->disallowedCalls, ErrorIdentifiers::DISALLOWED_UNSET);
+	}
+
+}

--- a/src/RuleErrors/ErrorIdentifiers.php
+++ b/src/RuleErrors/ErrorIdentifiers.php
@@ -41,6 +41,7 @@ class ErrorIdentifiers
 	public const DISALLOWED_RETURN = 'disallowed.return';
 	public const DISALLOWED_SWITCH = 'disallowed.switch';
 	public const DISALLOWED_TRAIT = 'disallowed.trait';
+	public const DISALLOWED_UNSET = 'disallowed.unset';
 	public const DISALLOWED_VARIABLE = 'disallowed.variable';
 	public const DISALLOWED_WHILE = 'disallowed.while';
 

--- a/tests/Calls/UnsetCallsTest.php
+++ b/tests/Calls/UnsetCallsTest.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Rules\Disallowed\Calls;
+
+use PHPStan\Rules\Rule;
+use PHPStan\ShouldNotHappenException;
+use PHPStan\Testing\RuleTestCase;
+use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
+
+class UnsetCallsTest extends RuleTestCase
+{
+
+	/**
+	 * @throws ShouldNotHappenException
+	 */
+	protected function getRule(): Rule
+	{
+		$container = self::getContainer();
+		return new UnsetCalls(
+			$container->getByType(DisallowedCallsRuleErrors::class),
+			$container->getByType(DisallowedCallFactory::class),
+			[
+				[
+					'function' => 'unset()',
+					'allowIn' => [
+						__DIR__ . '/../src/disallowed-allow/*.php',
+						__DIR__ . '/../src/*-allow/*.*',
+					],
+				],
+			]
+		);
+	}
+
+
+	public function testRule(): void
+	{
+		// Based on the configuration above, in this file:
+		$this->analyse([__DIR__ . '/../src/disallowed/functionCalls.php'], [
+			[
+				'Calling unset() is forbidden.',
+				121,
+			],
+		]);
+		// Based on the configuration above, no errors in this file:
+		$this->analyse([__DIR__ . '/../src/disallowed-allow/functionCalls.php'], []);
+	}
+
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__ . '/../../extension.neon',
+		];
+	}
+
+}

--- a/tests/src/disallowed-allow/functionCalls.php
+++ b/tests/src/disallowed-allow/functionCalls.php
@@ -118,3 +118,4 @@ ${'sneaky'}('foo');
 ('\Foo\Bar\Waldo')('foo');
 
 isset($bottle);
+unset($bottle);

--- a/tests/src/disallowed/functionCalls.php
+++ b/tests/src/disallowed/functionCalls.php
@@ -118,3 +118,4 @@ ${'sneaky'}('foo');
 ('\Foo\Bar\Waldo')('foo');
 
 isset($bottle);
+unset($bottle);


### PR DESCRIPTION
This is a companion PR to #289 which has added support to disallow `isset`, so for the sake of completeness, you can do that with `unset` too.