### PR TITLE
Allow directives fall through to the next one when they don't match

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ Let's say you have disallowed the `foo()` function (or any other supported items
 - [Allow in class with given attributes on any method](docs/allow-in-class-with-method-attributes.md)
 - [Allow in type hint positions](docs/allow-in-type-hint-positions.md) (param types, return types - `disallowedNamespaces` and `disallowedClasses` only)
 
+These directives can be combined in one configuration entry and are evaluated one after another - the item is allowed as soon as one of the allow directives matches (a match can be further narrowed by [parameter conditions](docs/allow-with-parameters.md)).
+The `allowExceptIn*` directives (also known as `disallowIn*`) are not "allow" directives despite the name - when present, the item is reported when a pattern matches and allowed when it doesn't, and directives evaluated after them are not consulted.
+The `allowExceptParams`-family [parameter conditions](docs/allow-with-parameters.md) (those without the `InAllowed` suffix) behave the same way.
+
+A config entry also replaces any previous entry for the same disallowed item (for calls, the `allowExceptParams` values have to match, too), which is how entries from the [bundled configurations](docs/configuration-bundled.md) can be customized.
+
 [Re-allowing attributes](docs/allow-attributes.md) uses a similar [configuration](docs/allow-attributes.md).
 
 

--- a/docs/allow-in-methods-with-attributes.md
+++ b/docs/allow-in-methods-with-attributes.md
@@ -26,6 +26,9 @@ parameters:
 
 The attribute names support [fnmatch()](https://www.php.net/function.fnmatch) patterns. If you specify multiple attributes, the method or the function in which the item should be allowed or disallowed, needs to have just one of them.
 
+`allowInMethodsWithAttributes` and `allowInFunctionsWithAttributes` are aliases for one list - when one config entry sets both keys, only `allowInFunctionsWithAttributes` is used, so put all the attributes in a list under one of the keys.
+The same applies to `allowExceptInMethodsWithAttributes` and its aliases.
+
 ### Attributes on methods
 
 In case of disallowing attributes and then re-allowing them in methods with attributes, the disallowed attributes can be both _inside_ the method, and _on_ the method.

--- a/docs/allow-in-methods.md
+++ b/docs/allow-in-methods.md
@@ -26,6 +26,9 @@ parameters:
 
 The function or method names support [fnmatch()](https://www.php.net/function.fnmatch) patterns.
 
+`allowInFunctions` and `allowInMethods` are aliases for one list of patterns matched against both method and function names - when one config entry sets both keys, only `allowInFunctions` is used, so put all the patterns in a list under one of the keys.
+The same applies to `allowExceptInFunctions` and its aliases.
+
 Both `allowInMethods` and `allowExceptInMethods` can be combined with `allowParamsInAllowed` or `allowExceptParamsInAllowed` (also known as `disallowParamsInAllowed`) to further narrow the allow condition by parameter values - see [allowing with specified parameters](allow-with-parameters.md).
 
 ### Attributes on methods

--- a/docs/custom-rules.md
+++ b/docs/custom-rules.md
@@ -202,6 +202,8 @@ The extension supports multiple directives you can use to re-allow previously di
 The `allowExceptIn*` directives (also known as `disallowIn*`) decide the result on their own despite the name - a match reports the item, no match allows it - and so do the `allowExceptParams`-family [parameter conditions](allow-with-parameters.md) without the `InAllowed` suffix.
 A config entry also replaces any previous entry for the same item (for calls, the `allowExceptParams` values have to match, too), which is how the [bundled config](configuration-bundled.md) entries can be customized.
 
+Many directives have aliases (`disallowInMethods` is `allowExceptInMethods`, `disallowParamsAnywhere` is `allowExceptParams` etc.) which all refer to one single directive, so when a config entry sets multiple aliases of the same directive, only one of them is used.
+
 ### Language constructs and constructors
 
 You can treat some language constructs as functions and disallow it in `disallowedFunctionCalls`. Currently detected language constructs are:

--- a/docs/custom-rules.md
+++ b/docs/custom-rules.md
@@ -196,7 +196,11 @@ parameters:
 
 Relative paths in `definedIn` are resolved based on the current working directory. When running PHPStan from a directory or subdirectory which is not your "root" directory, the paths will probably not work.
 Use `filesRootDir` in that case to specify an absolute root directory, you can use [`%rootDir%`](https://phpstan.org/config-reference#expanding-paths) to start with PHPStan's root directory (usually `/something/something/vendor/phpstan/phpstan`) and then `..` from there to your "root" directory.
-`filesRootDir` is also used to configure all `allowIn` directives, see below. The extension supports multiple directives you can use to re-allow a previously disallowed items.
+`filesRootDir` is also used to configure all `allowIn` directives, see below.
+
+The extension supports multiple directives you can use to re-allow previously disallowed items. The item is allowed as soon as one of the allow directives in a config entry matches (a match can be further narrowed by [parameter conditions](allow-with-parameters.md)).
+The `allowExceptIn*` directives (also known as `disallowIn*`) decide the result on their own despite the name - a match reports the item, no match allows it - and so do the `allowExceptParams`-family [parameter conditions](allow-with-parameters.md) without the `InAllowed` suffix.
+A config entry also replaces any previous entry for the same item (for calls, the `allowExceptParams` values have to match, too), which is how the [bundled config](configuration-bundled.md) entries can be customized.
 
 ### Language constructs and constructors
 

--- a/src/Allowed/Allowed.php
+++ b/src/Allowed/Allowed.php
@@ -100,10 +100,7 @@ class Allowed
 				}
 			}
 		}
-		if ($disallowed->getAllowInInstanceOf()) {
-			if (!$this->isInstanceOf($scope, $disallowed->getAllowInInstanceOf())) {
-				return false;
-			}
+		if ($disallowed->getAllowInInstanceOf() && $this->isInstanceOf($scope, $disallowed->getAllowInInstanceOf())) {
 			return !$hasParams || $this->hasAllowedParamsInAllowed($scope, $args, $disallowed, true);
 		}
 		if ($disallowed->getAllowExceptInInstanceOf()) {
@@ -115,23 +112,36 @@ class Allowed
 		if ($hasParams && $disallowed->getAllowExceptParams()) {
 			return $this->hasAllowedParams($scope, $args, $disallowed->getAllowExceptParams(), false);
 		}
-		if ($hasParams && $disallowed->getAllowParamsAnywhere()) {
-			return $this->hasAllowedParams($scope, $args, $disallowed->getAllowParamsAnywhere(), true);
+		if (
+			$hasParams
+			&& $disallowed->getAllowParamsAnywhere()
+			&& $this->hasAllowedParams($scope, $args, $disallowed->getAllowParamsAnywhere(), true)
+		) {
+			return true;
 		}
-		if ($disallowed->getAllowInClassWithAttributes()) {
-			return $this->hasAllowedAttribute($this->getAttributes($scope), $disallowed->getAllowInClassWithAttributes());
+		if (
+			$disallowed->getAllowInClassWithAttributes()
+			&& $this->hasAllowedAttribute($this->getAttributes($scope), $disallowed->getAllowInClassWithAttributes())
+		) {
+			return true;
 		}
 		if ($disallowed->getAllowExceptInClassWithAttributes()) {
 			return !$this->hasAllowedAttribute($this->getAttributes($scope), $disallowed->getAllowExceptInClassWithAttributes());
 		}
-		if ($disallowed->getAllowInCallsWithAttributes()) {
-			return $this->hasAllowedAttribute($this->getCallAttributes($node, $scope), $disallowed->getAllowInCallsWithAttributes());
+		if (
+			$disallowed->getAllowInCallsWithAttributes()
+			&& $this->hasAllowedAttribute($this->getCallAttributes($node, $scope), $disallowed->getAllowInCallsWithAttributes())
+		) {
+			return true;
 		}
 		if ($disallowed->getAllowExceptInCallsWithAttributes()) {
 			return !$this->hasAllowedAttribute($this->getCallAttributes($node, $scope), $disallowed->getAllowExceptInCallsWithAttributes());
 		}
-		if ($disallowed->getAllowInClassWithMethodAttributes()) {
-			return $this->hasAllowedAttribute($this->getAllMethodAttributes($scope), $disallowed->getAllowInClassWithMethodAttributes());
+		if (
+			$disallowed->getAllowInClassWithMethodAttributes()
+			&& $this->hasAllowedAttribute($this->getAllMethodAttributes($scope), $disallowed->getAllowInClassWithMethodAttributes())
+		) {
+			return true;
 		}
 		if ($disallowed->getAllowExceptInClassWithMethodAttributes()) {
 			return !$this->hasAllowedAttribute($this->getAllMethodAttributes($scope), $disallowed->getAllowExceptInClassWithMethodAttributes());

--- a/tests/Calls/FunctionCallsMultipleAllowDirectivesTest.php
+++ b/tests/Calls/FunctionCallsMultipleAllowDirectivesTest.php
@@ -1,0 +1,98 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Rules\Disallowed\Calls;
+
+use PHPStan\Rules\Rule;
+use PHPStan\ShouldNotHappenException;
+use PHPStan\Testing\RuleTestCase;
+use Spaze\PHPStan\Rules\Disallowed\DisallowedCallFactory;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedCallableParameterRuleErrors;
+use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedFunctionRuleErrors;
+
+/**
+ * @extends RuleTestCase<FunctionCalls>
+ */
+class FunctionCallsMultipleAllowDirectivesTest extends RuleTestCase
+{
+
+	/**
+	 * @throws ShouldNotHappenException
+	 */
+	protected function getRule(): Rule
+	{
+		$container = self::getContainer();
+		return new FunctionCalls(
+			$container->getByType(DisallowedFunctionRuleErrors::class),
+			$container->getByType(DisallowedCallableParameterRuleErrors::class),
+			$container->getByType(DisallowedCallFactory::class),
+			[
+				[
+					'function' => 'md5()',
+					'allowInInstanceOf' => [
+						'\Attributes\Nowhere',
+					],
+					'allowInClassWithAttributes' => [
+						'\Attributes\Attribute2',
+					],
+				],
+				[
+					'function' => 'sha1()',
+					'allowParamsAnywhere' => [
+						[
+							'position' => 1,
+							'value' => 'no-match',
+						],
+					],
+					'allowInClassWithAttributes' => [
+						'\Attributes\Attribute2',
+					],
+				],
+				[
+					'function' => 'strtolower()',
+					'allowInClassWithAttributes' => [
+						'\Attributes\Nowhere',
+					],
+					'allowInMethodsWithAttributes' => [
+						'Attribute11',
+					],
+				],
+			]
+		);
+	}
+
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/../src/AttributeClass.php'], [
+			[
+				'Calling md5() is forbidden.',
+				48,
+			],
+			[
+				'Calling strtolower() is forbidden.',
+				139,
+			],
+		]);
+	}
+
+
+	public function testRuleInFunctions(): void
+	{
+		$this->analyse([__DIR__ . '/../src/AttributeFunctions.php'], [
+			[
+				'Calling strtolower() is forbidden.',
+				7,
+			],
+		]);
+	}
+
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__ . '/../../extension.neon',
+		];
+	}
+
+}


### PR DESCRIPTION
Previously, `allowInInstanceOf`, `allowParamsAnywhere` and the `allowIn*WithAttributes` directives decided the result even when they didn't match, so any directive evaluated after them in the same config entry was never consulted - combining e.g. `allowInInstanceOf` with `allowInClassWithAttributes` meant the attributes were never checked. The split was never chosen: `allowInMethods` and `allowIn` fall through simply because they're pattern loops, the deciders were born as return-a-bool one-liners, and 1a66e61 silently removed the `isInClass()` guards which used to make the attribute directives fall through outside classes.

Now every allow directive keeps the evaluation going when it doesn't match, while the `allowExceptIn*` directives still decide the result on their own, because that's their meaning. Errors can only disappear with this change, a previously reported item can now be allowed by a directive that was never consulted before.

Also documents how the directives compose: allowed on the first match, `allowExceptIn*` decide on their own, and a config entry replaces any previous entry for the same item, which is how the bundled config entries can be customized.

Close #429

Plus document that setting multiple aliases of one directive uses just one of them.