### PR TITLE
Exclude ClassConstantTypeHint because we support older PHPs too

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
 		"php-parallel-lint/php-parallel-lint": "^1.2",
 		"php-parallel-lint/php-console-highlighter": "^1.0",
 		"phpstan/phpstan-deprecation-rules": "^1.2 || ^2.0",
-		"spaze/coding-standard": "^1.7"
+		"spaze/coding-standard": "^1.8"
 	},
 	"autoload": {
 		"psr-4": {"Spaze\\PHPStan\\Rules\\Disallowed\\": "src"}

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -9,6 +9,7 @@
 		<exclude name="SlevomatCodingStandard.Classes.RequireConstructorPropertyPromotion.RequiredConstructorPropertyPromotion" />
 		<exclude name="SlevomatCodingStandard.Functions.RequireTrailingCommaInCall" />
 		<exclude name="SlevomatCodingStandard.Functions.RequireTrailingCommaInDeclaration" />
+		<exclude name="SlevomatCodingStandard.TypeHints.ClassConstantTypeHint" />
 	</rule>
 	<exclude-pattern>tests/src/</exclude-pattern>
 </ruleset>


### PR DESCRIPTION
Need to bump the coding standard because otherwise phpcs complains that "Referenced sniff does not exist" even if excluded.

I could still add docblock types for the constants, but let's not go there and wait until only PHP 8.3+ is supported (don't hold your breath).

spaze/coding-standard [1.8.0](https://github.com/spaze/coding-standard/releases/tag/v1.8.0) adds the rule in https://github.com/spaze/coding-standard/pull/26.