### PR TITLE
Export-ignore `CLAUDE.md` and `phpstan-dead-code-detector.php`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,9 +2,11 @@
 .gitattributes export-ignore
 .github export-ignore
 .gitignore export-ignore
+CLAUDE.md export-ignore
 phpcs.xml export-ignore
 phpstan.neon export-ignore
 phpstan-attributes.php export-ignore
+phpstan-dead-code-detector.php export-ignore
 phpstan-exclude-paths.php export-ignore
 phpstan-ignore-errors.php export-ignore
 phpunit.xml export-ignore


### PR DESCRIPTION
`CLAUDE.md` is AI-assistance tooling metadata and `phpstan-dead-code-detector.php` is a dev-time Dead Code Detector config - neither needs to ship in the distributed archive.

Close #411