### PR TITLE
Call `fnmatch` less often only when needed

### DIFF
--- a/src/Allowed/Allowed.php
+++ b/src/Allowed/Allowed.php
@@ -17,6 +17,7 @@ use Spaze\PHPStan\Rules\Disallowed\Disallowed;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedWithParams;
 use Spaze\PHPStan\Rules\Disallowed\Exceptions\UnsupportedParamTypeException;
 use Spaze\PHPStan\Rules\Disallowed\Formatter\Formatter;
+use Spaze\PHPStan\Rules\Disallowed\Identifier\Identifier;
 use Spaze\PHPStan\Rules\Disallowed\Params\Param;
 
 class Allowed
@@ -26,16 +27,20 @@ class Allowed
 
 	private Reflector $reflector;
 
+	private Identifier $identifier;
+
 	private AllowedPath $allowedPath;
 
 
 	public function __construct(
 		Formatter $formatter,
 		Reflector $reflector,
+		Identifier $identifier,
 		AllowedPath $allowedPath
 	) {
 		$this->formatter = $formatter;
 		$this->reflector = $reflector;
+		$this->identifier = $identifier;
 		$this->allowedPath = $allowedPath;
 	}
 
@@ -109,7 +114,7 @@ class Allowed
 		} else {
 			$name = '';
 		}
-		return fnmatch($call, $name, FNM_NOESCAPE | FNM_CASEFOLD);
+		return $this->identifier->matches($call, $name);
 	}
 
 
@@ -180,7 +185,7 @@ class Allowed
 		}
 		foreach ($allowConfig as $allowAttribute) {
 			foreach ($names as $name) {
-				if (fnmatch($allowAttribute, $name, FNM_NOESCAPE | FNM_CASEFOLD)) {
+				if ($this->identifier->matches($allowAttribute, $name)) {
 					return true;
 				}
 			}

--- a/src/Identifier/Identifier.php
+++ b/src/Identifier/Identifier.php
@@ -12,7 +12,7 @@ class Identifier
 	 * @param list<string> $excludes
 	 * @return bool
 	 */
-	public function matches(string $pattern, string $value, array $excludes): bool
+	public function matches(string $pattern, string $value, array $excludes = []): bool
 	{
 		$matches = false;
 		if ($pattern === $value) {
@@ -20,7 +20,7 @@ class Identifier
 		} elseif (fnmatch($pattern, $value, FNM_NOESCAPE | FNM_CASEFOLD)) {
 			$matches = true;
 		}
-		if ($matches) {
+		if ($matches && $excludes) {
 			foreach ($excludes as $exclude) {
 				if (fnmatch($exclude, $value, FNM_NOESCAPE | FNM_CASEFOLD)) {
 					return false;


### PR DESCRIPTION
... and also in one place only. Or in two places. Three tops.

Slightly related to the `array_merge` speedup PR #287