### PR TITLE
Stop the "Undefined constant PhpParser\Node\Expr\Cast\Bool_::KIND_BOOL" errors with PHP-Parser 5.6.1

### DIFF
--- a/tests/src/disallowed-allow/constantUsages.php
+++ b/tests/src/disallowed-allow/constantUsages.php
@@ -37,7 +37,7 @@ $none = PhpOption\None::create();
 $none::NAME;
 
 // not disallowed by path
-PHP_EOL;
+echo PHP_EOL;
 
 // allowed by path
 $foo = new class extends Base {};

--- a/tests/src/disallowed/constantUsages.php
+++ b/tests/src/disallowed/constantUsages.php
@@ -37,7 +37,7 @@ $none = PhpOption\None::create();
 $none::NAME;
 
 // disallowed by path
-PHP_EOL;
+echo PHP_EOL;
 
 // disallowed
 $foo = new class extends Base {};


### PR DESCRIPTION
Why? How? I don't know, but this is one of the ways to do that. The others are to delete the whole line with PHP_EOL, another one is to disable code coverage.

Close #346