### PR TITLE
Reproducer for #323

### DIFF
--- a/reproducer.neon
+++ b/reproducer.neon
@@ -1,0 +1,11 @@
+includes:
+	- %currentWorkingDirectory%/extension.neon
+parameters:
+	disallowedClasses:
+		-
+			class: Reproducer\EventRecorder
+			allowInMethodsWithAttributes: [Reproducer\AsCommandHandler]
+			allowInUse: true
+	level: max
+	paths:
+		- %currentWorkingDirectory%/tests/src/ReproducerClass.php

--- a/tests/Usages/ReproducerTest.php
+++ b/tests/Usages/ReproducerTest.php
@@ -25,6 +25,10 @@ use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedNamespaceRuleErrors;
 
 class ReproducerTest extends RuleTestCase
 {
+	protected function shouldNarrowMethodScopeFromConstructor(): bool
+	{
+		return true;
+	}
 
 	protected function getRule(): Rule
 	{

--- a/tests/Usages/ReproducerTest.php
+++ b/tests/Usages/ReproducerTest.php
@@ -1,0 +1,100 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Rules\Disallowed\Usages;
+
+use Attributes\CallsWithAttributes;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Function_;
+use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\Container;
+use PHPStan\Node\InClassMethodNode;
+use PHPStan\Node\InFunctionNode;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use Reproducer\AsCommandHandler;
+use Reproducer\EventRecorder;
+use Spaze\PHPStan\Rules\Disallowed\Allowed\GetAttributesWhenInSignature;
+use Spaze\PHPStan\Rules\Disallowed\DisallowedNamespaceFactory;
+use Spaze\PHPStan\Rules\Disallowed\HelperRules\SetCurrentClassMethodNameHelperRule;
+use Spaze\PHPStan\Rules\Disallowed\HelperRules\SetCurrentFunctionNameHelperRule;
+use Spaze\PHPStan\Rules\Disallowed\HelperRules\UnsetCurrentClassMethodNameHelperRule;
+use Spaze\PHPStan\Rules\Disallowed\HelperRules\UnsetCurrentFunctionNameHelperRule;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedNamespaceRuleErrors;
+
+class ReproducerTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new class (
+			self::getContainer(),
+			[
+				[
+					'class' => EventRecorder::class,
+					'allowInMethodsWithAttributes' => [AsCommandHandler::class],
+					'allowInUse' => true,
+				],
+			]
+		) extends NamespaceUsages {
+
+			private Container $container;
+
+
+			public function __construct(
+				Container $container,
+				array $forbiddenNamespaces
+			) {
+				parent::__construct(
+					$container->getByType(DisallowedNamespaceRuleErrors::class),
+					$container->getByType(DisallowedNamespaceFactory::class),
+					$container->getByType(NamespaceUsageFactory::class),
+					$forbiddenNamespaces,
+				);
+				$this->container = $container;
+			}
+
+
+			public function processNode(Node $node, Scope $scope): array
+			{
+				if ($node instanceof ClassMethod) {
+					$this->container->getByType(SetCurrentClassMethodNameHelperRule::class)->processNode($node, $scope);
+				} elseif ($node instanceof InClassMethodNode) {
+					$this->container->getByType(UnsetCurrentClassMethodNameHelperRule::class)->processNode($node, $scope);
+				} elseif ($node instanceof Function_) {
+					$this->container->getByType(SetCurrentFunctionNameHelperRule::class)->processNode($node, $scope);
+				} elseif ($node instanceof InFunctionNode) {
+					$this->container->getByType(UnsetCurrentFunctionNameHelperRule::class)->processNode($node, $scope);
+				}
+
+				return parent::processNode($node, $scope);
+			}
+
+		};
+	}
+
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/../src/ReproducerClass.php'], [
+			[
+				'Class Reproducer\EventRecorder is forbidden.',
+				15,
+			],
+			[
+				'Class Reproducer\EventRecorder is forbidden.',
+				25,
+			]
+		]);
+	}
+
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__ . '/../../extension.neon',
+		];
+	}
+
+}

--- a/tests/src/ReproducerClass.php
+++ b/tests/src/ReproducerClass.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types = 1);
+
+namespace Reproducer;
+
+use Attribute;
+
+#[Attribute]
+class AsCommandHandler {}
+
+class EventRecorder {}
+
+class ReproducerClassNotAllowed
+{
+	public function __invoke(EventRecorder $eventRecorder): void
+	{
+	}
+}
+class ReproducerClassWithConstructorNotAllowed
+{
+	public function __construct()
+	{
+	}
+
+	public function __invoke(EventRecorder $eventRecorder): void
+	{
+	}
+}
+
+class ReproducerClassAllowed
+{
+	#[AsCommandHandler]
+	public function __invoke(EventRecorder $eventRecorder): void
+	{
+	}
+}
+
+class ReproducerClassWithConstructorAllowed
+{
+	public function __construct()
+	{
+	}
+
+	#[AsCommandHandler]
+	public function __invoke(EventRecorder $eventRecorder): void
+	{
+	}
+}


### PR DESCRIPTION
When I try it in user land you can see the problem.

```command
composer req phpstan/phpstan:2.1.11 && vendor/bin/phpstan --configuration=reproducer.neon

  15     Class Reproducer\EventRecorder is forbidden.
         🪪  disallowed.class
  25     Class Reproducer\EventRecorder is forbidden.
         🪪  disallowed.class
```

This is expected.

When you try it with:

```command
composer req phpstan/phpstan:2.1.12 && vendor/bin/phpstan --configuration=reproducer.neon

  15     Class Reproducer\EventRecorder is forbidden.
         🪪  disallowed.class
  25     Class Reproducer\EventRecorder is forbidden.
         🪪  disallowed.class
  45     Class Reproducer\EventRecorder is forbidden.
         🪪  disallowed.class
```

I cannot reproduce this using a test. I think the reason being that the test only tests 1 rule, and fakes the helper rules. But in user land, PHPStan runs all rules together in the order that it chooses. Maybe it's caused by that.

https://github.com/spaze/phpstan-disallowed-calls/tree/main/src/HelperRules

I understand what you're trying to do here. But I believe that these shouldn't be `Rule`'s but `NodeVisitor`'s (tagged as `phpstan.parser.richParserNodeVisitor`).

In NamespaceUsagesAllowInClassWithAttributesTest.php you have to go through hoops to fake these rules:
https://github.com/spaze/phpstan-disallowed-calls/blob/1d61d45b2b484a9481afc740228b5d685393d8bd/tests/Usages/NamespaceUsagesAllowInClassWithAttributesTest.php#L100-L115
