### PR TITLE
Match attributes on methods and functions with allowInMethods and `allowInFunctions`

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Let's say you have disallowed the `foo()` function (or any other supported items
 - [Allow with specified flags](docs/allow-with-flags.md)
 - [Allow in classes, child classes, classes implementing an interface](docs/allow-in-instance-of.md) (same as the `instanceof` operator)
 - [Allow in class with given attributes](docs/allow-in-class-with-attributes.md)
-- [Allow in methods or functions with given attributes](docs/allow-in-methods.md)
+- [Allow in methods or functions with given attributes](docs/allow-in-methods-with-attributes.md)
 - [Allow in class with given attributes on any method](docs/allow-in-class-with-method-attributes.md)
 - [Allow in type hint positions](docs/allow-in-type-hint-positions.md) (param types, return types - `disallowedNamespaces` and `disallowedClasses` only)
 

--- a/docs/allow-in-methods.md
+++ b/docs/allow-in-methods.md
@@ -27,3 +27,34 @@ parameters:
 The function or method names support [fnmatch()](https://www.php.net/function.fnmatch) patterns.
 
 Both `allowInMethods` and `allowExceptInMethods` can be combined with `allowParamsInAllowed` or `allowExceptParamsInAllowed` (also known as `disallowParamsInAllowed`) to further narrow the allow condition by parameter values - see [allowing with specified parameters](allow-with-parameters.md).
+
+### Attributes on methods
+
+In case of disallowing attributes and then re-allowing them in methods or functions by name, the disallowed attributes can be both _inside_ the method or the function, and _on_ the method or the function.
+This means that the following code with the following configuration is also valid, even though `CrossOriginRedirect` is technically not used _inside_ the method.
+
+```php
+class Presenter
+{
+
+    #[CrossOriginRedirect]
+    public function actionFoo(): void
+    {
+    }
+
+}
+```
+
+```neon
+parameters:
+    disallowedAttributes:
+        -
+            attribute: CrossOriginRedirect
+            allowInMethods:
+                - '*::action*()'
+```
+
+No error would be reported for `CrossOriginRedirect` as it is used "in" a method whose name matches one of the `allowInMethods` patterns.
+The same applies to `allowExceptInMethods` (and the aliases): an attribute placed on a method or a function whose name matches one of the patterns will be reported.
+
+For a named function declared inside a method or another function, the enclosing method or function is the one matched against the patterns, the same way `allowInMethodsWithAttributes` uses the enclosing method's or function's attributes.

--- a/src/Allowed/Allowed.php
+++ b/src/Allowed/Allowed.php
@@ -60,13 +60,13 @@ class Allowed
 	{
 		$hasParams = $disallowed instanceof DisallowedWithParams;
 		foreach ($disallowed->getAllowInCalls() as $call) {
-			if ($this->callMatches($scope, $call)) {
+			if ($this->callMatches($node, $scope, $call)) {
 				return !$hasParams || $this->hasAllowedParamsInAllowed($scope, $args, $disallowed, true);
 			}
 		}
 		if ($disallowed->getAllowExceptInCalls()) {
 			foreach ($disallowed->getAllowExceptInCalls() as $call) {
-				if ($this->callMatches($scope, $call)) {
+				if ($this->callMatches($node, $scope, $call)) {
 					return $hasParams && $this->hasAllowedParamsInAllowed($scope, $args, $disallowed, false);
 				}
 			}
@@ -140,12 +140,16 @@ class Allowed
 	}
 
 
-	private function callMatches(Scope $scope, string $call): bool
+	private function callMatches(?Node $node, Scope $scope, string $call): bool
 	{
 		if ($scope->getFunction() instanceof MethodReflection) {
 			$name = $this->formatter->getFullyQualified($scope->getFunction()->getDeclaringClass()->getDisplayName(false), $scope->getFunction());
 		} elseif ($scope->getFunction() instanceof FunctionReflection) {
 			$name = $scope->getFunction()->getName();
+		} elseif ($node instanceof ClassMethod && $scope->isInClass()) {
+			$name = sprintf('%s::%s', $scope->getClassReflection()->getDisplayName(false), $node->name->name);
+		} elseif ($node instanceof Function_) {
+			$name = ($node->namespacedName ?? $node->name)->toString();
 		} else {
 			$name = '';
 		}

--- a/tests/Usages/AttributeUsagesAllowInMethodsTest.php
+++ b/tests/Usages/AttributeUsagesAllowInMethodsTest.php
@@ -1,0 +1,85 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Rules\Disallowed\Usages;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use Spaze\PHPStan\Rules\Disallowed\DisallowedAttributeFactory;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedAttributeRuleErrors;
+
+/**
+ * @extends RuleTestCase<AttributeUsages>
+ */
+class AttributeUsagesAllowInMethodsTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		$container = self::getContainer();
+		return new AttributeUsages(
+			$container->getByType(DisallowedAttributeRuleErrors::class),
+			$container->getByType(DisallowedAttributeFactory::class),
+			[
+				[
+					'attribute' => 'AttributeMethods\SomeAttribute',
+					'allowInMethods' => [
+						'*::action*()',
+					],
+				],
+				[
+					'attribute' => 'AttributeMethods\AnotherAttribute',
+					'allowExceptInMethods' => [
+						'*::forbidden*()',
+					],
+				],
+				[
+					'attribute' => 'AttributeMethods\FuncAttribute',
+					'allowInFunctions' => [
+						'AttributeMethods\allowed*()',
+					],
+				],
+			]
+		);
+	}
+
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/../src/AttributeMethods.php'], [
+			[
+				'Attribute AttributeMethods\SomeAttribute is forbidden.',
+				26,
+			],
+			[
+				'Attribute AttributeMethods\SomeAttribute is forbidden.',
+				36,
+			],
+			[
+				'Attribute AttributeMethods\SomeAttribute is forbidden.',
+				42,
+			],
+			[
+				'Attribute AttributeMethods\SomeAttribute is forbidden.',
+				57,
+			],
+			[
+				'Attribute AttributeMethods\AnotherAttribute is forbidden.',
+				69,
+			],
+			[
+				'Attribute AttributeMethods\FuncAttribute is forbidden.',
+				95,
+			],
+		]);
+	}
+
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__ . '/../../extension.neon',
+		];
+	}
+
+}

--- a/tests/src/AttributeMethods.php
+++ b/tests/src/AttributeMethods.php
@@ -1,0 +1,98 @@
+<?php
+declare(strict_types = 1);
+
+namespace AttributeMethods;
+
+use Attribute;
+
+#[Attribute]
+class SomeAttribute
+{
+}
+
+
+#[Attribute]
+class AnotherAttribute
+{
+}
+
+
+#[Attribute]
+class FuncAttribute
+{
+}
+
+
+#[SomeAttribute]
+class Presenter
+{
+
+	#[SomeAttribute]
+	public function actionFoo(): void
+	{
+	}
+
+
+	#[SomeAttribute]
+	public function renderBar(): void
+	{
+	}
+
+
+	#[SomeAttribute]
+	public string $actionProperty = '';
+
+
+	public function actionWithNestedFunction(): void
+	{
+		#[SomeAttribute]
+		function nestedInAction(): void
+		{
+		}
+	}
+
+
+	public function renderWithNestedFunction(): void
+	{
+		#[SomeAttribute]
+		function nestedInRender(): void
+		{
+		}
+	}
+
+}
+
+
+class Service
+{
+
+	#[AnotherAttribute]
+	public function forbiddenMethod(): void
+	{
+	}
+
+
+	#[AnotherAttribute]
+	public function allowedMethod(): void
+	{
+	}
+
+}
+
+
+#[AnotherAttribute]
+class ServiceWithClassAttribute
+{
+}
+
+
+#[FuncAttribute]
+function allowedFunction(): void
+{
+}
+
+
+#[FuncAttribute]
+function otherFunction(): void
+{
+}


### PR DESCRIPTION
A disallowed attribute placed on a method or a function is technically not *in* the method or the function, so `$scope->getFunction()` returns `null` and the name compared against the `allowInMethods` (and aliases) patterns would always be empty, never matching anything. The name is now resolved from the node when there's no function in the scope, the same way `allowInMethodsWithAttributes` already reads the attributes off the node, and produces the same name the reflection-based branches would produce for the same symbol.

This also means `allowExceptInMethods` (and aliases) can now report an attribute placed on a matching method or function, which was previously always allowed.

Close #427