### PR TITLE
Ignore PHPStan's ClassReflection::isEnum error when analyzing the extension code on PHP 7.4

### DIFF
--- a/phpstan-ignore-errors.php
+++ b/phpstan-ignore-errors.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types = 1);
+
+$config = [
+	'parameters' => [
+		'ignoreErrors' => [],
+	]
+];
+
+if (PHP_VERSION_ID < 80000) {
+	// https://github.com/phpstan/phpstan/discussions/12888
+	$config['parameters']['ignoreErrors'][] = [
+		'message' => '#^Call to method PHPStan\\\\Reflection\\\\ClassReflection::isEnum\\(\\) will always evaluate to false\\.$#',
+		'reportUnmatched' => false,
+	];
+}
+
+return $config;

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -17,6 +17,7 @@ parameters:
 			- src/PHPStan1Compatibility.php
 
 includes:
+	- phpstan-ignore-errors.php
 	- vendor/phpstan/phpstan/conf/bleedingEdge.neon
 	- vendor/phpstan/phpstan-deprecation-rules/rules.neon
 	- extension.neon


### PR DESCRIPTION
The error is unintentional and maybe it will be resolved soon, but until then let's ignore it.

It needs to be ignored only when running on PHP 7.4 and with PHPStan 2.x. The ignore would be reported as unmatched when running with `--prefer-lowest` (PHPStan 1.x), so that's why `reportUnmatched` is set to `false`.

See https://github.com/phpstan/phpstan/discussions/12888