### PR TITLE
Can get method/function attributes for params of disallowed classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
 	},
 	"require-dev": {
 		"nette/neon": "^3.3.1",
-		"nikic/php-parser": "^4.13 || ^5.0",
+		"nikic/php-parser": "^4.13.2 || ^5.0",
 		"phpunit/phpunit": "^8.5.14 || ^10.1 || ^11.0 || ^12.0",
 		"php-parallel-lint/php-parallel-lint": "^1.2",
 		"php-parallel-lint/php-console-highlighter": "^1.0",
@@ -41,7 +41,7 @@
 	},
 	"scripts": {
 		"lint": "vendor/bin/parallel-lint --colors src/ tests/",
-		"lint-7.x": "vendor/bin/parallel-lint --colors src/ tests/ --exclude tests/src/TypesEverywhere.php --exclude tests/src/AttributesEverywhere.php --exclude tests/src/disallowed/functionCallsNamedParams.php --exclude tests/src/disallowed-allow/functionCallsNamedParams.php --exclude tests/src/disallowed/attributeUsages.php --exclude tests/src/disallowed-allow/attributeUsages.php --exclude tests/src/disallowed/constantDynamicUsages.php --exclude tests/src/disallowed-allow/constantDynamicUsages.php --exclude tests/src/Bar.php --exclude tests/src/Enums.php --exclude tests/src/disallowed/controlStructures.php --exclude tests/src/disallowed-allow/controlStructures.php --exclude tests/src/disallowed/firstClassCallable.php --exclude tests/src/disallowed-allow/firstClassCallable.php --exclude tests/src/disallowed/callableParameters.php --exclude tests/src/disallowed-allow/callableParameters.php",
+		"lint-7.x": "vendor/bin/parallel-lint --colors src/ tests/ --exclude tests/src/TypesEverywhere.php --exclude tests/src/AttributesEverywhere.php --exclude tests/src/disallowed/functionCallsNamedParams.php --exclude tests/src/disallowed-allow/functionCallsNamedParams.php --exclude tests/src/disallowed/attributeUsages.php --exclude tests/src/disallowed-allow/attributeUsages.php --exclude tests/src/disallowed/constantDynamicUsages.php --exclude tests/src/disallowed-allow/constantDynamicUsages.php --exclude tests/src/AttributeClass.php --exclude tests/src/Bar.php --exclude tests/src/Enums.php --exclude tests/src/Functions.php --exclude tests/src/disallowed/controlStructures.php --exclude tests/src/disallowed-allow/controlStructures.php --exclude tests/src/disallowed/firstClassCallable.php --exclude tests/src/disallowed-allow/firstClassCallable.php --exclude tests/src/disallowed/callableParameters.php --exclude tests/src/disallowed-allow/callableParameters.php",
 		"lint-8.0": "vendor/bin/parallel-lint --colors src/ tests/ --exclude tests/src/TypesEverywhere.php --exclude tests/src/AttributesEverywhere.php --exclude tests/src/disallowed/constantDynamicUsages.php --exclude tests/src/disallowed-allow/constantDynamicUsages.php --exclude tests/src/Enums.php --exclude tests/src/disallowed/firstClassCallable.php --exclude tests/src/disallowed-allow/firstClassCallable.php",
 		"lint-8.1": "vendor/bin/parallel-lint --colors src/ tests/ --exclude tests/src/AttributesEverywhere.php --exclude tests/src/disallowed/constantDynamicUsages.php --exclude tests/src/disallowed-allow/constantDynamicUsages.php --exclude tests/src/disallowed/firstClassCallable.php --exclude tests/src/disallowed-allow/firstClassCallable.php",
 		"lint-8.2": "vendor/bin/parallel-lint --colors src/ tests/ --exclude tests/src/disallowed/constantDynamicUsages.php --exclude tests/src/disallowed-allow/constantDynamicUsages.php",

--- a/extension.neon
+++ b/extension.neon
@@ -418,6 +418,7 @@ services:
 	- Spaze\PHPStan\Rules\Disallowed\Allowed\Allowed
 	- Spaze\PHPStan\Rules\Disallowed\Allowed\AllowedConfigFactory
 	- Spaze\PHPStan\Rules\Disallowed\Allowed\AllowedPath
+	- Spaze\PHPStan\Rules\Disallowed\Allowed\GetAttributesWhenInSignature
 	- Spaze\PHPStan\Rules\Disallowed\DisallowedAttributeFactory
 	- Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory
 	- Spaze\PHPStan\Rules\Disallowed\DisallowedConstantFactory
@@ -573,5 +574,21 @@ services:
 			- phpstan.rules.rule
 	-
 		factory: Spaze\PHPStan\Rules\Disallowed\ControlStructures\WhileControlStructure(disallowedControlStructures: @Spaze\PHPStan\Rules\Disallowed\DisallowedControlStructureFactory::getDisallowedControlStructures(%disallowedControlStructures%))
+		tags:
+			- phpstan.rules.rule
+	-
+		factory: Spaze\PHPStan\Rules\Disallowed\HelperRules\SetCurrentClassMethodNameHelperRule
+		tags:
+			- phpstan.rules.rule
+	-
+		factory: Spaze\PHPStan\Rules\Disallowed\HelperRules\UnsetCurrentClassMethodNameHelperRule
+		tags:
+			- phpstan.rules.rule
+	-
+		factory: Spaze\PHPStan\Rules\Disallowed\HelperRules\SetCurrentFunctionNameHelperRule
+		tags:
+			- phpstan.rules.rule
+	-
+		factory: Spaze\PHPStan\Rules\Disallowed\HelperRules\UnsetCurrentFunctionNameHelperRule
 		tags:
 			- phpstan.rules.rule

--- a/src/Allowed/Allowed.php
+++ b/src/Allowed/Allowed.php
@@ -32,6 +32,8 @@ class Allowed
 
 	private Identifier $identifier;
 
+	private GetAttributesWhenInSignature $attributesWhenInSignature;
+
 	private AllowedPath $allowedPath;
 
 
@@ -39,11 +41,13 @@ class Allowed
 		Formatter $formatter,
 		Reflector $reflector,
 		Identifier $identifier,
+		GetAttributesWhenInSignature $attributesWhenInSignature,
 		AllowedPath $allowedPath
 	) {
 		$this->formatter = $formatter;
 		$this->reflector = $reflector;
 		$this->identifier = $identifier;
+		$this->attributesWhenInSignature = $attributesWhenInSignature;
 		$this->allowedPath = $allowedPath;
 	}
 
@@ -268,6 +272,10 @@ class Allowed
 				return $scope->getClassReflection()->getNativeReflection()->getMethod($node->name->name)->getAttributes();
 			} elseif ($node instanceof Function_) {
 				return $this->reflector->reflectFunction($node->name->name)->getAttributes();
+			}
+			$attributes = $this->attributesWhenInSignature->get($scope);
+			if ($attributes !== null) {
+				return $attributes;
 			}
 		}
 		return [];

--- a/src/Allowed/GetAttributesWhenInSignature.php
+++ b/src/Allowed/GetAttributesWhenInSignature.php
@@ -1,0 +1,92 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Rules\Disallowed\Allowed;
+
+use PHPStan\Analyser\Scope;
+use PHPStan\BetterReflection\Reflection\Adapter\FakeReflectionAttribute;
+use PHPStan\BetterReflection\Reflection\Adapter\ReflectionAttribute;
+use PHPStan\BetterReflection\Reflection\ReflectionAttribute as BetterReflectionAttribute;
+use PHPStan\BetterReflection\Reflector\Reflector;
+
+class GetAttributesWhenInSignature
+{
+
+	private Reflector $reflector;
+
+	/** @var class-string|null */
+	private ?string $currentClass = null;
+
+	private ?string $currentMethod = null;
+
+	/** @var string|null */
+	private ?string $currentFunction = null;
+
+
+	public function __construct(Reflector $reflector)
+	{
+		$this->reflector = $reflector;
+	}
+
+
+	/**
+	 * Emulates the missing $scope->getMethodOrFunctionSignature().
+	 *
+	 * Because $scope->getFunction() returns null when the node, like for example a namespace node (instance of FullyQualified),
+	 * is inside the method or the function signature, it's impossible to get to the current method or function reflection using $scope to get its attributes.
+	 * The hacky solution is to store the current method name in a ClassMethod rule, read it here, and unset it in a InClassMethodNode rule,
+	 * or the function name in a Function_ and a InFunctionNode rules.
+	 *
+	 * @param Scope $scope
+	 * @return list<FakeReflectionAttribute|ReflectionAttribute|BetterReflectionAttribute>|null
+	 */
+	public function get(Scope $scope): ?array
+	{
+		if (
+			$this->currentClass !== null
+			&& $this->currentMethod !== null
+			&& $scope->isInClass()
+			&& $scope->getClassReflection()->getName() === $this->currentClass
+		) {
+			return $scope->getClassReflection()->getNativeReflection()->getMethod($this->currentMethod)->getAttributes();
+		} elseif ($this->currentFunction !== null) {
+			return $this->reflector->reflectFunction($this->currentFunction)->getAttributes();
+		}
+		return null;
+	}
+
+
+	/**
+	 * @param class-string $className
+	 * @param string $methodName
+	 * @return void
+	 */
+	public function setCurrentClassMethodName(string $className, string $methodName): void
+	{
+		$this->currentClass = $className;
+		$this->currentMethod = $methodName;
+	}
+
+
+	public function unsetCurrentClassMethodName(): void
+	{
+		$this->currentClass = $this->currentMethod = null;
+	}
+
+
+	/**
+	 * @param string $functionName
+	 * @return void
+	 */
+	public function setCurrentFunctionName(string $functionName): void
+	{
+		$this->currentFunction = $functionName;
+	}
+
+
+	public function unsetCurrentFunctionName(): void
+	{
+		$this->currentFunction = null;
+	}
+
+}

--- a/src/HelperRules/SetCurrentClassMethodNameHelperRule.php
+++ b/src/HelperRules/SetCurrentClassMethodNameHelperRule.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Rules\Disallowed\HelperRules;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use Spaze\PHPStan\Rules\Disallowed\Allowed\GetAttributesWhenInSignature;
+
+/**
+ * @implements Rule<ClassMethod>
+ */
+class SetCurrentClassMethodNameHelperRule implements Rule
+{
+
+	private GetAttributesWhenInSignature $attributesWhenInSignature;
+
+
+	public function __construct(GetAttributesWhenInSignature $attributesWhenInSignature)
+	{
+		$this->attributesWhenInSignature = $attributesWhenInSignature;
+	}
+
+
+	public function getNodeType(): string
+	{
+		return ClassMethod::class;
+	}
+
+
+	/**
+	 * @param ClassMethod $node
+	 * @param Scope $scope
+	 * @return array{}
+	 */
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if ($scope->isInClass()) {
+			$this->attributesWhenInSignature->setCurrentClassMethodName($scope->getClassReflection()->getName(), $node->name->name);
+		}
+		return [];
+	}
+
+}

--- a/src/HelperRules/SetCurrentFunctionNameHelperRule.php
+++ b/src/HelperRules/SetCurrentFunctionNameHelperRule.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Rules\Disallowed\HelperRules;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Function_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use Spaze\PHPStan\Rules\Disallowed\Allowed\GetAttributesWhenInSignature;
+
+/**
+ * @implements Rule<Function_>
+ */
+class SetCurrentFunctionNameHelperRule implements Rule
+{
+
+	private GetAttributesWhenInSignature $attributesWhenInSignature;
+
+
+	public function __construct(GetAttributesWhenInSignature $attributesWhenInSignature)
+	{
+		$this->attributesWhenInSignature = $attributesWhenInSignature;
+	}
+
+
+	public function getNodeType(): string
+	{
+		return Function_::class;
+	}
+
+
+	/**
+	 * @param Function_ $node
+	 * @param Scope $scope
+	 * @return array{}
+	 */
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if ($node->namespacedName !== null) {
+			$this->attributesWhenInSignature->setCurrentFunctionName($node->namespacedName->toString());
+		}
+		return [];
+	}
+
+}

--- a/src/HelperRules/UnsetCurrentClassMethodNameHelperRule.php
+++ b/src/HelperRules/UnsetCurrentClassMethodNameHelperRule.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Rules\Disallowed\HelperRules;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\InClassMethodNode;
+use PHPStan\Rules\Rule;
+use Spaze\PHPStan\Rules\Disallowed\Allowed\GetAttributesWhenInSignature;
+
+/**
+ * @implements Rule<InClassMethodNode>
+ */
+class UnsetCurrentClassMethodNameHelperRule implements Rule
+{
+
+	private GetAttributesWhenInSignature $attributesWhenInSignature;
+
+
+	public function __construct(GetAttributesWhenInSignature $attributesWhenInSignature)
+	{
+		$this->attributesWhenInSignature = $attributesWhenInSignature;
+	}
+
+
+	public function getNodeType(): string
+	{
+		return InClassMethodNode::class;
+	}
+
+
+	/**
+	 * @param InClassMethodNode $node
+	 * @param Scope $scope
+	 * @return array{}
+	 */
+	public function processNode(Node $node, Scope $scope): array
+	{
+		$this->attributesWhenInSignature->unsetCurrentClassMethodName();
+		return [];
+	}
+
+}

--- a/src/HelperRules/UnsetCurrentFunctionNameHelperRule.php
+++ b/src/HelperRules/UnsetCurrentFunctionNameHelperRule.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Rules\Disallowed\HelperRules;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\InFunctionNode;
+use PHPStan\Rules\Rule;
+use Spaze\PHPStan\Rules\Disallowed\Allowed\GetAttributesWhenInSignature;
+
+/**
+ * @implements Rule<InFunctionNode>
+ */
+class UnsetCurrentFunctionNameHelperRule implements Rule
+{
+
+	private GetAttributesWhenInSignature $attributesWhenInSignature;
+
+
+	public function __construct(GetAttributesWhenInSignature $attributesWhenInSignature)
+	{
+		$this->attributesWhenInSignature = $attributesWhenInSignature;
+	}
+
+
+	public function getNodeType(): string
+	{
+		return InFunctionNode::class;
+	}
+
+
+	/**
+	 * @param InFunctionNode $node
+	 * @param Scope $scope
+	 * @return array{}
+	 */
+	public function processNode(Node $node, Scope $scope): array
+	{
+		$this->attributesWhenInSignature->unsetCurrentFunctionName();
+		return [];
+	}
+
+}

--- a/tests/src/AttributeClass.php
+++ b/tests/src/AttributeClass.php
@@ -134,7 +134,7 @@ class CallsWithAttributes
 {
 
 	#[\Attribute10, \Attribute12]
-	public function method1(): void
+	public function method1(None|Some $union, None $none, Some $some, Blade $foo, $bar): void
 	{
 		strtolower('');
 		strtoupper('');
@@ -148,7 +148,7 @@ class CallsWithAttributes
 
 
 	#[\Attribute11, \Attribute13]
-	public function method2(): void
+	public function method2(None|Some $union, None $none, Some $some, Blade $foo, $bar): void
 	{
 		strtolower('');
 		strtoupper('');

--- a/tests/src/Functions.php
+++ b/tests/src/Functions.php
@@ -68,3 +68,21 @@ function intParam4(int $param): void
 function mixedParam1($param): void
 {
 }
+
+use PhpOption\None;
+use PhpOption\Some;
+use Waldo\Quux\Blade;
+
+#[\Attribute10, \Attribute12]
+function method1(None|Some $union, None $none, Some $some, Blade $foo, $bar): void
+{
+	new None();
+	new Some(303);
+}
+
+#[\Attribute11, \Attribute13]
+function method2(None|Some $union, None $none, Some $some, Blade $foo, $bar): void
+{
+	new None();
+	new Some(303);
+}


### PR DESCRIPTION
When a disallowed classname is detected in method or function params, and it is allowed by method/function attributes, this change will allow to get the method/func attributes. It's way hacky as it seems to be not possible natively in PHPStan because `$scope->getFunction()` returns null for `FullyQualified` nodes in method/func parameter types. So we store the method name in `ClassMethod` rule, use it in `Allowed` service when set, and unset the function name in `InClassMethodNode` which is a virtual node which marks the beginning of the method body. Similar for functions in `Function_` and `InFunctionBody`.

Close #314