### PR TITLE
Check also attributes on methods when checking whether an attribute should be allowed in methods

### DIFF
--- a/docs/allow-in-methods-with-attributes.md
+++ b/docs/allow-in-methods-with-attributes.md
@@ -25,3 +25,32 @@ parameters:
 ```
 
 The attribute names support [fnmatch()](https://www.php.net/function.fnmatch) patterns. If you specify multiple attributes, the method or the function in which the item should be allowed or disallowed, needs to have just one of them.
+
+### Attributes on methods
+
+In case of disallowing attributes and then re-allowing them in methods with attributes, the disallowed attributes can be both _inside_ the method, and _on_ the method.
+This means that the following code with the following configuration is also valid, even though `Attribute1` is technically not used _inside_ the method.
+
+```php
+class Foo
+{
+
+    #[Attribute1]
+    #[Attribute2]
+    public function bar()
+    {
+    }
+
+}
+```
+
+```neon
+parameters:
+    disallowedAttributes:
+        -
+            attribute: Attribute1
+            allowInMethodsWithAttributes:
+                - Attribute2
+```
+
+No error would be reported for `Attribute1` as it is used "in" a method with `Attribute2`.

--- a/src/RuleErrors/DisallowedAttributeRuleErrors.php
+++ b/src/RuleErrors/DisallowedAttributeRuleErrors.php
@@ -3,6 +3,7 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Rules\Disallowed\RuleErrors;
 
+use PhpParser\Node;
 use PhpParser\Node\Attribute;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\IdentifierRuleError;
@@ -31,19 +32,19 @@ class DisallowedAttributeRuleErrors
 
 
 	/**
-	 * @param Attribute $attribute
+	 * @param Node $node
 	 * @param Scope $scope
 	 * @param list<DisallowedAttribute> $disallowedAttributes
 	 * @return list<IdentifierRuleError>
 	 */
-	public function get(Attribute $attribute, Scope $scope, array $disallowedAttributes): array
+	public function get(Node $node, Attribute $attribute, Scope $scope, array $disallowedAttributes): array
 	{
 		foreach ($disallowedAttributes as $disallowedAttribute) {
 			$attributeName = $attribute->name->toString();
 			if (!$this->identifier->matches($disallowedAttribute->getAttribute(), $attributeName, $disallowedAttribute->getExcludes())) {
 				continue;
 			}
-			if ($this->allowed->isAllowed($scope, $attribute->args, $disallowedAttribute)) {
+			if ($this->allowed->isAllowed($node, $scope, $attribute->args, $disallowedAttribute)) {
 				continue;
 			}
 

--- a/src/RuleErrors/DisallowedCallsRuleErrors.php
+++ b/src/RuleErrors/DisallowedCallsRuleErrors.php
@@ -53,7 +53,7 @@ class DisallowedCallsRuleErrors
 			if (
 				$this->identifier->matches($disallowedCall->getCall(), $name, $disallowedCall->getExcludes())
 				&& $this->definedInMatches($disallowedCall, $definedIn)
-				&& !$this->allowed->isAllowed($scope, isset($node) ? $node->getArgs() : null, $disallowedCall)
+				&& !$this->allowed->isAllowed($node, $scope, isset($node) ? $node->getArgs() : null, $disallowedCall)
 			) {
 				$errorBuilder = RuleErrorBuilder::message(sprintf(
 					$message ?? 'Calling %s is forbidden%s%s',

--- a/src/RuleErrors/DisallowedNamespaceRuleErrors.php
+++ b/src/RuleErrors/DisallowedNamespaceRuleErrors.php
@@ -3,6 +3,7 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Rules\Disallowed\RuleErrors;
 
+use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\RuleErrorBuilder;
@@ -31,6 +32,7 @@ class DisallowedNamespaceRuleErrors
 
 
 	/**
+	 * @param Node $node
 	 * @param NamespaceUsage $namespaceUsage
 	 * @param string $description
 	 * @param Scope $scope
@@ -38,12 +40,12 @@ class DisallowedNamespaceRuleErrors
 	 * @param string $identifier
 	 * @return list<IdentifierRuleError>
 	 */
-	public function getDisallowedMessage(NamespaceUsage $namespaceUsage, string $description, Scope $scope, array $disallowedNamespaces, string $identifier): array
+	public function getDisallowedMessage(Node $node, NamespaceUsage $namespaceUsage, string $description, Scope $scope, array $disallowedNamespaces, string $identifier): array
 	{
 		foreach ($disallowedNamespaces as $disallowedNamespace) {
 			if (
 				!$this->identifier->matches($disallowedNamespace->getNamespace(), $namespaceUsage->getNamespace(), $disallowedNamespace->getExcludes())
-				|| $this->allowed->isAllowed($scope, null, $disallowedNamespace)
+				|| $this->allowed->isAllowed($node, $scope, null, $disallowedNamespace)
 				|| ($disallowedNamespace->isAllowInUse() && $namespaceUsage->isUseItem())
 			) {
 				continue;

--- a/src/Usages/AttributeUsages.php
+++ b/src/Usages/AttributeUsages.php
@@ -89,7 +89,7 @@ class AttributeUsages implements Rule
 
 		$errors = [];
 		foreach ($this->attributes as $attribute) {
-			$ruleErrors = $this->disallowedAttributeRuleErrors->get($attribute, $scope, $this->disallowedAttributes);
+			$ruleErrors = $this->disallowedAttributeRuleErrors->get($node, $attribute, $scope, $this->disallowedAttributes);
 			if ($ruleErrors) {
 				$errors = array_merge($errors, $ruleErrors);
 			}

--- a/src/Usages/NamespaceUsages.php
+++ b/src/Usages/NamespaceUsages.php
@@ -122,6 +122,7 @@ class NamespaceUsages implements Rule
 		$errors = [];
 		foreach ($namespaces as $namespaceUsage) {
 			$ruleErrors = $this->disallowedNamespaceRuleErrors->getDisallowedMessage(
+				$node,
 				$namespaceUsage,
 				$description ?? 'Namespace',
 				$scope,

--- a/tests/Usages/AttributeUsagesAllowInClassWithAttributesTest.php
+++ b/tests/Usages/AttributeUsagesAllowInClassWithAttributesTest.php
@@ -95,12 +95,27 @@ class AttributeUsagesAllowInClassWithAttributesTest extends RuleTestCase
 				123,
 			],
 			[
+				'Attribute Attribute13 is forbidden.',
+				150,
+			],
+			[
 				'Attribute Attribute12 is forbidden.',
 				157,
 			],
 			[
 				'Attribute Attribute13 is forbidden.',
 				159,
+			],
+		]);
+	}
+
+
+	public function testRuleInFunctions(): void
+	{
+		$this->analyse([__DIR__ . '/../src/AttributeFunctions.php'], [
+			[
+				'Attribute Attribute13 is forbidden.',
+				26,
 			],
 		]);
 	}

--- a/tests/src/AttributeClass.php
+++ b/tests/src/AttributeClass.php
@@ -133,7 +133,7 @@ use PhpOption\Some;
 class CallsWithAttributes
 {
 
-	#[\Attribute10]
+	#[\Attribute10, \Attribute12]
 	public function method1(): void
 	{
 		strtolower('');
@@ -147,7 +147,7 @@ class CallsWithAttributes
 	}
 
 
-	#[\Attribute11]
+	#[\Attribute11, \Attribute13]
 	public function method2(): void
 	{
 		strtolower('');

--- a/tests/src/AttributeFunctions.php
+++ b/tests/src/AttributeFunctions.php
@@ -15,3 +15,15 @@ function withAttribute11(): void
 	strtolower('');
 	strtoupper('');
 }
+
+
+#[\Attribute10, \Attribute12]
+function withAttribute10And12(): void
+{
+}
+
+
+#[\Attribute11, \Attribute13]
+function withAttribute11And13(): void
+{
+}


### PR DESCRIPTION
A disallowed attribute used on a method (or on a function) is technically not in the method, so `$scope->getFunction()` returns null and thus no attributes could be returned. Now the original node is passed around and used to get the reflection to get the attributes.

Close #303