### PR TITLE
Treat typeString '0' as valid, throw on empty `typeString`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ Test classes live in `tests/Calls/`, `tests/Usages/`, `tests/ControlStructures/`
 
 ## Project structure
 
-`extension.neon` is the entry point wiring all rules together. Each feature has its own documentation file in `docs/` — new features get their own doc or extend an existing one.
+`extension.neon` is the entry point wiring all rules together. It also defines the NEON schema for all config options — type declarations like `string()`, `int()`, `bool()` are enforced by NEON at config parse time, before any PHP runs. This means defensive runtime checks for wrong-typed config values (e.g. an array where a string is expected) are unnecessary when using the extension normally through PHPStan. Each feature has its own documentation file in `docs/` — new features get their own doc or extend an existing one.
 
 `disallow*` config keys are generally aliases for their `allowExcept*` counterparts, handled in `AllowedConfigFactory`.
 

--- a/src/Allowed/AllowedConfigFactory.php
+++ b/src/Allowed/AllowedConfigFactory.php
@@ -10,6 +10,7 @@ use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\NullType;
 use PHPStan\Type\VerbosityLevel;
+use Spaze\PHPStan\Rules\Disallowed\Exceptions\EmptyTypeStringInConfigException;
 use Spaze\PHPStan\Rules\Disallowed\Exceptions\InvalidConfigException;
 use Spaze\PHPStan\Rules\Disallowed\Exceptions\InvalidTypeStringInConfigException;
 use Spaze\PHPStan\Rules\Disallowed\Exceptions\UnsupportedParamTypeInConfigException;
@@ -182,13 +183,15 @@ class AllowedConfigFactory
 			$typeString = null;
 		}
 
-		if ($typeString) {
+		if (is_string($typeString) && $typeString !== '') {
 			try {
 				$type = $this->typeStringResolver->resolve($typeString);
 			} catch (ParserException $e) {
 				$hint = str_contains($typeString, '*') ? ' Wildcards are not supported in typeString.' : '';
 				throw new InvalidTypeStringInConfigException($typeString, $e->getMessage() . $hint, $e);
 			}
+		} elseif ($typeString !== null) {
+			throw new EmptyTypeStringInConfigException();
 		} elseif (is_int($paramValue)) {
 			$type = new ConstantIntegerType($paramValue);
 		} elseif (is_bool($paramValue)) {

--- a/src/Exceptions/EmptyTypeStringInConfigException.php
+++ b/src/Exceptions/EmptyTypeStringInConfigException.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Rules\Disallowed\Exceptions;
+
+class EmptyTypeStringInConfigException extends InvalidConfigException
+{
+
+	public function __construct()
+	{
+		parent::__construct('typeString is empty');
+	}
+
+}

--- a/tests/Calls/FunctionCallsInvalidTypeStringConfigTest.php
+++ b/tests/Calls/FunctionCallsInvalidTypeStringConfigTest.php
@@ -66,6 +66,56 @@ class FunctionCallsInvalidTypeStringConfigTest extends PHPStanTestCase
 	}
 
 
+	/**
+	 * @throws ShouldNotHappenException
+	 */
+	public function testEmptyTypeStringThrows(): void
+	{
+		$this->expectException(ShouldNotHappenException::class);
+		$this->expectExceptionMessage("foo(): typeString is empty");
+		$container = self::getContainer();
+		new FunctionCalls(
+			$container->getByType(DisallowedFunctionRuleErrors::class),
+			$container->getByType(DisallowedCallableParameterRuleErrors::class),
+			$container->getByType(DisallowedCallFactory::class),
+			[
+				[
+					'function' => 'foo()',
+					'disallowParamsInAllowed' => [
+						1 => [
+							'position' => 1,
+							'typeString' => '',
+						],
+					],
+				],
+			]
+		);
+	}
+
+
+	public function testZeroTypeStringIsValid(): void
+	{
+		$container = self::getContainer();
+		$calls = new FunctionCalls(
+			$container->getByType(DisallowedFunctionRuleErrors::class),
+			$container->getByType(DisallowedCallableParameterRuleErrors::class),
+			$container->getByType(DisallowedCallFactory::class),
+			[
+				[
+					'function' => 'foo()',
+					'disallowParamsInAllowed' => [
+						1 => [
+							'position' => 1,
+							'typeString' => '0',
+						],
+					],
+				],
+			]
+		);
+		$this->assertInstanceOf(FunctionCalls::class, $calls);
+	}
+
+
 	public static function getAdditionalConfigFiles(): array
 	{
 		return [

--- a/tests/Calls/FunctionCallsTypeStringParamsTest.php
+++ b/tests/Calls/FunctionCallsTypeStringParamsTest.php
@@ -191,6 +191,15 @@ class FunctionCallsTypeStringParamsTest extends RuleTestCase
 					],
 				],
 				[
+					'function' => '\Foo\Bar\Waldo\zeroParam()',
+					'allowParamsAnywhere' => [
+						[
+							'position' => 1,
+							'typeString' => '0',
+						],
+					],
+				],
+				[
 					'function' => '\Foo\Bar\Waldo\mixedParam1()',
 					'allowIn' => [
 						__DIR__ . '/../src/disallowed-allow/*.php',
@@ -292,6 +301,10 @@ class FunctionCallsTypeStringParamsTest extends RuleTestCase
 				'Calling Foo\Bar\Waldo\mixedParam1() is forbidden.',
 				33,
 			],
+			[
+				'Calling Foo\Bar\Waldo\zeroParam() is forbidden.',
+				35,
+			],
 		]);
 		$this->analyse([__DIR__ . '/../src/disallowed-allow/functionCallsTypeStringParams.php'], [
 			[
@@ -321,6 +334,10 @@ class FunctionCallsTypeStringParamsTest extends RuleTestCase
 			[
 				'Calling Foo\Bar\Waldo\mixedParam1() is forbidden.',
 				32,
+			],
+			[
+				'Calling Foo\Bar\Waldo\zeroParam() is forbidden.',
+				35,
 			],
 		]);
 	}

--- a/tests/Usages/NamespaceUsagesAllowInClassWithAttributesTest.php
+++ b/tests/Usages/NamespaceUsagesAllowInClassWithAttributesTest.php
@@ -137,27 +137,27 @@ class NamespaceUsagesAllowInClassWithAttributesTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/../src/Functions.php'], [
 			[
 				'Class PhpOption\None is forbidden.',
-				84,
+				88,
 			],
 			[
 				'Class PhpOption\Some is forbidden.',
-				84,
+				88,
 			],
 			[
 				'Class PhpOption\None is forbidden.',
-				84,
+				88,
 			],
 			[
 				'Class PhpOption\Some is forbidden.',
-				84,
+				88,
 			],
 			[
 				'Class PhpOption\None is forbidden.',
-				86,
+				90,
 			],
 			[
 				'Class PhpOption\Some is forbidden.',
-				87,
+				91,
 			],
 		]);
 	}

--- a/tests/src/Functions.php
+++ b/tests/src/Functions.php
@@ -69,6 +69,10 @@ function mixedParam1($param): void
 {
 }
 
+function zeroParam(int $param): void
+{
+}
+
 use PhpOption\None;
 use PhpOption\Some;
 use Waldo\Quux\Blade;

--- a/tests/src/disallowed-allow/functionCallsTypeStringParams.php
+++ b/tests/src/disallowed-allow/functionCallsTypeStringParams.php
@@ -31,3 +31,5 @@ config(['foo' => 'bar'], ['what' => 'ever']); // allowed by path but param #1 mu
 \Foo\Bar\Waldo\mixedParam1(new DateTime()); // disallowed param
 \Foo\Bar\Waldo\mixedParam1(new DateTimeImmutable()); // disallowed param
 \Foo\Bar\Waldo\mixedParam1(new Exception); // not a disallowed param
+\Foo\Bar\Waldo\zeroParam(0); // allowed param
+\Foo\Bar\Waldo\zeroParam(1); // disallowed param

--- a/tests/src/disallowed/functionCallsTypeStringParams.php
+++ b/tests/src/disallowed/functionCallsTypeStringParams.php
@@ -31,3 +31,5 @@ config(['foo' => 'BAH'], ['waldo' => 'baz', 'pine' => 'apple', 'orly' => [0, -1]
 \Foo\Bar\Waldo\mixedParam1(new DateTime()); // disallowed
 \Foo\Bar\Waldo\mixedParam1(new DateTimeImmutable()); // disallowed
 \Foo\Bar\Waldo\mixedParam1(new Exception); // disallowed
+\Foo\Bar\Waldo\zeroParam(0); // allowed param
+\Foo\Bar\Waldo\zeroParam(1); // disallowed param


### PR DESCRIPTION
The `if ($typeString)` truthiness check treated `'0'` as absent, silently falling through to value-based type matching instead of resolving it as `ConstantIntegerType(0)` via the type string resolver. The check is now `is_string($typeString) && $typeString !== ''`.

Empty `typeString` previously either passed a raw `ParserException` through or was silently ignored. It now throws `EmptyTypeStringInConfigException`, which extends `InvalidConfigException` alongside `InvalidTypeStringInConfigException`, giving users a clear "typeString is empty" message.

Closes #408