### PR TITLE
Throw a descriptive exception when `typeString` cannot be parsed

### DIFF
--- a/src/Allowed/AllowedConfigFactory.php
+++ b/src/Allowed/AllowedConfigFactory.php
@@ -4,11 +4,14 @@ declare(strict_types = 1);
 namespace Spaze\PHPStan\Rules\Disallowed\Allowed;
 
 use PHPStan\PhpDoc\TypeStringResolver;
+use PHPStan\PhpDocParser\Parser\ParserException;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\NullType;
 use PHPStan\Type\VerbosityLevel;
+use Spaze\PHPStan\Rules\Disallowed\Exceptions\InvalidConfigException;
+use Spaze\PHPStan\Rules\Disallowed\Exceptions\InvalidTypeStringInConfigException;
 use Spaze\PHPStan\Rules\Disallowed\Exceptions\UnsupportedParamTypeInConfigException;
 use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\Params\ParamValue;
@@ -42,7 +45,7 @@ class AllowedConfigFactory
 	 * @param array $allowed
 	 * @phpstan-param AllowDirectivesConfig $allowed
 	 * @return AllowedConfig
-	 * @throws UnsupportedParamTypeInConfigException
+	 * @throws InvalidConfigException
 	 */
 	public function getConfig(array $allowed): AllowedConfig
 	{
@@ -147,7 +150,7 @@ class AllowedConfigFactory
 	 * @param int|string $key
 	 * @param int|bool|string|null|array{position:int, value?:int|bool|string, typeString?:string, name?:string} $value
 	 * @return T
-	 * @throws UnsupportedParamTypeInConfigException
+	 * @throws InvalidConfigException
 	 */
 	private function paramFactory(string $class, $key, $value): ParamValue
 	{
@@ -180,7 +183,12 @@ class AllowedConfigFactory
 		}
 
 		if ($typeString) {
-			$type = $this->typeStringResolver->resolve($typeString);
+			try {
+				$type = $this->typeStringResolver->resolve($typeString);
+			} catch (ParserException $e) {
+				$hint = str_contains($typeString, '*') ? ' Wildcards are not supported in typeString.' : '';
+				throw new InvalidTypeStringInConfigException($typeString, $e->getMessage() . $hint, $e);
+			}
 		} elseif (is_int($paramValue)) {
 			$type = new ConstantIntegerType($paramValue);
 		} elseif (is_bool($paramValue)) {

--- a/src/DisallowedAttributeFactory.php
+++ b/src/DisallowedAttributeFactory.php
@@ -3,8 +3,10 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Rules\Disallowed;
 
+use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\Allowed\AllowedConfigFactory;
-use Spaze\PHPStan\Rules\Disallowed\Exceptions\UnsupportedParamTypeInConfigException;
+use Spaze\PHPStan\Rules\Disallowed\Exceptions\InvalidConfigException;
+use Spaze\PHPStan\Rules\Disallowed\Formatter\Formatter;
 use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 
 class DisallowedAttributeFactory
@@ -14,11 +16,14 @@ class DisallowedAttributeFactory
 
 	private Normalizer $normalizer;
 
+	private Formatter $formatter;
 
-	public function __construct(AllowedConfigFactory $allowedConfigFactory, Normalizer $normalizer)
+
+	public function __construct(AllowedConfigFactory $allowedConfigFactory, Normalizer $normalizer, Formatter $formatter)
 	{
 		$this->allowedConfigFactory = $allowedConfigFactory;
 		$this->normalizer = $normalizer;
+		$this->formatter = $formatter;
 	}
 
 
@@ -26,27 +31,31 @@ class DisallowedAttributeFactory
 	 * @param array $config
 	 * @phpstan-param DisallowedAttributesConfig $config
 	 * @return list<DisallowedAttribute>
-	 * @throws UnsupportedParamTypeInConfigException
+	 * @throws ShouldNotHappenException
 	 */
 	public function createFromConfig(array $config): array
 	{
 		$disallowedAttributes = [];
 		foreach ($config as $disallowed) {
-			$attributes = $disallowed['attribute'];
+			$attributes = (array)$disallowed['attribute'];
 			$excludes = [];
 			foreach ((array)($disallowed['exclude'] ?? []) as $exclude) {
 				$excludes[] = $this->normalizer->normalizeAttribute($exclude);
 			}
-			foreach ((array)$attributes as $attribute) {
-				$disallowedAttribute = new DisallowedAttribute(
-					$this->normalizer->normalizeAttribute($attribute),
-					$excludes,
-					$disallowed['message'] ?? null,
-					$this->allowedConfigFactory->getConfig($disallowed),
-					$disallowed['errorIdentifier'] ?? null,
-					$disallowed['errorTip'] ?? []
-				);
-				$disallowedAttributes[$disallowedAttribute->getAttribute()] = $disallowedAttribute;
+			try {
+				foreach ($attributes as $attribute) {
+					$disallowedAttribute = new DisallowedAttribute(
+						$this->normalizer->normalizeAttribute($attribute),
+						$excludes,
+						$disallowed['message'] ?? null,
+						$this->allowedConfigFactory->getConfig($disallowed),
+						$disallowed['errorIdentifier'] ?? null,
+						$disallowed['errorTip'] ?? []
+					);
+					$disallowedAttributes[$disallowedAttribute->getAttribute()] = $disallowedAttribute;
+				}
+			} catch (InvalidConfigException $e) {
+				throw new ShouldNotHappenException(sprintf('%s: %s', $this->formatter->formatIdentifier($attributes), $e->getMessage()));
 			}
 		}
 		return array_values($disallowedAttributes);

--- a/src/DisallowedCallFactory.php
+++ b/src/DisallowedCallFactory.php
@@ -5,7 +5,7 @@ namespace Spaze\PHPStan\Rules\Disallowed;
 
 use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\Allowed\AllowedConfigFactory;
-use Spaze\PHPStan\Rules\Disallowed\Exceptions\UnsupportedParamTypeInConfigException;
+use Spaze\PHPStan\Rules\Disallowed\Exceptions\InvalidConfigException;
 use Spaze\PHPStan\Rules\Disallowed\Formatter\Formatter;
 use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 
@@ -61,7 +61,7 @@ class DisallowedCallFactory
 					);
 					$disallowedCalls[$disallowedCall->getKey()] = $disallowedCall;
 				}
-			} catch (UnsupportedParamTypeInConfigException $e) {
+			} catch (InvalidConfigException $e) {
 				throw new ShouldNotHappenException(sprintf('%s: %s', $this->formatter->formatIdentifier($calls), $e->getMessage()));
 			}
 		}

--- a/src/DisallowedConstantFactory.php
+++ b/src/DisallowedConstantFactory.php
@@ -5,7 +5,7 @@ namespace Spaze\PHPStan\Rules\Disallowed;
 
 use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\Allowed\AllowedConfigFactory;
-use Spaze\PHPStan\Rules\Disallowed\Exceptions\UnsupportedParamTypeInConfigException;
+use Spaze\PHPStan\Rules\Disallowed\Exceptions\InvalidConfigException;
 use Spaze\PHPStan\Rules\Disallowed\Formatter\Formatter;
 use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 
@@ -54,7 +54,7 @@ class DisallowedConstantFactory
 					);
 					$disallowedConstants[$disallowedConstant->getConstant()] = $disallowedConstant;
 				}
-			} catch (UnsupportedParamTypeInConfigException $e) {
+			} catch (InvalidConfigException $e) {
 				throw new ShouldNotHappenException(sprintf('%s: %s', $this->formatter->formatIdentifier($constants), $e->getMessage()));
 			}
 		}

--- a/src/DisallowedKeywordFactory.php
+++ b/src/DisallowedKeywordFactory.php
@@ -5,7 +5,7 @@ namespace Spaze\PHPStan\Rules\Disallowed;
 
 use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\Allowed\AllowedConfigFactory;
-use Spaze\PHPStan\Rules\Disallowed\Exceptions\UnsupportedParamTypeInConfigException;
+use Spaze\PHPStan\Rules\Disallowed\Exceptions\InvalidConfigException;
 use Spaze\PHPStan\Rules\Disallowed\Formatter\Formatter;
 
 class DisallowedKeywordFactory
@@ -84,7 +84,7 @@ class DisallowedKeywordFactory
 					);
 					$disallowedKeywords[$disallowedKeyword->getKeyword()] = $disallowedKeyword;
 				}
-			} catch (UnsupportedParamTypeInConfigException $e) {
+			} catch (InvalidConfigException $e) {
 				throw new ShouldNotHappenException(sprintf('%s: %s', $this->formatter->formatIdentifier($keywords), $e->getMessage()));
 			}
 		}

--- a/src/DisallowedNamespaceFactory.php
+++ b/src/DisallowedNamespaceFactory.php
@@ -5,7 +5,7 @@ namespace Spaze\PHPStan\Rules\Disallowed;
 
 use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\Allowed\AllowedConfigFactory;
-use Spaze\PHPStan\Rules\Disallowed\Exceptions\UnsupportedParamTypeInConfigException;
+use Spaze\PHPStan\Rules\Disallowed\Exceptions\InvalidConfigException;
 use Spaze\PHPStan\Rules\Disallowed\Formatter\Formatter;
 use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 
@@ -64,7 +64,7 @@ class DisallowedNamespaceFactory
 					);
 					$disallowedNamespaces[$disallowedNamespace->getNamespace()] = $disallowedNamespace;
 				}
-			} catch (UnsupportedParamTypeInConfigException $e) {
+			} catch (InvalidConfigException $e) {
 				throw new ShouldNotHappenException(sprintf('%s: %s', $this->formatter->formatIdentifier($namespaces), $e->getMessage()));
 			}
 		}

--- a/src/DisallowedPropertyFactory.php
+++ b/src/DisallowedPropertyFactory.php
@@ -3,8 +3,10 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Rules\Disallowed;
 
+use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\Allowed\AllowedConfigFactory;
-use Spaze\PHPStan\Rules\Disallowed\Exceptions\UnsupportedParamTypeInConfigException;
+use Spaze\PHPStan\Rules\Disallowed\Exceptions\InvalidConfigException;
+use Spaze\PHPStan\Rules\Disallowed\Formatter\Formatter;
 use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 
 class DisallowedPropertyFactory
@@ -14,33 +16,40 @@ class DisallowedPropertyFactory
 
 	private Normalizer $normalizer;
 
+	private Formatter $formatter;
 
-	public function __construct(AllowedConfigFactory $allowedConfigFactory, Normalizer $normalizer)
+
+	public function __construct(AllowedConfigFactory $allowedConfigFactory, Normalizer $normalizer, Formatter $formatter)
 	{
 		$this->allowedConfigFactory = $allowedConfigFactory;
 		$this->normalizer = $normalizer;
+		$this->formatter = $formatter;
 	}
 
 
 	/**
 	 * @param array<array{property:string|list<string>, message?:string, errorIdentifier?:string, errorTip?:string|list<string>}> $config + AllowDirectivesConfig
 	 * @return list<DisallowedProperty>
-	 * @throws UnsupportedParamTypeInConfigException
+	 * @throws ShouldNotHappenException
 	 */
 	public function createFromConfig(array $config): array
 	{
 		$disallowedProperties = [];
 		foreach ($config as $disallowed) {
-			$properties = $disallowed['property'];
-			foreach ((array)$properties as $property) {
-				$disallowedProperty = new DisallowedProperty(
-					$this->normalizer->normalizeProperty($property),
-					$disallowed['message'] ?? null,
-					$this->allowedConfigFactory->getConfig($disallowed),
-					$disallowed['errorIdentifier'] ?? null,
-					$disallowed['errorTip'] ?? []
-				);
-				$disallowedProperties[$disallowedProperty->getProperty()] = $disallowedProperty;
+			$properties = (array)$disallowed['property'];
+			try {
+				foreach ($properties as $property) {
+					$disallowedProperty = new DisallowedProperty(
+						$this->normalizer->normalizeProperty($property),
+						$disallowed['message'] ?? null,
+						$this->allowedConfigFactory->getConfig($disallowed),
+						$disallowed['errorIdentifier'] ?? null,
+						$disallowed['errorTip'] ?? []
+					);
+					$disallowedProperties[$disallowedProperty->getProperty()] = $disallowedProperty;
+				}
+			} catch (InvalidConfigException $e) {
+				throw new ShouldNotHappenException(sprintf('%s: %s', $this->formatter->formatIdentifier($properties), $e->getMessage()));
 			}
 		}
 		return array_values($disallowedProperties);

--- a/src/DisallowedSuperglobalFactory.php
+++ b/src/DisallowedSuperglobalFactory.php
@@ -5,7 +5,7 @@ namespace Spaze\PHPStan\Rules\Disallowed;
 
 use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\Allowed\AllowedConfigFactory;
-use Spaze\PHPStan\Rules\Disallowed\Exceptions\UnsupportedParamTypeInConfigException;
+use Spaze\PHPStan\Rules\Disallowed\Exceptions\InvalidConfigException;
 use Spaze\PHPStan\Rules\Disallowed\Formatter\Formatter;
 
 class DisallowedSuperglobalFactory
@@ -67,7 +67,7 @@ class DisallowedSuperglobalFactory
 					);
 					$disallowedSuperglobals[$disallowedSuperglobal->getVariable()] = $disallowedSuperglobal;
 				}
-			} catch (UnsupportedParamTypeInConfigException $e) {
+			} catch (InvalidConfigException $e) {
 				throw new ShouldNotHappenException(sprintf('%s: %s', $this->formatter->formatIdentifier($superglobals), $e->getMessage()));
 			}
 		}

--- a/src/Exceptions/InvalidConfigException.php
+++ b/src/Exceptions/InvalidConfigException.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Rules\Disallowed\Exceptions;
+
+use Exception;
+
+abstract class InvalidConfigException extends Exception
+{
+
+}

--- a/src/Exceptions/InvalidTypeStringInConfigException.php
+++ b/src/Exceptions/InvalidTypeStringInConfigException.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Rules\Disallowed\Exceptions;
+
+use Throwable;
+
+class InvalidTypeStringInConfigException extends InvalidConfigException
+{
+
+	public function __construct(string $typeString, string $reason, ?Throwable $previous = null)
+	{
+		parent::__construct(sprintf("Invalid typeString '%s': %s", $typeString, $reason), 0, $previous);
+	}
+
+}

--- a/src/Exceptions/UnsupportedParamTypeInConfigException.php
+++ b/src/Exceptions/UnsupportedParamTypeInConfigException.php
@@ -3,10 +3,9 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Rules\Disallowed\Exceptions;
 
-use Exception;
 use Throwable;
 
-class UnsupportedParamTypeInConfigException extends Exception
+class UnsupportedParamTypeInConfigException extends InvalidConfigException
 {
 
 	public function __construct(?int $position, ?string $name, string $type, int $code = 0, ?Throwable $previous = null)

--- a/src/Usages/InstancePropertyUsages.php
+++ b/src/Usages/InstancePropertyUsages.php
@@ -13,7 +13,6 @@ use PHPStan\Rules\RuleError;
 use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedProperty;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedPropertyFactory;
-use Spaze\PHPStan\Rules\Disallowed\Exceptions\UnsupportedParamTypeInConfigException;
 use Spaze\PHPStan\Rules\Disallowed\PHPStan1Compatibility;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedPropertyRuleErrors;
 
@@ -34,7 +33,7 @@ class InstancePropertyUsages implements Rule
 
 	/**
 	 * @param array<array{property:string|list<string>, message?:string, errorIdentifier?:string, errorTip?:string|list<string>}> $disallowedProperties + AllowDirectivesConfig
-	 * @throws UnsupportedParamTypeInConfigException
+	 * @throws ShouldNotHappenException
 	 */
 	public function __construct(
 		DisallowedPropertyFactory $disallowedPropertyFactory,

--- a/src/Usages/StaticPropertyUsages.php
+++ b/src/Usages/StaticPropertyUsages.php
@@ -13,7 +13,6 @@ use PHPStan\Rules\RuleError;
 use PHPStan\ShouldNotHappenException;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedProperty;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedPropertyFactory;
-use Spaze\PHPStan\Rules\Disallowed\Exceptions\UnsupportedParamTypeInConfigException;
 use Spaze\PHPStan\Rules\Disallowed\PHPStan1Compatibility;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedPropertyRuleErrors;
 
@@ -34,7 +33,7 @@ class StaticPropertyUsages implements Rule
 
 	/**
 	 * @param array<array{property:string|list<string>, message?:string, allowIn?:list<string>, allowExceptIn?:list<string>, disallowIn?:list<string>, errorIdentifier?:string, errorTip?:string|list<string>}> $disallowedProperties + AllowDirectivesConfig
-	 * @throws UnsupportedParamTypeInConfigException
+	 * @throws ShouldNotHappenException
 	 */
 	public function __construct(
 		DisallowedPropertyFactory $disallowedPropertyFactory,

--- a/tests/Calls/FunctionCallsInvalidTypeStringConfigTest.php
+++ b/tests/Calls/FunctionCallsInvalidTypeStringConfigTest.php
@@ -1,0 +1,76 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Rules\Disallowed\Calls;
+
+use PHPStan\ShouldNotHappenException;
+use PHPStan\Testing\PHPStanTestCase;
+use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallableParameterRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedFunctionRuleErrors;
+
+class FunctionCallsInvalidTypeStringConfigTest extends PHPStanTestCase
+{
+
+	/**
+	 * @throws ShouldNotHappenException
+	 */
+	public function testInvalidTypeStringWithWildcard(): void
+	{
+		$this->expectException(ShouldNotHappenException::class);
+		$this->expectExceptionMessageMatches("~foo\\(\\): Invalid typeString 'Foo\\\\\\*':.*Wildcards are not supported in typeString\\.~");
+		$container = self::getContainer();
+		new FunctionCalls(
+			$container->getByType(DisallowedFunctionRuleErrors::class),
+			$container->getByType(DisallowedCallableParameterRuleErrors::class),
+			$container->getByType(DisallowedCallFactory::class),
+			[
+				[
+					'function' => 'foo()',
+					'disallowParamsInAllowed' => [
+						1 => [
+							'position' => 1,
+							'typeString' => 'Foo\*',
+						],
+					],
+				],
+			]
+		);
+	}
+
+
+	/**
+	 * @throws ShouldNotHappenException
+	 */
+	public function testInvalidTypeStringWithoutWildcard(): void
+	{
+		$this->expectException(ShouldNotHappenException::class);
+		$this->expectExceptionMessage("foo(): Invalid typeString 'array<int':");
+		$container = self::getContainer();
+		new FunctionCalls(
+			$container->getByType(DisallowedFunctionRuleErrors::class),
+			$container->getByType(DisallowedCallableParameterRuleErrors::class),
+			$container->getByType(DisallowedCallFactory::class),
+			[
+				[
+					'function' => 'foo()',
+					'disallowParamsInAllowed' => [
+						1 => [
+							'position' => 1,
+							'typeString' => 'array<int',
+						],
+					],
+				],
+			]
+		);
+	}
+
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__ . '/../../extension.neon',
+		];
+	}
+
+}


### PR DESCRIPTION
A wildcard or other invalid value in `typeString` caused PHPStan to crash at DI container initialisation with a raw `ParserException` and no indication of which config entry was responsible.

The new `InvalidTypeStringInConfigException` names the offending `typeString` value, includes the parser's own reason, and appends a wildcard-specific hint when the value contains `*`. Both it and the existing `UnsupportedParamTypeInConfigException` extend a new abstract `InvalidConfigException`, which the call, constant, keyword, namespace, and superglobal factories catch and wrap in `ShouldNotHappenException` with the config identifier prepended.

Two tests cover the wildcard and non-wildcard invalid `typeString` paths, asserting on the full message including the call identifier prefix.
