### PR TITLE
Short-cut "defined in" checks for built-in functions and methods

### DIFF
--- a/src/Calls/EchoCalls.php
+++ b/src/Calls/EchoCalls.php
@@ -54,7 +54,16 @@ class EchoCalls implements Rule
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{
-		return $this->disallowedCallsRuleErrors->get(null, $scope, 'echo', 'echo', null, $this->disallowedCalls, ErrorIdentifiers::DISALLOWED_ECHO);
+		return $this->disallowedCallsRuleErrors->get(
+			null,
+			$scope,
+			'echo',
+			'echo',
+			null,
+			true,
+			$this->disallowedCalls,
+			ErrorIdentifiers::DISALLOWED_ECHO,
+		);
 	}
 
 }

--- a/src/Calls/EmptyCalls.php
+++ b/src/Calls/EmptyCalls.php
@@ -54,7 +54,16 @@ class EmptyCalls implements Rule
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{
-		return $this->disallowedCallsRuleErrors->get(null, $scope, 'empty', 'empty', null, $this->disallowedCalls, ErrorIdentifiers::DISALLOWED_EMPTY);
+		return $this->disallowedCallsRuleErrors->get(
+			null,
+			$scope,
+			'empty',
+			'empty',
+			null,
+			true,
+			$this->disallowedCalls,
+			ErrorIdentifiers::DISALLOWED_EMPTY,
+		);
 	}
 
 }

--- a/src/Calls/EvalCalls.php
+++ b/src/Calls/EvalCalls.php
@@ -54,7 +54,16 @@ class EvalCalls implements Rule
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{
-		return $this->disallowedCallsRuleErrors->get(null, $scope, 'eval', 'eval', null, $this->disallowedCalls, ErrorIdentifiers::DISALLOWED_EVAL);
+		return $this->disallowedCallsRuleErrors->get(
+			null,
+			$scope,
+			'eval',
+			'eval',
+			null,
+			true,
+			$this->disallowedCalls,
+			ErrorIdentifiers::DISALLOWED_EVAL,
+		);
 	}
 
 }

--- a/src/Calls/ExitDieCalls.php
+++ b/src/Calls/ExitDieCalls.php
@@ -55,7 +55,16 @@ class ExitDieCalls implements Rule
 	public function processNode(Node $node, Scope $scope): array
 	{
 		$kind = $node->getAttribute('kind', Exit_::KIND_DIE) === Exit_::KIND_EXIT ? 'exit' : 'die';
-		return $this->disallowedCallsRuleErrors->get(null, $scope, $kind, $kind, null, $this->disallowedCalls, $kind === 'exit' ? ErrorIdentifiers::DISALLOWED_EXIT : ErrorIdentifiers::DISALLOWED_DIE);
+		return $this->disallowedCallsRuleErrors->get(
+			null,
+			$scope,
+			$kind,
+			$kind,
+			null,
+			true,
+			$this->disallowedCalls,
+			$kind === 'exit' ? ErrorIdentifiers::DISALLOWED_EXIT : ErrorIdentifiers::DISALLOWED_DIE,
+		);
 	}
 
 }

--- a/src/Calls/IssetCalls.php
+++ b/src/Calls/IssetCalls.php
@@ -54,7 +54,16 @@ class IssetCalls implements Rule
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{
-		return $this->disallowedCallsRuleErrors->get(null, $scope, 'isset', 'isset', null, $this->disallowedCalls, ErrorIdentifiers::DISALLOWED_ISSET);
+		return $this->disallowedCallsRuleErrors->get(
+			null,
+			$scope,
+			'isset',
+			'isset',
+			null,
+			true,
+			$this->disallowedCalls,
+			ErrorIdentifiers::DISALLOWED_ISSET,
+		);
 	}
 
 }

--- a/src/Calls/NewCalls.php
+++ b/src/Calls/NewCalls.php
@@ -95,10 +95,17 @@ class NewCalls implements Rule
 					$names[] = $interface->getName();
 				}
 			}
-			$definedIn = $reflection ? $reflection->getFileName() : null;
-
 			foreach ($names as $name) {
-				$ruleErrors = $this->disallowedCallsRuleErrors->get($node, $scope, $name . '::' . self::CONSTRUCT, $type->getClassName() . '::' . self::CONSTRUCT, $definedIn, $this->disallowedCalls, ErrorIdentifiers::DISALLOWED_NEW);
+				$ruleErrors = $this->disallowedCallsRuleErrors->get(
+					$node,
+					$scope,
+					$name . '::' . self::CONSTRUCT,
+					$type->getClassName() . '::' . self::CONSTRUCT,
+					$reflection ? $reflection->getFileName() : null,
+					$reflection && $reflection->isBuiltin(),
+					$this->disallowedCalls,
+					ErrorIdentifiers::DISALLOWED_NEW,
+				);
 				$paramErrors = $this->disallowedCallableParameterRuleErrors->getForConstructor(new Name($name), $node, $scope);
 				if ($errors || $ruleErrors || $paramErrors) {
 					$errors = array_merge($errors, $ruleErrors, $paramErrors);

--- a/src/Calls/PrintCalls.php
+++ b/src/Calls/PrintCalls.php
@@ -54,7 +54,16 @@ class PrintCalls implements Rule
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{
-		return $this->disallowedCallsRuleErrors->get(null, $scope, 'print', 'print', null, $this->disallowedCalls, ErrorIdentifiers::DISALLOWED_PRINT);
+		return $this->disallowedCallsRuleErrors->get(
+			null,
+			$scope,
+			'print',
+			'print',
+			null,
+			true,
+			$this->disallowedCalls,
+			ErrorIdentifiers::DISALLOWED_PRINT,
+		);
 	}
 
 }

--- a/src/Calls/ShellExecCalls.php
+++ b/src/Calls/ShellExecCalls.php
@@ -64,9 +64,10 @@ class ShellExecCalls implements Rule
 			'shell_exec',
 			null,
 			null,
+			true,
 			$this->disallowedCalls,
 			ErrorIdentifiers::DISALLOWED_BACKTICK,
-			'Using the backtick operator (`...`) is forbidden because shell_exec() is forbidden%2$s%3$s'
+			'Using the backtick operator (`...`) is forbidden because shell_exec() is forbidden%2$s%3$s',
 		);
 	}
 

--- a/src/Calls/UnsetCalls.php
+++ b/src/Calls/UnsetCalls.php
@@ -54,7 +54,16 @@ class UnsetCalls implements Rule
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{
-		return $this->disallowedCallsRuleErrors->get(null, $scope, 'unset', 'unset', null, $this->disallowedCalls, ErrorIdentifiers::DISALLOWED_UNSET);
+		return $this->disallowedCallsRuleErrors->get(
+			null,
+			$scope,
+			'unset',
+			'unset',
+			null,
+			true,
+			$this->disallowedCalls,
+			ErrorIdentifiers::DISALLOWED_UNSET,
+		);
 	}
 
 }

--- a/src/RuleErrors/DisallowedCallsRuleErrors.php
+++ b/src/RuleErrors/DisallowedCallsRuleErrors.php
@@ -44,19 +44,20 @@ class DisallowedCallsRuleErrors
 	 * @param string $name
 	 * @param string|null $displayName
 	 * @param string|null $definedIn
+	 * @param bool $isBuiltIn
 	 * @param list<DisallowedCall> $disallowedCalls
 	 * @param string $identifier
 	 * @param string|null $message
 	 * @return list<IdentifierRuleError>
 	 * @throws ShouldNotHappenException
 	 */
-	public function get(?CallLike $node, Scope $scope, string $name, ?string $displayName, ?string $definedIn, array $disallowedCalls, string $identifier, ?string $message = null): array
+	public function get(?CallLike $node, Scope $scope, string $name, ?string $displayName, ?string $definedIn, bool $isBuiltIn, array $disallowedCalls, string $identifier, ?string $message = null): array
 	{
 		$args = isset($node) && !$node->isFirstClassCallable() ? $node->getArgs() : null;
 		foreach ($disallowedCalls as $disallowedCall) {
 			if (
 				$this->identifier->matches($disallowedCall->getCall(), $name, $disallowedCall->getExcludes())
-				&& $this->definedInMatches($disallowedCall, $definedIn)
+				&& $this->definedInMatches($disallowedCall, $definedIn, $isBuiltIn)
 				&& !$this->allowed->isAllowed($node, $scope, $args, $disallowedCall)
 			) {
 				$errorBuilder = RuleErrorBuilder::message(sprintf(
@@ -76,9 +77,13 @@ class DisallowedCallsRuleErrors
 	}
 
 
-	private function definedInMatches(DisallowedCall $disallowedCall, ?string $definedIn): bool
+	private function definedInMatches(DisallowedCall $disallowedCall, ?string $definedIn, bool $isBuiltIn): bool
 	{
-		if (!$disallowedCall->getDefinedIn() || !$definedIn) {
+		if (!$disallowedCall->getDefinedIn()) {
+			return true;
+		} elseif ($isBuiltIn) {
+			return false;
+		} elseif ($definedIn === null) {
 			return true;
 		}
 		foreach ($disallowedCall->getDefinedIn() as $callDefinedIn) {

--- a/src/RuleErrors/DisallowedFunctionRuleErrors.php
+++ b/src/RuleErrors/DisallowedFunctionRuleErrors.php
@@ -82,11 +82,22 @@ class DisallowedFunctionRuleErrors
 	{
 		if ($this->reflectionProvider->hasFunction($name, $scope)) {
 			$functionReflection = $this->reflectionProvider->getFunction($name, $scope);
-			$definedIn = $functionReflection->isBuiltin() ? null : $functionReflection->getFileName();
+			$definedIn = $functionReflection->getFileName();
+			$isBuiltIn = $functionReflection->isBuiltin();
 		} else {
 			$definedIn = null;
+			$isBuiltIn = false;
 		}
-		return $this->disallowedCallsRuleErrors->get($node, $scope, (string)$name, (string)($displayName ?? $name), $definedIn, $disallowedCalls, ErrorIdentifiers::DISALLOWED_FUNCTION);
+		return $this->disallowedCallsRuleErrors->get(
+			$node,
+			$scope,
+			(string)$name,
+			(string)($displayName ?? $name),
+			$definedIn,
+			$isBuiltIn,
+			$disallowedCalls,
+			ErrorIdentifiers::DISALLOWED_FUNCTION,
+		);
 	}
 
 }

--- a/src/RuleErrors/DisallowedMethodRuleErrors.php
+++ b/src/RuleErrors/DisallowedMethodRuleErrors.php
@@ -129,7 +129,16 @@ class DisallowedMethodRuleErrors
 		foreach ($classes as $class) {
 			if ($class->hasMethod($method->getName())) {
 				$declaredAs = $this->formatter->getFullyQualified($class->getDisplayName(false), $method);
-				$ruleErrors = $this->disallowedCallsRuleErrors->get($node, $scope, $declaredAs, $calledAs, $class->getFileName(), $disallowedCalls, ErrorIdentifiers::DISALLOWED_METHOD);
+				$ruleErrors = $this->disallowedCallsRuleErrors->get(
+					$node,
+					$scope,
+					$declaredAs,
+					$calledAs,
+					$class->getFileName(),
+					$class->isBuiltin(),
+					$disallowedCalls,
+					ErrorIdentifiers::DISALLOWED_METHOD,
+				);
 				if ($ruleErrors) {
 					return $ruleErrors;
 				}

--- a/tests/Bugs/Bug383RuleWithDefinedInSkipsBuiltinClassMethodsTest.php
+++ b/tests/Bugs/Bug383RuleWithDefinedInSkipsBuiltinClassMethodsTest.php
@@ -1,0 +1,61 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Rules\Disallowed\Bugs;
+
+use PHPStan\Rules\Rule;
+use PHPStan\ShouldNotHappenException;
+use PHPStan\Testing\RuleTestCase;
+use Spaze\PHPStan\Rules\Disallowed\Calls\MethodCalls;
+use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallableParameterRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedMethodRuleErrors;
+
+/**
+ * @extends RuleTestCase<MethodCalls>
+ */
+class Bug383RuleWithDefinedInSkipsBuiltinClassMethodsTest extends RuleTestCase
+{
+
+	/**
+	 * @throws ShouldNotHappenException
+	 */
+	protected function getRule(): Rule
+	{
+		$container = self::getContainer();
+		return new MethodCalls(
+			$container->getByType(DisallowedMethodRuleErrors::class),
+			$container->getByType(DisallowedCallableParameterRuleErrors::class),
+			$container->getByType(DisallowedCallFactory::class),
+			[
+				[
+					'method' => '*',
+					'definedIn' => [
+						__DIR__ . '/../src/Blade*',
+						'phar://*', // The built-in classes are defined in PHPStan phar
+					],
+				],
+			],
+		);
+	}
+
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/../src/bugs/Bug383RuleWithDefinedInSkipsBuiltinClasses.php'], [
+			[
+				'Calling Waldo\Quux\Blade::runner() is forbidden. [Waldo\Quux\Blade::runner() matches *()]',
+				19,
+			],
+		]);
+	}
+
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__ . '/../../extension.neon',
+		];
+	}
+
+}

--- a/tests/Bugs/Bug383RuleWithDefinedInSkipsBuiltinClassNewCallsTest.php
+++ b/tests/Bugs/Bug383RuleWithDefinedInSkipsBuiltinClassNewCallsTest.php
@@ -1,0 +1,61 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Rules\Disallowed\Bugs;
+
+use PHPStan\Rules\Rule;
+use PHPStan\ShouldNotHappenException;
+use PHPStan\Testing\RuleTestCase;
+use Spaze\PHPStan\Rules\Disallowed\Calls\NewCalls;
+use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallableParameterRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallsRuleErrors;
+
+/**
+ * @extends RuleTestCase<NewCalls>
+ */
+class Bug383RuleWithDefinedInSkipsBuiltinClassNewCallsTest extends RuleTestCase
+{
+
+	/**
+	 * @throws ShouldNotHappenException
+	 */
+	protected function getRule(): Rule
+	{
+		$container = self::getContainer();
+		return new NewCalls(
+			$container->getByType(DisallowedCallsRuleErrors::class),
+			$container->getByType(DisallowedCallableParameterRuleErrors::class),
+			$container->getByType(DisallowedCallFactory::class),
+			[
+				[
+					'method' => '*',
+					'definedIn' => [
+						__DIR__ . '/../src/Blade*',
+						'phar://*', // The built-in classes are defined in PHPStan phar
+					],
+				],
+			],
+		);
+	}
+
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/../src/bugs/Bug383RuleWithDefinedInSkipsBuiltinClasses.php'], [
+			[
+				'Calling Waldo\Quux\Blade::__construct() is forbidden. [Waldo\Quux\Blade::__construct() matches *()]',
+				18,
+			],
+		]);
+	}
+
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__ . '/../../extension.neon',
+		];
+	}
+
+}

--- a/tests/Bugs/Bug383RuleWithDefinedInSkipsBuiltinFunctionsTest.php
+++ b/tests/Bugs/Bug383RuleWithDefinedInSkipsBuiltinFunctionsTest.php
@@ -1,0 +1,70 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Rules\Disallowed\Bugs;
+
+use PHPStan\Rules\Rule;
+use PHPStan\ShouldNotHappenException;
+use PHPStan\Testing\RuleTestCase;
+use Spaze\PHPStan\Rules\Disallowed\Calls\FunctionCalls;
+use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallableParameterRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedFunctionRuleErrors;
+
+/**
+ * @extends RuleTestCase<FunctionCalls>
+ */
+class Bug383RuleWithDefinedInSkipsBuiltinFunctionsTest extends RuleTestCase
+{
+
+	/**
+	 * @throws ShouldNotHappenException
+	 */
+	protected function getRule(): Rule
+	{
+		$container = self::getContainer();
+		return new FunctionCalls(
+			$container->getByType(DisallowedFunctionRuleErrors::class),
+			$container->getByType(DisallowedCallableParameterRuleErrors::class),
+			$container->getByType(DisallowedCallFactory::class),
+			[
+				[
+					'function' => '*',
+					'definedIn' => __DIR__ . '/../src/Fun*.php',
+				],
+			],
+		);
+	}
+
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/../src/bugs/Bug383RuleWithDefinedInSkipsBuiltinFunctions.php'], [
+			[
+				'Calling __() is forbidden. [__() matches *()]',
+				12,
+			],
+			[
+				'Calling MyNamespace\__() is forbidden. [MyNamespace\__() matches *()]',
+				13,
+			],
+			[
+				'Calling Foo\Bar\Waldo\foo() is forbidden. [Foo\Bar\Waldo\foo() matches *()]',
+				14,
+			],
+			[
+				'Calling Foo\Bar\Waldo\config() is forbidden. [Foo\Bar\Waldo\config() matches *()]',
+				15,
+			],
+		]);
+	}
+
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__ . '/../../extension.neon',
+		];
+	}
+
+}

--- a/tests/src/bugs/Bug383RuleWithDefinedInSkipsBuiltinClasses.php
+++ b/tests/src/bugs/Bug383RuleWithDefinedInSkipsBuiltinClasses.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types = 1);
+
+class FooBarFredHelper
+{
+
+	public function setWaldo()
+	{
+	}
+
+}
+
+// defined outside definedIn path, should be allowed
+$foo = new FooBarFredHelper();
+$foo->setWaldo();
+
+// defined in definedIn path, disallowed
+$blade = new \Waldo\Quux\Blade();
+$blade->runner();
+
+// built-in classes, definitely not defined in definedIn path, should not be disallowed
+$now = new DateTimeImmutable();
+$now->format('Y-m-d H:i:s');

--- a/tests/src/bugs/Bug383RuleWithDefinedInSkipsBuiltinFunctions.php
+++ b/tests/src/bugs/Bug383RuleWithDefinedInSkipsBuiltinFunctions.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types = 1);
+
+function laravel_config_helper()
+{
+}
+
+// defined outside definedIn path, should be allowed
+laravel_config_helper();
+
+// defined in definedIn path, disallowed
+__();
+MyNamespace\__();
+\Foo\Bar\Waldo\foo('bar');
+\Foo\Bar\Waldo\config('baz');
+
+// built-in functions, definitely not defined in definedIn path, should not be disallowed
+$answer = sprintf('%d', 42);
+iterator_to_array(new ArrayIterator([]));
+$length = strlen('42');


### PR DESCRIPTION
Those would never be defined in userland code anyway.

Close #383

Follow-up fix in #388