### PR TITLE
Remove nikic/php-parser as a direct dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
 	},
 	"require-dev": {
 		"nette/neon": "^3.3.1",
-		"nikic/php-parser": "^4.13.2 || ^5.0",
 		"phpunit/phpunit": "^8.5.14 || ^10.1 || ^11.0 || ^12.0",
 		"php-parallel-lint/php-parallel-lint": "^1.2",
 		"php-parallel-lint/php-console-highlighter": "^1.0",


### PR DESCRIPTION
Some packages still need it, but *we* don't.

While this is probably a good idea, it hasn't closed #346 as I initially hoped. But let's merge it anyway.