### PR TITLE
Add `fnmatch()` wildcard support to `allowInInstanceOf` and friends

### DIFF
--- a/docs/allow-in-instance-of.md
+++ b/docs/allow-in-instance-of.md
@@ -5,6 +5,19 @@ Use `allowInInstanceOf`, named after the PHP's `instanceof` operator, if you wan
 - a class that inherits from a class of given name
 - a class that implements given interface
 
+The class names support [fnmatch()](https://www.php.net/fnmatch) patterns. When a wildcard pattern is used, it is matched against the current class name as well as all its parent class and interface names transitively, so the same instanceof semantics apply.
+
+For example, to allow a function call in any class inside the `App\Wrappers` namespace and its subclasses:
+
+```neon
+parameters:
+    disallowedFunctionCalls:
+        -
+            function: 'someFunction()'
+            allowInInstanceOf:
+                - 'App\Wrappers\*'
+```
+
 This is useful for example when you want to allow properties or parameters of class `ClassName` in all classes that extend `ParentClass`:
 
 ```neon

--- a/src/Allowed/Allowed.php
+++ b/src/Allowed/Allowed.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use PHPStan\Analyser\Scope;
 use PHPStan\BetterReflection\Reflector\Reflector;
+use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\Type;
@@ -150,8 +151,31 @@ class Allowed
 	 */
 	private function isInstanceOf(Scope $scope, array $allowConfig): bool
 	{
+		if (!$scope->isInClass()) {
+			return false;
+		}
+		$classReflection = $scope->getClassReflection();
 		foreach ($allowConfig as $allowInstanceOf) {
-			if ($scope->isInClass() && $scope->getClassReflection()->is($allowInstanceOf)) {
+			if ($this->classOrAncestorMatches($classReflection, $allowInstanceOf)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+
+	private function classOrAncestorMatches(ClassReflection $classReflection, string $pattern): bool
+	{
+		if (fnmatch($pattern, $classReflection->getName(), FNM_NOESCAPE | FNM_CASEFOLD)) {
+			return true;
+		}
+		foreach ($classReflection->getParentClassesNames() as $name) {
+			if (fnmatch($pattern, $name, FNM_NOESCAPE | FNM_CASEFOLD)) {
+				return true;
+			}
+		}
+		foreach (array_keys($classReflection->getInterfaces()) as $name) {
+			if (fnmatch($pattern, $name, FNM_NOESCAPE | FNM_CASEFOLD)) {
 				return true;
 			}
 		}

--- a/tests/Calls/FunctionCallsTest.php
+++ b/tests/Calls/FunctionCallsTest.php
@@ -225,6 +225,19 @@ class FunctionCallsTest extends RuleTestCase
 						Stringable::class,
 					],
 				],
+				// test allowed instances with wildcards, intentionally wrong case to test FNM_CASEFOLD
+				[
+					'function' => 'str_pad()',
+					'allowInInstanceOf' => [
+						'waldo\foo\wild*',
+					],
+				],
+				[
+					'function' => 'str_repeat()',
+					'disallowInInstanceOf' => [
+						'Waldo\Foo\Wild*',
+					],
+				],
 			]
 		);
 	}
@@ -418,6 +431,37 @@ class FunctionCallsTest extends RuleTestCase
 			[
 				'Calling dom_import_simplexml() is forbidden.',
 				76,
+			],
+		]);
+	}
+
+
+	public function testAllowInInstanceOfWildcard(): void
+	{
+		$this->analyse([__DIR__ . '/../src/BarWildcard.php'], [
+			[
+				'Calling str_repeat() is forbidden.',
+				16,
+			],
+			[
+				'Calling str_repeat() is forbidden.',
+				27,
+			],
+			[
+				'Calling str_repeat() is forbidden.',
+				38,
+			],
+			[
+				'Calling str_repeat() is forbidden.',
+				49,
+			],
+			[
+				'Calling str_repeat() is forbidden.',
+				60,
+			],
+			[
+				'Calling str_pad() is forbidden.',
+				70,
 			],
 		]);
 	}

--- a/tests/src/BarWildcard.php
+++ b/tests/src/BarWildcard.php
@@ -1,0 +1,74 @@
+<?php
+declare(strict_types = 1);
+
+namespace Waldo\Foo;
+
+interface WildInterface
+{
+}
+
+class WildBase
+{
+
+	public function inWild(): void
+	{
+		str_pad('foo', 10);
+		str_repeat('bar', 3);
+	}
+
+}
+
+class ChildOfBase extends WildBase
+{
+
+	public function inWild(): void
+	{
+		str_pad('foo', 10);
+		str_repeat('bar', 3);
+	}
+
+}
+
+class GrandChildOfBase extends ChildOfBase
+{
+
+	public function inWild(): void
+	{
+		str_pad('foo', 10);
+		str_repeat('bar', 3);
+	}
+
+}
+
+class ImplementsWildInterface implements WildInterface
+{
+
+	public function inWild(): void
+	{
+		str_pad('foo', 10);
+		str_repeat('bar', 3);
+	}
+
+}
+
+class InheritsWildInterface extends ImplementsWildInterface
+{
+
+	public function inWild(): void
+	{
+		str_pad('foo', 10);
+		str_repeat('bar', 3);
+	}
+
+}
+
+class NotWild
+{
+
+	public function inWild(): void
+	{
+		str_pad('foo', 10);
+		str_repeat('bar', 3);
+	}
+
+}


### PR DESCRIPTION
`allowInInstanceOf`, `allowExceptInInstanceOf`, and `disallowInInstanceOf` now accept fnmatch() patterns (e.g. `App\Wrappers\*`). Pattern is matched against the class name and all parent classes and interfaces transitively, consistent with `instanceof` semantics
