### PR TITLE
Update the e2e test after the `vendor`/`vendor-dev` split

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,7 +15,7 @@ jobs:
             repo: spaze/michalspacek.cz
             php-version: "8.5"
             run: make --directory=app phpstan
-            composer-params: --working-dir=app
+            composer-params: --working-dir=app/vendor-dev
           -
             repo: spaze/security-txt
             php-version: "8.5"


### PR DESCRIPTION
See these in the e2e'd repo for more info:
- https://github.com/spaze/michalspacek.cz/issues/725
- https://github.com/spaze/michalspacek.cz/pull/726