### PR TITLE
Support param conditions in `allowExceptIn` and `allowExceptInMethods`

### DIFF
--- a/docs/allow-in-methods.md
+++ b/docs/allow-in-methods.md
@@ -25,3 +25,5 @@ parameters:
 ```
 
 The function or method names support [fnmatch()](https://www.php.net/function.fnmatch) patterns.
+
+Both `allowInMethods` and `allowExceptInMethods` can be combined with `allowParamsInAllowed` or `allowExceptParamsInAllowed` (also known as `disallowParamsInAllowed`) to further narrow the allow condition by parameter values - see [allowing with specified parameters](allow-with-parameters.md).

--- a/docs/allow-in-paths.md
+++ b/docs/allow-in-paths.md
@@ -43,4 +43,6 @@ parameters:
 ```
 This will disallow `PotentiallyDangerous\Logger::log()` calls in `%rootDir%/../../../path/to/some/dir/*.php`.
 
+Both `allowIn` and `allowExceptIn` can be combined with `allowParamsInAllowed` or `allowExceptParamsInAllowed` (also known as `disallowParamsInAllowed`) to further narrow the allow condition by parameter values - see [allowing with specified parameters](allow-with-parameters.md).
+
 Please note that before version 2.15, `filesRootDir` was called `allowInRootDir` which is still supported, but deprecated.

--- a/docs/allow-with-parameters.md
+++ b/docs/allow-with-parameters.md
@@ -33,7 +33,25 @@ parameters:
                     value: true
 ```
 
-When using `allowParamsInAllowed`, calls will be allowed only when they are in one of the `allowIn` paths (or in a class hierarchy matched by `allowInInstanceOf`), and are called with all parameters listed in `allowParamsInAllowed`.
+When using `allowParamsInAllowed`, the parameter condition is applied to the location matched by the accompanying allow directive — `allowIn`, `allowExceptIn`, `allowInInstanceOf`, `allowExceptInInstanceOf`, `allowInMethods`/`allowInFunctions`, or `allowExceptInMethods`/`allowExceptInFunctions`. For `allowIn`-style directives the call must be in a matching location *and* have the right params to be allowed. For `allowExceptIn`-style directives the call is normally disallowed in the matched location, but the right params can allow it there.
+
+For example, to allow `redirect()` everywhere except in `handleRequest()`, where it remains disallowed unless the first parameter is of type `App\SafeUrl`:
+
+```neon
+parameters:
+    disallowedMethodCalls:
+        -
+            method: 'Controller::redirect()'
+            message: 'use a safe redirect instead'
+            allowExceptInMethods:
+                - Controller::handleRequest()
+            allowParamsInAllowed:
+                -
+                    position: 1
+                    name: 'url'
+                    typeString: App\SafeUrl
+```
+
 With `allowParamsAnywhere`, calls are allowed when called with all parameters listed no matter in which file. In the example above, the `log()` method will be disallowed unless called as:
 - `log(..., true)` (or `log(..., alert: true)`) anywhere
 - `log('foo', true)` (or `log(message: 'foo', alert: true)`) in `another/file.php` or `optional/path/to/log.tests.php`
@@ -117,7 +135,7 @@ parameters:
 ```
 This configuration will disallow calls like `waldo('foo', 'bar')` or `waldo('*', '*')`, but `waldo('foo')` or `waldo()` will be still allowed.
 
-It's also possible to disallow functions and methods previously allowed by path (using `allowIn`), by function/method name (`allowInMethods`), or by class hierarchy (`allowInInstanceOf`) when they're called with specified parameters, and allow when called with any other parameter. This is done using the `allowExceptParamsInAllowed` config option.
+It's also possible to disallow functions and methods previously allowed by path (using `allowIn`), by function/method name (`allowInMethods`), or by class hierarchy (`allowInInstanceOf`) when they're called with specified parameters, and allow when called with any other parameter. The same applies in reverse for the `allowExceptIn`-style directives: a call that would otherwise be disallowed in the matched location is allowed unless the parameters match. This is done using the `allowExceptParamsInAllowed` config option.
 
 Take this example configuration:
 

--- a/src/Allowed/Allowed.php
+++ b/src/Allowed/Allowed.php
@@ -67,7 +67,7 @@ class Allowed
 		if ($disallowed->getAllowExceptInCalls()) {
 			foreach ($disallowed->getAllowExceptInCalls() as $call) {
 				if ($this->callMatches($scope, $call)) {
-					return false;
+					return $hasParams && $this->hasAllowedParamsInAllowed($scope, $args, $disallowed, false);
 				}
 			}
 			return true;
@@ -80,7 +80,7 @@ class Allowed
 		if ($disallowed->getAllowExceptIn()) {
 			foreach ($disallowed->getAllowExceptIn() as $allowedExceptPath) {
 				if ($this->allowedPath->matches($scope, $allowedExceptPath)) {
-					return false;
+					return $hasParams && $this->hasAllowedParamsInAllowed($scope, $args, $disallowed, false);
 				}
 			}
 			return true;

--- a/tests/Calls/FunctionCallsAllowExceptInMethodsWithParamsTest.php
+++ b/tests/Calls/FunctionCallsAllowExceptInMethodsWithParamsTest.php
@@ -1,0 +1,75 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Rules\Disallowed\Calls;
+
+use PHPStan\Rules\Rule;
+use PHPStan\ShouldNotHappenException;
+use PHPStan\Testing\RuleTestCase;
+use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallableParameterRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedFunctionRuleErrors;
+
+/**
+ * @extends RuleTestCase<FunctionCalls>
+ */
+class FunctionCallsAllowExceptInMethodsWithParamsTest extends RuleTestCase
+{
+
+	/**
+	 * @throws ShouldNotHappenException
+	 */
+	protected function getRule(): Rule
+	{
+		$container = self::getContainer();
+		return new FunctionCalls(
+			$container->getByType(DisallowedFunctionRuleErrors::class),
+			$container->getByType(DisallowedCallableParameterRuleErrors::class),
+			$container->getByType(DisallowedCallFactory::class),
+			[
+				[
+					'function' => 'crc32()',
+					'allowExceptInMethods' => [
+						'Fiction\Pulp\RoyaleExceptWithParams::methodA()',
+					],
+					'allowParamsInAllowed' => [
+						1 => 'a',
+					],
+				],
+				[
+					'function' => 'strtolower()',
+					'allowExceptInMethods' => [
+						'Fiction\Pulp\RoyaleExceptWithParams::methodA()',
+					],
+					'allowExceptParamsInAllowed' => [
+						1 => 'a',
+					],
+				],
+			]
+		);
+	}
+
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/../src/RoyaleExceptWithParams.php'], [
+			[
+				'Calling crc32() is forbidden.',
+				12,
+			],
+			[
+				'Calling strtolower() is forbidden.',
+				13,
+			],
+		]);
+	}
+
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__ . '/../../extension.neon',
+		];
+	}
+
+}

--- a/tests/Calls/FunctionCallsTest.php
+++ b/tests/Calls/FunctionCallsTest.php
@@ -278,6 +278,26 @@ class FunctionCallsTest extends RuleTestCase
 						'Waldo\Foo\Wild*',
 					],
 				],
+				// test allowExceptIn + allowParamsInAllowed
+				[
+					'function' => 'pow()',
+					'allowExceptIn' => [
+						__DIR__ . '/../src/disallowed-allow/*.php',
+					],
+					'allowParamsInAllowed' => [
+						1 => 2,
+					],
+				],
+				// test allowExceptIn + allowExceptParamsInAllowed
+				[
+					'function' => 'intdiv()',
+					'allowExceptIn' => [
+						__DIR__ . '/../src/disallowed-allow/*.php',
+					],
+					'allowExceptParamsInAllowed' => [
+						1 => 2,
+					],
+				],
 			]
 		);
 	}
@@ -502,6 +522,21 @@ class FunctionCallsTest extends RuleTestCase
 			[
 				'Calling str_pad() is forbidden.',
 				70,
+			],
+		]);
+	}
+
+
+	public function testAllowExceptInWithParams(): void
+	{
+		$this->analyse([__DIR__ . '/../src/disallowed-allow/functionCallsExceptWithParams.php'], [
+			[
+				'Calling pow() is forbidden.',
+				6,
+			],
+			[
+				'Calling intdiv() is forbidden.',
+				10,
 			],
 		]);
 	}

--- a/tests/src/RoyaleExceptWithParams.php
+++ b/tests/src/RoyaleExceptWithParams.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types = 1);
+
+namespace Fiction\Pulp;
+
+class RoyaleExceptWithParams
+{
+
+	public function methodA(): void
+	{
+		crc32('a');       // allowed: in except zone, param matches allowParamsInAllowed
+		crc32('b');       // disallowed: in except zone, param doesn't match allowParamsInAllowed
+		strtolower('a');  // disallowed: in except zone, param is forbidden by allowExceptParamsInAllowed
+		strtolower('b');  // allowed: in except zone, param not forbidden
+	}
+
+
+	public function methodB(): void
+	{
+		crc32('a');       // allowed: not in except zone
+		crc32('b');       // allowed: not in except zone
+		strtolower('a');  // allowed: not in except zone
+		strtolower('b');  // allowed: not in except zone
+	}
+
+}

--- a/tests/src/disallowed-allow/functionCallsExceptWithParams.php
+++ b/tests/src/disallowed-allow/functionCallsExceptWithParams.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types = 1);
+
+// in the except zone: allowed only when first param matches allowParamsInAllowed
+pow(2, 3);
+pow(3, 2);
+
+// in the except zone: allowed only when first param doesn't match allowExceptParamsInAllowed
+intdiv(3, 2);
+intdiv(2, 3);


### PR DESCRIPTION
When `allowParamsInAllowed` or `allowExceptParamsInAllowed` was combined with `allowExceptIn` or `allowExceptInMethods`, the param condition was silently ignored - the config looked valid, produced no error, and had no effect. `allowExceptInInstanceOf` already supported param conditions; this extends the same behaviour to the path-based (`allowExceptIn`) and call-based (`allowExceptInMethods`, `allowExceptInFunctions`) directives. In the matched (disallowed) location, `allowParamsInAllowed` can allow a call when params match, and `allowExceptParamsInAllowed` can allow a call when params don't match the forbidden values.

The documentation in `allow-with-parameters.md` is updated to explain the difference between `allowIn`-style and `allowExceptIn`-style semantics and includes a concrete config example. `allow-in-paths.md` gains a cross-reference to the params documentation.

Close #406