### PR TITLE
Update the docs for constant usage in params 

### DIFF
--- a/disallowed-loose-calls.neon
+++ b/disallowed-loose-calls.neon
@@ -9,4 +9,4 @@ parameters:
 			function: 'htmlspecialchars()'
 			message: 'set the $flags parameter to `ENT_QUOTES` to also convert single quotes to entities to prevent some HTML injection bugs'
 			allowParamFlagsAnywhere:
-				2: 3 # ENT_QUOTES
+				2: 3 # ENT_QUOTES; using ::constant(ENT_QUOTES) is discouraged as it may break when PHPStan updates nette/di

--- a/docs/allow-with-parameters.md
+++ b/docs/allow-with-parameters.md
@@ -146,7 +146,7 @@ parameters:
                 -
                     position: 4
                     name: 'flags'
-                    value: ::JSON_THROW_ON_ERROR
+                    value: 4194304 # JSON_THROW_ON_ERROR; using ::constant(JSON_THROW_ON_ERROR) is discouraged as it may break when PHPStan updates nette/di
 ```
 
 This format allows to detect the value in both cases whether it's used with a traditional positional parameter (e.g. `json_decode($foo, null, 512, JSON_THROW_ON_ERROR)`) or a named parameter (e.g. `json_decode($foo, flags: JSON_THROW_ON_ERROR)`).


### PR DESCRIPTION
The docs said you can use `::JSON_THROW_ON_ERROR` in allowed param values which is incorrect as you have to use `::constant(JSON_THROW_ON_ERROR)` but only if PHPStan uses an older version of nette/di, which it currently does. If one day PHPStan will start using a newer version, it may break, but consider yourself warned.

Close #361
See also #250