### PR TITLE
Narrow the thrown type when no exception is thrown

### DIFF
--- a/src/Params/ParamValueAny.php
+++ b/src/Params/ParamValueAny.php
@@ -8,6 +8,9 @@ use PHPStan\Type\Type;
 final class ParamValueAny extends ParamValue
 {
 
+	/**
+	 * @throws void
+	 */
 	public function matches(Type $type): bool
 	{
 		return true;

--- a/src/Params/ParamValueExceptAny.php
+++ b/src/Params/ParamValueExceptAny.php
@@ -8,6 +8,9 @@ use PHPStan\Type\Type;
 final class ParamValueExceptAny extends ParamValue
 {
 
+	/**
+	 * @throws void
+	 */
 	public function matches(Type $type): bool
 	{
 		return false;


### PR DESCRIPTION
PHPStan 2.1.31 with bleeding edge config started reporting implicit (inherited) too-wide `@throws` type, so let's be ready for the future.

https://github.com/phpstan/phpstan/releases/tag/2.1.31