### PR TITLE
Test rule registration

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -441,7 +441,7 @@ services:
 	- Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors
 	- Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedVariableRuleErrors
 	- Spaze\PHPStan\Rules\Disallowed\Type\TypeResolver
-	- Spaze\PHPStan\Rules\Disallowed\Usages\NamespaceUsageFactory
+	- Spaze\PHPStan\Rules\Disallowed\UsageFactory\NamespaceUsageFactory
 	-
 		factory: Spaze\PHPStan\Rules\Disallowed\Usages\NamespaceUsages(forbiddenNamespaces: %disallowedNamespaces%)
 		tags:

--- a/src/RuleErrors/DisallowedNamespaceRuleErrors.php
+++ b/src/RuleErrors/DisallowedNamespaceRuleErrors.php
@@ -11,7 +11,7 @@ use Spaze\PHPStan\Rules\Disallowed\Allowed\Allowed;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedNamespace;
 use Spaze\PHPStan\Rules\Disallowed\Formatter\Formatter;
 use Spaze\PHPStan\Rules\Disallowed\Identifier\Identifier;
-use Spaze\PHPStan\Rules\Disallowed\Usages\NamespaceUsage;
+use Spaze\PHPStan\Rules\Disallowed\UsageFactory\NamespaceUsage;
 
 class DisallowedNamespaceRuleErrors
 {

--- a/src/UsageFactory/NamespaceUsage.php
+++ b/src/UsageFactory/NamespaceUsage.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types = 1);
 
-namespace Spaze\PHPStan\Rules\Disallowed\Usages;
+namespace Spaze\PHPStan\Rules\Disallowed\UsageFactory;
 
 class NamespaceUsage
 {

--- a/src/UsageFactory/NamespaceUsageFactory.php
+++ b/src/UsageFactory/NamespaceUsageFactory.php
@@ -1,9 +1,10 @@
 <?php
 declare(strict_types = 1);
 
-namespace Spaze\PHPStan\Rules\Disallowed\Usages;
+namespace Spaze\PHPStan\Rules\Disallowed\UsageFactory;
 
 use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
+use Spaze\PHPStan\Rules\Disallowed\UsageFactory\NamespaceUsage;
 
 class NamespaceUsageFactory
 {

--- a/src/Usages/NamespaceUsages.php
+++ b/src/Usages/NamespaceUsages.php
@@ -22,6 +22,7 @@ use Spaze\PHPStan\Rules\Disallowed\DisallowedNamespace;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedNamespaceFactory;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedNamespaceRuleErrors;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\ErrorIdentifiers;
+use Spaze\PHPStan\Rules\Disallowed\UsageFactory\NamespaceUsageFactory;
 
 /**
  * @implements Rule<Node>

--- a/tests/AllRulesRegisteredTest.php
+++ b/tests/AllRulesRegisteredTest.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Rules\Disallowed;
+
+use DirectoryIterator;
+use PHPStan\Testing\PHPStanTestCase;
+
+class AllRulesRegisteredTest extends PHPStanTestCase
+{
+
+	private const RULES_DIRS = [
+		'Calls',
+		'Usages',
+		'HelperRules',
+	];
+
+
+	public function testAllRulesRegistered(): void
+	{
+		foreach (self::RULES_DIRS as $directory) {
+			foreach (new DirectoryIterator(__DIR__ . '/../src/' . $directory) as $file) {
+				if ($file->getExtension() === 'php') {
+					$class = sprintf('Spaze\PHPStan\Rules\Disallowed\%s\%s', $directory, $file->getBasename('.php'));
+					if (!class_exists($class)) {
+						continue;
+					}
+					$services = self::getContainer()->findServiceNamesByType($class);
+					self::assertNotEmpty($services, "{$class} is not a registered rule");
+				}
+			}
+		}
+	}
+
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__ . '/../extension.neon',
+		];
+	}
+
+}

--- a/tests/Usages/NamespaceUsagesAllowInClassWithAttributesTest.php
+++ b/tests/Usages/NamespaceUsagesAllowInClassWithAttributesTest.php
@@ -20,6 +20,7 @@ use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\Allowed\GetAttributesWhenInSignature;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedNamespaceFactory;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedNamespaceRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\UsageFactory\NamespaceUsageFactory;
 
 /**
  * @extends RuleTestCase<NamespaceUsages>

--- a/tests/Usages/NamespaceUsagesExcludeAttributeTest.php
+++ b/tests/Usages/NamespaceUsagesExcludeAttributeTest.php
@@ -7,6 +7,7 @@ use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedNamespaceFactory;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedNamespaceRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\UsageFactory\NamespaceUsageFactory;
 
 /**
  * @extends RuleTestCase<NamespaceUsages>

--- a/tests/Usages/NamespaceUsagesTest.php
+++ b/tests/Usages/NamespaceUsagesTest.php
@@ -7,6 +7,7 @@ use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedNamespaceFactory;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedNamespaceRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\UsageFactory\NamespaceUsageFactory;
 
 /**
  * @extends RuleTestCase<NamespaceUsages>

--- a/tests/Usages/NamespaceUsagesTypesTest.php
+++ b/tests/Usages/NamespaceUsagesTypesTest.php
@@ -8,6 +8,7 @@ use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedNamespaceFactory;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedNamespaceRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\UsageFactory\NamespaceUsageFactory;
 
 /**
  * @requires PHP >= 8.1


### PR DESCRIPTION
Another option to prevent unregistered rules (see #330). There's one already, and that's the Dead Code Detector (#332 #333), but I think this is quite important to get it right, and _nobody ever got fired for adding one more test_ or so they [say](https://www.origina.com/blog/nobody-ever-got-fired-for-buying-ibm).