### PR TITLE
Don't include template types in constant's declaring class display name

### DIFF
--- a/src/Usages/ClassConstantUsages.php
+++ b/src/Usages/ClassConstantUsages.php
@@ -121,7 +121,7 @@ class ClassConstantUsages implements Rule
 			if (!$usedOnType->hasConstant($constant)->yes()) {
 				return [];
 			}
-			$classNames = [$usedOnType->getConstant($constant)->getDeclaringClass()->getDisplayName()];
+			$classNames = [$usedOnType->getConstant($constant)->getDeclaringClass()->getDisplayName(false)];
 		}
 		return $this->disallowedConstantRuleErrors->get($this->getFullyQualified($classNames, $constant), $node, $scope, $displayName, $this->disallowedConstants, ErrorIdentifiers::DISALLOWED_CLASS_CONSTANT);
 	}


### PR DESCRIPTION
PHPStan 2.1.38 have started adding the types, so instead of e.g. `PhpOption\Option` we got `PhpOption\Option<mixed>` and that didn't match with the configured class for a disallowed constant, causing `ClassConstantUsagesTest` to fail.

I think the change was introduced in https://github.com/phpstan/phpstan-src/pull/4829 because if you look at the changed files, you'll see a lot of `->getDisplayName()` => `->getDisplayName(false)`.