### PR TITLE
Bump the Dead Code Detector to 0.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
 		"php-parallel-lint/php-parallel-lint": "^1.2",
 		"php-parallel-lint/php-console-highlighter": "^1.0",
 		"phpstan/phpstan-deprecation-rules": "^1.2 || ^2.0",
-		"shipmonk/dead-code-detector": "^0.11.0",
+		"shipmonk/dead-code-detector": "^0.12",
 		"spaze/coding-standard": "^1.8"
 	},
 	"autoload": {


### PR DESCRIPTION
Can't use just `^0` to allow all future 0.x versions, because then the `--prefer-lowest` test fails, because it installs 0.1.0 which doesn't have the `shipmonkDeadCode` configuration option.