### PR TITLE
Make `goto` reachable again in the test fixture

### DIFF
--- a/tests/ControlStructures/DeclareControlStructureTest.php
+++ b/tests/ControlStructures/DeclareControlStructureTest.php
@@ -48,7 +48,7 @@ class DeclareControlStructureTest extends RuleTestCase
 			],
 			[
 				'Using the declare control structure is forbidden.',
-				117,
+				118,
 			],
 		]);
 		$this->analyse([__DIR__ . '/../src/disallowed-allow/controlStructures.php'], []);

--- a/tests/src/disallowed/controlStructures.php
+++ b/tests/src/disallowed/controlStructures.php
@@ -114,8 +114,8 @@ match ($true) {
 };
 
 goto main_sub3;
-declare(ticks = 123);
 main_sub3:
+declare(ticks = 123);
 
 require __FILE__;
 include __FILE__;


### PR DESCRIPTION
PHPStan's `goto` support is now improved and declare has started to be unreachable https://github.com/phpstan/phpstan/releases/tag/2.1.56

See also https://www.php.net/control-structures.goto