### PR TITLE
Use the new `getAttributes()` API to get attributes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 	},
 	"require": {
 		"php": "^7.4 || ^8.0",
-		"phpstan/phpstan": "^1.12.6 || ^2.0"
+		"phpstan/phpstan": "^2.1.3"
 	},
 	"require-dev": {
 		"nette/neon": "^3.3.1",

--- a/src/Allowed/Allowed.php
+++ b/src/Allowed/Allowed.php
@@ -8,9 +8,9 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use PHPStan\Analyser\Scope;
-use PHPStan\BetterReflection\Reflector\Reflector;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use Spaze\PHPStan\Rules\Disallowed\Disallowed;
@@ -27,7 +27,7 @@ class Allowed
 
 	private Formatter $formatter;
 
-	private Reflector $reflector;
+	private ReflectionProvider $reflectionProvider;
 
 	private Identifier $identifier;
 
@@ -36,12 +36,12 @@ class Allowed
 
 	public function __construct(
 		Formatter $formatter,
-		Reflector $reflector,
+		ReflectionProvider $reflectionProvider,
 		Identifier $identifier,
 		AllowedPath $allowedPath
 	) {
 		$this->formatter = $formatter;
-		$this->reflector = $reflector;
+		$this->reflectionProvider = $reflectionProvider;
 		$this->identifier = $identifier;
 		$this->allowedPath = $allowedPath;
 	}
@@ -261,7 +261,7 @@ class Allowed
 		if (!$scope->isInClass()) {
 			return [];
 		}
-		return array_map(static fn($a) => $a->getName(), $scope->getClassReflection()->getNativeReflection()->getAttributes());
+		return array_map(static fn($a) => $a->getName(), $scope->getClassReflection()->getAttributes());
 	}
 
 
@@ -273,19 +273,13 @@ class Allowed
 	private function getCallAttributes(?Node $node, Scope $scope): array
 	{
 		$function = $scope->getFunction();
-		if ($function instanceof MethodReflection) {
-			if (!$scope->isInClass()) {
-				return [];
-			}
-			return array_map(static fn($a) => $a->getName(), $scope->getClassReflection()->getNativeReflection()->getMethod($function->getName())->getAttributes());
-		} elseif ($function instanceof FunctionReflection) {
-			return array_map(static fn($a) => $a->getName(), $this->reflector->reflectFunction($function->getName())->getAttributes());
-		} elseif ($function === null) {
-			if ($node instanceof ClassMethod && $scope->isInClass()) {
-				return array_map(static fn($a) => $a->getName(), $scope->getClassReflection()->getNativeReflection()->getMethod($node->name->name)->getAttributes());
-			} elseif ($node instanceof Function_) {
-				return array_map(static fn($a) => $a->getName(), $this->reflector->reflectFunction(($node->namespacedName ?? $node->name)->toString())->getAttributes());
-			}
+		if ($function !== null) {
+			return array_map(static fn($a) => $a->getName(), $function->getAttributes());
+		} elseif ($node instanceof ClassMethod && $scope->isInClass()) {
+			return array_map(static fn($a) => $a->getName(), $scope->getClassReflection()->getNativeMethod($node->name->name)->getAttributes());
+		} elseif ($node instanceof Function_ && $node->namespacedName !== null) {
+			return array_map(static fn($a) => $a->getName(), $this->reflectionProvider->getFunction($node->namespacedName, $scope)->getAttributes());
+		} else {
 			// $scope->getFunction() is null in param/return type hints, use the enclosing function attributes stored by TypeHintContextVisitor
 			if ($node !== null) {
 				$names = $node->getAttribute(TypeHintContextVisitor::ATTRIBUTE_ENCLOSING_FUNCTION_ATTR_NAMES);

--- a/src/Allowed/Allowed.php
+++ b/src/Allowed/Allowed.php
@@ -8,10 +8,10 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use PHPStan\Analyser\Scope;
-use PHPStan\BetterReflection\Reflector\Reflector;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use Spaze\PHPStan\Rules\Disallowed\Disallowed;
@@ -28,7 +28,7 @@ class Allowed
 
 	private Formatter $formatter;
 
-	private Reflector $reflector;
+	private ReflectionProvider $reflectionProvider;
 
 	private Identifier $identifier;
 
@@ -37,12 +37,12 @@ class Allowed
 
 	public function __construct(
 		Formatter $formatter,
-		Reflector $reflector,
+		ReflectionProvider $reflectionProvider,
 		Identifier $identifier,
 		AllowedPath $allowedPath
 	) {
 		$this->formatter = $formatter;
-		$this->reflector = $reflector;
+		$this->reflectionProvider = $reflectionProvider;
 		$this->identifier = $identifier;
 		$this->allowedPath = $allowedPath;
 	}
@@ -318,7 +318,7 @@ class Allowed
 		if (!$scope->isInClass()) {
 			return [];
 		}
-		return array_map(static fn($a) => $a->getName(), $scope->getClassReflection()->getNativeReflection()->getAttributes());
+		return array_map(static fn($a) => $a->getName(), $scope->getClassReflection()->getAttributes());
 	}
 
 
@@ -330,19 +330,13 @@ class Allowed
 	private function getCallAttributes(?Node $node, Scope $scope): array
 	{
 		$function = $scope->getFunction();
-		if ($function instanceof MethodReflection) {
-			if (!$scope->isInClass()) {
-				return [];
-			}
-			return array_map(static fn($a) => $a->getName(), $scope->getClassReflection()->getNativeReflection()->getMethod($function->getName())->getAttributes());
-		} elseif ($function instanceof FunctionReflection) {
-			return array_map(static fn($a) => $a->getName(), $this->reflector->reflectFunction($function->getName())->getAttributes());
-		} elseif ($function === null) {
-			if ($node instanceof ClassMethod && $scope->isInClass()) {
-				return array_map(static fn($a) => $a->getName(), $scope->getClassReflection()->getNativeReflection()->getMethod($node->name->name)->getAttributes());
-			} elseif ($node instanceof Function_) {
-				return array_map(static fn($a) => $a->getName(), $this->reflector->reflectFunction(($node->namespacedName ?? $node->name)->toString())->getAttributes());
-			}
+		if ($function !== null) {
+			return array_map(static fn($a) => $a->getName(), $function->getAttributes());
+		} elseif ($node instanceof ClassMethod && $scope->isInClass()) {
+			return array_map(static fn($a) => $a->getName(), $scope->getClassReflection()->getNativeMethod($node->name->name)->getAttributes());
+		} elseif ($node instanceof Function_ && $node->namespacedName !== null) {
+			return array_map(static fn($a) => $a->getName(), $this->reflectionProvider->getFunction($node->namespacedName, $scope)->getAttributes());
+		} else {
 			// $scope->getFunction() is null in param/return type hints, use the enclosing function attributes stored by TypeHintContextVisitor
 			if ($node !== null) {
 				$names = $node->getAttribute(TypeHintContextVisitor::ATTRIBUTE_ENCLOSING_FUNCTION_ATTR_NAMES);

--- a/src/Identifier/Identifier.php
+++ b/src/Identifier/Identifier.php
@@ -3,17 +3,17 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Rules\Disallowed\Identifier;
 
-use PHPStan\BetterReflection\Reflector\Exception\IdentifierNotFound;
-use PHPStan\BetterReflection\Reflector\Reflector;
+use PHPStan\Reflection\ReflectionProvider;
 
 class Identifier
 {
-	private Reflector $reflector;
+
+	private ReflectionProvider $reflectionProvider;
 
 
-	public function __construct(Reflector $reflector)
+	public function __construct(ReflectionProvider $reflectionProvider)
 	{
-		$this->reflector = $reflector;
+		$this->reflectionProvider = $reflectionProvider;
 	}
 
 
@@ -40,12 +40,10 @@ class Identifier
 			}
 		}
 		if ($matches && $excludeWithAttributes) {
-			try {
-				$attributes = array_map(fn($a) => $a->getName(), $this->reflector->reflectClass($value)->getAttributes());
-			} catch (IdentifierNotFound $e) {
-				$attributes = [];
+			if (!$this->reflectionProvider->hasClass($value)) {
+				return true;
 			}
-
+			$attributes = array_map(fn($a) => $a->getName(), $this->reflectionProvider->getClass($value)->getAttributes());
 			foreach ($attributes as $attribute) {
 				foreach ($excludeWithAttributes as $excludeWithAttribute) {
 					if (fnmatch($excludeWithAttribute, $attribute, FNM_NOESCAPE | FNM_CASEFOLD)) {

--- a/src/Usages/NamespaceUsages.php
+++ b/src/Usages/NamespaceUsages.php
@@ -13,8 +13,8 @@ use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\NullableType;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\TraitUse;
-use PhpParser\Node\Stmt\UseUse;
 use PhpParser\Node\UnionType;
+use PhpParser\Node\UseItem;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleError;
@@ -92,7 +92,7 @@ class NamespaceUsages implements Rule
 				}
 			}
 			$position = $this->getPosition($node);
-		} elseif ($node instanceof UseUse) {
+		} elseif ($node instanceof UseItem) {
 			$namespaces = [$this->namespaceUsageFactory->create($node->name->toString(), true)];
 		} elseif ($node instanceof StaticCall && $node->class instanceof Name) {
 			$namespaces = [$this->namespaceUsageFactory->create($node->class->toString())];


### PR DESCRIPTION
The API is used instead of code added in #296 and is available starting with PHPStan [2.1.3](https://github.com/phpstan/phpstan/releases/tag/2.1.3) so I'll need to decide when to merge this and when or how to remove support for earlier versions.

Seems like the last real 1.12.x release [1.12.28](https://github.com/phpstan/phpstan/releases/tag/1.12.28) was in Jul 17, 2025, I'd say it's time to call it.