### PR TITLE
De-downgrade de Dead Code Detector dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
 		"php-parallel-lint/php-parallel-lint": "^1.2",
 		"php-parallel-lint/php-console-highlighter": "^1.0",
 		"phpstan/phpstan-deprecation-rules": "^1.2 || ^2.0",
-		"shipmonk/dead-code-detector": "^0.12",
+		"shipmonk/dead-code-detector": "^0.13.2",
 		"spaze/coding-standard": "^1.8"
 	},
 	"autoload": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -29,6 +29,8 @@ parameters:
 		usageExcluders:
 			tests:
 				enabled: true
+		detect:
+			deadEnumCases: true
 
 includes:
 	- phpstan-exclude-paths.php


### PR DESCRIPTION
Also enable dead enum cases detection (added in 0.13) even if this extension doesn't use any enum at all.