### PR TITLE
PHPUnit 13.2 deprecated `expectExceptionMessage()` but I want to keep using older versions too

### DIFF
--- a/tests/Calls/FunctionCallsInvalidClassPatternConfigTest.php
+++ b/tests/Calls/FunctionCallsInvalidClassPatternConfigTest.php
@@ -18,7 +18,7 @@ class FunctionCallsInvalidClassPatternConfigTest extends PHPStanTestCase
 	public function testEmptyClassPatternThrows(): void
 	{
 		$this->expectException(ShouldNotHappenException::class);
-		$this->expectExceptionMessage("foo(): classPattern is empty");
+		$this->expectExceptionMessageMatches('~foo\(\): classPattern is empty~');
 		$container = self::getContainer();
 		new FunctionCalls(
 			$container->getByType(DisallowedFunctionRuleErrors::class),
@@ -45,7 +45,7 @@ class FunctionCallsInvalidClassPatternConfigTest extends PHPStanTestCase
 	public function testBackslashOnlyClassPatternThrows(): void
 	{
 		$this->expectException(ShouldNotHappenException::class);
-		$this->expectExceptionMessage("foo(): classPattern is empty");
+		$this->expectExceptionMessageMatches('~foo\(\): classPattern is empty~');
 		$container = self::getContainer();
 		new FunctionCalls(
 			$container->getByType(DisallowedFunctionRuleErrors::class),

--- a/tests/Calls/FunctionCallsInvalidTypeStringConfigTest.php
+++ b/tests/Calls/FunctionCallsInvalidTypeStringConfigTest.php
@@ -45,7 +45,7 @@ class FunctionCallsInvalidTypeStringConfigTest extends PHPStanTestCase
 	public function testInvalidTypeStringWithoutWildcard(): void
 	{
 		$this->expectException(ShouldNotHappenException::class);
-		$this->expectExceptionMessage("foo(): Invalid typeString 'array<int':");
+		$this->expectExceptionMessageMatches("~foo\(\): Invalid typeString 'array<int':~");
 		$container = self::getContainer();
 		new FunctionCalls(
 			$container->getByType(DisallowedFunctionRuleErrors::class),
@@ -72,7 +72,7 @@ class FunctionCallsInvalidTypeStringConfigTest extends PHPStanTestCase
 	public function testEmptyTypeStringThrows(): void
 	{
 		$this->expectException(ShouldNotHappenException::class);
-		$this->expectExceptionMessage("foo(): typeString is empty");
+		$this->expectExceptionMessageMatches('~foo\(\): typeString is empty~');
 		$container = self::getContainer();
 		new FunctionCalls(
 			$container->getByType(DisallowedFunctionRuleErrors::class),

--- a/tests/Calls/FunctionCallsTypeStringParamsInvalidFlagsConfigTest.php
+++ b/tests/Calls/FunctionCallsTypeStringParamsInvalidFlagsConfigTest.php
@@ -18,7 +18,7 @@ class FunctionCallsTypeStringParamsInvalidFlagsConfigTest extends PHPStanTestCas
 	public function testException(): void
 	{
 		$this->expectException(ShouldNotHappenException::class);
-		$this->expectExceptionMessage("Foo\Bar\Waldo\intParam1(): Parameter #1 has an unsupported type string of 2|'bruh' specified in configuration");
+		$this->expectExceptionMessageMatches("~Foo\\\\Bar\\\\Waldo\\\\intParam1\\(\\): Parameter #1 has an unsupported type string of 2\\|'bruh' specified in configuration~");
 		$container = self::getContainer();
 		new FunctionCalls(
 			$container->getByType(DisallowedFunctionRuleErrors::class),

--- a/tests/Calls/FunctionCallsUnsupportedParamConfigTest.php
+++ b/tests/Calls/FunctionCallsUnsupportedParamConfigTest.php
@@ -18,7 +18,7 @@ class FunctionCallsUnsupportedParamConfigTest extends PHPStanTestCase
 	public function testUnsupportedArrayInParamConfig(): void
 	{
 		$this->expectException(ShouldNotHappenException::class);
-		$this->expectExceptionMessage('{foo(),bar()}: Parameter #2 $definitelyNotScalar has an unsupported type array specified in configuration');
+		$this->expectExceptionMessageMatches('~{foo\(\),bar\(\)}: Parameter #2 \$definitelyNotScalar has an unsupported type array specified in configuration~');
 		$container = self::getContainer();
 		new FunctionCalls(
 			$container->getByType(DisallowedFunctionRuleErrors::class),

--- a/tests/ControlStructures/ElseIfControlStructureTest.php
+++ b/tests/ControlStructures/ElseIfControlStructureTest.php
@@ -61,7 +61,7 @@ class ElseIfControlStructureTest extends RuleTestCase
 	public function testElseSpaceIfException(): void
 	{
 		$this->expectException(ShouldNotHappenException::class);
-		$this->expectExceptionMessage("Use 'elseif' instead of 'else if', because 'else if' is parsed as 'else' followed by 'if' and the behaviour may be unexpected if using 'else if' in the configuration");
+		$this->expectExceptionMessageMatches("~Use 'elseif' instead of 'else if', because 'else if' is parsed as 'else' followed by 'if' and the behaviour may be unexpected if using 'else if' in the configuration~");
 		$container = self::getContainer();
 		/** @phpstan-ignore new.resultUnused (Throws an exception, which is tested) */
 		new ElseIfControlStructure(

--- a/tests/DisallowedSuperglobalFactoryTest.php
+++ b/tests/DisallowedSuperglobalFactoryTest.php
@@ -18,11 +18,11 @@ class DisallowedSuperglobalFactoryTest extends PHPStanTestCase
 	 * @throws ShouldNotHappenException
 	 */
 	#[DataProvider('superglobalsProvider')]
-	public function testNonSuperglobalInConfig(string $superglobal, ?string $exceptionClass): void
+	public function testNonSuperglobalInConfig(string $superglobal, string $superglobalQuoted, ?string $exceptionClass): void
 	{
 		if ($exceptionClass) {
 			$this->expectException($exceptionClass);
-			$this->expectExceptionMessage("{$superglobal} is not a superglobal variable");
+			$this->expectExceptionMessageMatches("~{$superglobalQuoted} is not a superglobal variable~");
 		} else {
 			$this->expectNotToPerformAssertions();
 		}
@@ -31,20 +31,20 @@ class DisallowedSuperglobalFactoryTest extends PHPStanTestCase
 
 
 	/**
-	 * @return Generator<int, array{0:string, class-string<ShouldNotHappenException>|null}>
+	 * @return Generator<int, array{0:string, 1:string, class-string<ShouldNotHappenException>|null}>
 	 */
 	public static function superglobalsProvider(): Generator
 	{
-		yield ['$GLOBALS', null];
-		yield ['$_SERVER', null];
-		yield ['$_GET', null];
-		yield ['$_POST', null];
-		yield ['$_FILES', null];
-		yield ['$_COOKIE', null];
-		yield ['$_SESSION', null];
-		yield ['$_REQUEST', null];
-		yield ['$_ENV', null];
-		yield ['$foo', ShouldNotHappenException::class];
+		yield ['$GLOBALS', '\$GLOBALS', null];
+		yield ['$_SERVER', '\$_SERVER', null];
+		yield ['$_GET', '\$_GET', null];
+		yield ['$_POST', '\$_POST', null];
+		yield ['$_FILES', '\$_FILES', null];
+		yield ['$_COOKIE', '\$_COOKIE', null];
+		yield ['$_SESSION', '\$_SESSION', null];
+		yield ['$_REQUEST', '\$_REQUEST', null];
+		yield ['$_ENV', '\$_ENV', null];
+		yield ['$foo', '\$foo', ShouldNotHappenException::class];
 	}
 
 

--- a/tests/Normalizer/NormalizerTest.php
+++ b/tests/Normalizer/NormalizerTest.php
@@ -62,19 +62,19 @@ class NormalizerTest extends PHPStanTestCase
 	{
 		yield [
 			'foo',
-			"Property 'foo' is invalid, use 'Namespace\\Class::\$property' syntax",
+			"~Property 'foo' is invalid, use 'Namespace\\\\Class::\\\$property' syntax~",
 		];
 		yield [
 			'\\foo',
-			"Property '\\foo' is invalid, use 'Namespace\\Class::\$property' syntax",
+			"~Property '\\\\foo' is invalid, use 'Namespace\\\\Class::\\\$property' syntax~",
 		];
 		yield [
 			'foo:$bar',
-			"Property 'foo:\$bar' is invalid, use 'Namespace\\Class::\$property' syntax",
+			"~Property 'foo:\\\$bar' is invalid, use 'Namespace\\\\Class::\\\$property' syntax~",
 		];
 		yield [
 			'foo:$bar:baz',
-			"Property 'foo:\$bar:baz' is invalid, use 'Namespace\\Class::\$property' syntax",
+			"~Property 'foo:\\\$bar:baz' is invalid, use 'Namespace\\\\Class::\\\$property' syntax~",
 		];
 	}
 
@@ -86,7 +86,7 @@ class NormalizerTest extends PHPStanTestCase
 	public function testNormalizeInvalidProperty(string $property, string $exceptionMessage): void
 	{
 		$this->expectException(ShouldNotHappenException::class);
-		$this->expectExceptionMessage($exceptionMessage);
+		$this->expectExceptionMessageMatches($exceptionMessage);
 		$this->normalizer->normalizeProperty($property);
 	}
 


### PR DESCRIPTION
"Soft-deprecate expectExceptionMessage(), use expectExceptionMessageIsOrContains() instead" https://github.com/sebastianbergmann/phpunit/releases/tag/13.2.0

But `expectExceptionMessageIsOrContains()` is not available in older PHPUnit version which I want to use when running tests on older PHP versions, PHPUnit 13 requires PHP 8.4+ https://phpunit.de/supported-versions.html

Another considered options:
- Run PHPStan (which flags the deprecated methods because I use phpstan/phpstan-deprecation-rules) only on PHPUnit older than 13.2, the config would seem to be too complicated
- Remove phpstan/phpstan-deprecation-rules, but I'd like to keep it
- Ignore those particular errors in PHPStan config, this is just postponing the problem
- Use yoast/phpunit-polyfills, but that does not support `expectExceptionMessageIsOrContains()`
- Stop supporting older versions of everything (https://github.com/spaze/phpstan-disallowed-calls/issues/394) but PHPUnit 13.2 requires PHP 8.4+ and that's too new for this option

Using `expectExceptionMessageMatches()` instead of `expectExceptionMessage()` seems the most straightforward and compatible way.