### PR TITLE
"Upgrade" the lowest possible PHPUnit to 9.6 which supports PHP 7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
 	},
 	"require-dev": {
 		"nette/neon": "^3.3.1",
-		"phpunit/phpunit": "^8.5.14 || ^10.1 || ^11.0 || ^12.0 || ^13.0",
+		"phpunit/phpunit": "^9.6 || ^10.1 || ^11.0 || ^12.0 || ^13.0",
 		"php-parallel-lint/php-parallel-lint": "^1.2",
 		"php-parallel-lint/php-console-highlighter": "^1.0",
 		"phpstan/phpstan-deprecation-rules": "^1.2 || ^2.0",


### PR DESCRIPTION
This library also supports PHP 7.4, so there's that.
https://phpunit.de/supported-versions.html