### PR TITLE
Don't process the function name if the function reflection is not available (wrong namespace etc.)

### DIFF
--- a/src/RuleErrors/DisallowedFunctionRuleErrors.php
+++ b/src/RuleErrors/DisallowedFunctionRuleErrors.php
@@ -80,21 +80,18 @@ class DisallowedFunctionRuleErrors
 	 */
 	private function getErrors(Name $name, Scope $scope, ?FuncCall $node, ?Name $displayName, array $disallowedCalls): array
 	{
-		if ($this->reflectionProvider->hasFunction($name, $scope)) {
-			$functionReflection = $this->reflectionProvider->getFunction($name, $scope);
-			$definedIn = $functionReflection->getFileName();
-			$isBuiltIn = $functionReflection->isBuiltin();
-		} else {
-			$definedIn = null;
-			$isBuiltIn = false;
+		if (!$this->reflectionProvider->hasFunction($name, $scope)) {
+			return [];
 		}
+
+		$functionReflection = $this->reflectionProvider->getFunction($name, $scope);
 		return $this->disallowedCallsRuleErrors->get(
 			$node,
 			$scope,
 			(string)$name,
 			(string)($displayName ?? $name),
-			$definedIn,
-			$isBuiltIn,
+			$functionReflection->getFileName(),
+			$functionReflection->isBuiltin(),
 			$disallowedCalls,
 			ErrorIdentifiers::DISALLOWED_FUNCTION,
 		);

--- a/tests/Bugs/Bug383RuleWithDefinedInSkipsBuiltinFunctionsTest.php
+++ b/tests/Bugs/Bug383RuleWithDefinedInSkipsBuiltinFunctionsTest.php
@@ -42,19 +42,35 @@ class Bug383RuleWithDefinedInSkipsBuiltinFunctionsTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/../src/bugs/Bug383RuleWithDefinedInSkipsBuiltinFunctions.php'], [
 			[
 				'Calling __() is forbidden. [__() matches *()]',
-				12,
-			],
-			[
-				'Calling MyNamespace\__() is forbidden. [MyNamespace\__() matches *()]',
-				13,
-			],
-			[
-				'Calling Foo\Bar\Waldo\foo() is forbidden. [Foo\Bar\Waldo\foo() matches *()]',
 				14,
 			],
 			[
-				'Calling Foo\Bar\Waldo\config() is forbidden. [Foo\Bar\Waldo\config() matches *()]',
+				'Calling MyNamespace\__() is forbidden. [MyNamespace\__() matches *()]',
 				15,
+			],
+			[
+				'Calling Foo\Bar\Waldo\foo() is forbidden. [Foo\Bar\Waldo\foo() matches *()]',
+				16,
+			],
+			[
+				'Calling Foo\Bar\Waldo\config() is forbidden. [Foo\Bar\Waldo\config() matches *()]',
+				17,
+			],
+			[
+				'Calling __() is forbidden. [__() matches *()]',
+				36,
+			],
+			[
+				'Calling MyNamespace\__() is forbidden. [MyNamespace\__() matches *()]',
+				37,
+			],
+			[
+				'Calling Foo\Bar\Waldo\foo() is forbidden. [Foo\Bar\Waldo\foo() matches *()]',
+				38,
+			],
+			[
+				'Calling Foo\Bar\Waldo\config() is forbidden. [Foo\Bar\Waldo\config() matches *()]',
+				39,
 			],
 		]);
 	}

--- a/tests/Calls/FunctionCallsTest.php
+++ b/tests/Calls/FunctionCallsTest.php
@@ -219,7 +219,7 @@ class FunctionCallsTest extends RuleTestCase
 					],
 				],
 				[
-					'function' => '\Dom\import_simplexml()',
+					'function' => 'dom_import_simplexml()',
 					'disallowInInstanceOf' => [
 						Bar::class,
 						Stringable::class,
@@ -408,7 +408,7 @@ class FunctionCallsTest extends RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/../src/Bar.php'], [
 			[
-				'Calling Dom\import_simplexml() is forbidden.',
+				'Calling dom_import_simplexml() is forbidden.',
 				38,
 			],
 			[
@@ -416,7 +416,7 @@ class FunctionCallsTest extends RuleTestCase
 				56,
 			],
 			[
-				'Calling Dom\import_simplexml() is forbidden.',
+				'Calling dom_import_simplexml() is forbidden.',
 				76,
 			],
 		]);

--- a/tests/Configs/InsecureConfigFunctionCallsTest.php
+++ b/tests/Configs/InsecureConfigFunctionCallsTest.php
@@ -34,8 +34,6 @@ class InsecureConfigFunctionCallsTest extends RuleTestCase
 			['Calling hash_file() is forbidden, use hash_file() with at least SHA-256 for secure hash, or password_hash() for passwords.', 12],
 			['Calling hash_init() is forbidden, use hash_init() with at least SHA-256 for secure hash, or password_hash() for passwords.', 14],
 			['Calling hash_init() is forbidden, use hash_init() with at least SHA-256 for secure hash, or password_hash() for passwords.', 15],
-			['Calling mysql_query() is forbidden, use PDO::prepare() with variable binding/parametrized queries to prevent SQL Injection vulnerability.', 17],
-			['Calling mysql_unbuffered_query() is forbidden, use PDO::prepare() with variable binding/parametrized queries to prevent SQL Injection vulnerability.', 18],
 			['Calling mysqli_query() is forbidden, use PDO::prepare() with variable binding/parametrized queries to prevent SQL Injection vulnerability.', 19],
 			['Calling mysqli_multi_query() is forbidden, use PDO::prepare() with variable binding/parametrized queries to prevent SQL Injection vulnerability.', 20],
 			['Calling mysqli_real_query() is forbidden, use PDO::prepare() with variable binding/parametrized queries to prevent SQL Injection vulnerability.', 21],

--- a/tests/src/Bar.php
+++ b/tests/src/Bar.php
@@ -35,7 +35,7 @@ class BarChild extends Bar
 	public function inInstanceOf(DateTimeZone $a, DateTimeImmutable $b): void
 	{
 		$el = simplexml_load_string('<foo/>');
-		\Dom\import_simplexml($el);
+		dom_import_simplexml($el);
 		$zone = new (DateTimeZone::class)('Europe/Prague');
 		$zone->getLocation();
 		$date = new DateTimeImmutable();
@@ -54,7 +54,7 @@ class Bar2
 	public function inInstanceOf(DateTimeZone $a, DateTimeImmutable $b): void
 	{
 		$el = simplexml_load_string('<foo/>');
-		\Dom\import_simplexml($el);
+		dom_import_simplexml($el);
 		$zone = new DateTimeZone('Europe/Prague');
 		$zone->getLocation();
 		$date = new(DateTimeImmutable::class)();
@@ -73,7 +73,7 @@ class BarInterface implements \Stringable
 	public function inInstanceOf(DateTimeZone $a, DateTimeImmutable $b): void
 	{
 		$el = simplexml_load_string('<foo/>');
-		\Dom\import_simplexml($el);
+		dom_import_simplexml($el);
 		$zone = new (DateTimeZone::class)('Europe/Prague');
 		$zone->getLocation();
 		$date = new DateTimeImmutable();

--- a/tests/src/Functions.php
+++ b/tests/src/Functions.php
@@ -86,3 +86,9 @@ function method2(None|Some $union, None $none, Some $some, Blade $foo, $bar): vo
 	new None();
 	new Some(303);
 }
+
+namespace Foo\Bar;
+
+function waldo()
+{
+}

--- a/tests/src/bugs/Bug383RuleWithDefinedInSkipsBuiltinFunctions.php
+++ b/tests/src/bugs/Bug383RuleWithDefinedInSkipsBuiltinFunctions.php
@@ -1,20 +1,46 @@
 <?php
 declare(strict_types = 1);
 
-function laravel_config_helper()
-{
+namespace {
+
+	function config()
+	{
+	}
+
+	// defined outside definedIn path, should be allowed
+	config();
+
+	// defined in definedIn path, disallowed
+	__();
+	\MyNamespace\__();
+	\Foo\Bar\Waldo\foo('bar');
+	\Foo\Bar\Waldo\config('baz');
+
+	// built-in functions, definitely not defined in definedIn path, should not be disallowed
+	$answer = sprintf('%d', 42);
+	iterator_to_array(new ArrayIterator([]));
+	$length = strlen('42');
+
 }
 
-// defined outside definedIn path, should be allowed
-laravel_config_helper();
+namespace Foo {
 
-// defined in definedIn path, disallowed
-__();
-MyNamespace\__();
-\Foo\Bar\Waldo\foo('bar');
-\Foo\Bar\Waldo\config('baz');
+	function config2()
+	{
+	}
 
-// built-in functions, definitely not defined in definedIn path, should not be disallowed
-$answer = sprintf('%d', 42);
-iterator_to_array(new ArrayIterator([]));
-$length = strlen('42');
+	// defined outside definedIn path, should be allowed
+	config2();
+
+	// defined in definedIn path, disallowed
+	__();
+	\MyNamespace\__();
+	\Foo\Bar\Waldo\foo('bar');
+	\Foo\Bar\Waldo\config('baz');
+
+	// built-in functions, definitely not defined in definedIn path, should not be disallowed
+	$answer = sprintf('%d', 42);
+	iterator_to_array(new \ArrayIterator([]));
+	$length = strlen('42');
+
+}


### PR DESCRIPTION
Also
- Add `Foo\Bar\waldo()` otherwise tests fail
- Don't expect errors generated by `mysql_*` functions which do not exist anymore
  Both `mysql_query()` and `mysql_unbuffered_query` were deprecated in PHP 5.5.0, and removed in PHP 7.0.0. I feel old now.

Close #386

(Previous take #384)