### PR TITLE
Add a bundled config file for encoding functions that are not timing-safe

### DIFF
--- a/disallowed-non-timing-safe-calls.neon
+++ b/disallowed-non-timing-safe-calls.neon
@@ -1,0 +1,20 @@
+# For code that handles secrets: byte encoding should go through constant-time functions, enforced by the rules below.
+# Comparing secrets and digests is the other half: use hash_equals(), not === (which is an operator, so no rule here can catch it).
+parameters:
+	disallowedFunctionCalls:
+		-
+			function: 'hex2bin()'
+			message: 'it is not timing-safe, use sodium_hex2bin() instead'
+			errorTip: 'ext-sodium is bundled with PHP since 7.2 but not always enabled, use ParagonIE\ConstantTime\Hex::decode() if not available'
+		-
+			function: 'bin2hex()'
+			message: 'it is not timing-safe, use sodium_bin2hex() instead'
+			errorTip: 'ext-sodium is bundled with PHP since 7.2 but not always enabled, use ParagonIE\ConstantTime\Hex::encode() if not available'
+		-
+			function: 'base64_decode()'
+			message: 'it is not timing-safe, use sodium_base642bin() instead'
+			errorTip: 'ext-sodium is bundled with PHP since 7.2 but not always enabled, use ParagonIE\ConstantTime\Base64::decode() if not available'
+		-
+			function: 'base64_encode()'
+			message: 'it is not timing-safe, use sodium_bin2base64() instead'
+			errorTip: 'ext-sodium is bundled with PHP since 7.2 but not always enabled, use ParagonIE\ConstantTime\Base64::encode() if not available'

--- a/docs/configuration-bundled.md
+++ b/docs/configuration-bundled.md
@@ -38,3 +38,10 @@ Some function calls are better when done for example with some parameters set to
 includes:
     - vendor/spaze/phpstan-disallowed-calls/disallowed-loose-calls.neon
 ```
+
+For code that works with keys, tokens, passwords, and other secrets: encoding functions whose runtime depends on the processed bytes and can leak information about them. Include `disallowed-non-timing-safe-calls.neon` to disallow these calls.
+
+```neon
+includes:
+    - vendor/spaze/phpstan-disallowed-calls/disallowed-non-timing-safe-calls.neon
+```

--- a/tests/Configs/NonTimingSafeCallsConfigTest.php
+++ b/tests/Configs/NonTimingSafeCallsConfigTest.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Rules\Disallowed\Configs;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use Spaze\PHPStan\Rules\Disallowed\Calls\FunctionCalls;
+
+/**
+ * @extends RuleTestCase<FunctionCalls>
+ */
+class NonTimingSafeCallsConfigTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return self::getContainer()->getByType(FunctionCalls::class);
+	}
+
+
+	public function testRule(): void
+	{
+		// Based on the configuration above, in this file:
+		$this->analyse([__DIR__ . '/../src/configs/nonTimingSafeCalls.php'], [
+			// expect these error messages, on these lines:
+			['Calling hex2bin() is forbidden, it is not timing-safe, use sodium_hex2bin() instead.', 4, 'ext-sodium is bundled with PHP since 7.2 but not always enabled, use ParagonIE\ConstantTime\Hex::decode() if not available'],
+			['Calling bin2hex() is forbidden, it is not timing-safe, use sodium_bin2hex() instead.', 5, 'ext-sodium is bundled with PHP since 7.2 but not always enabled, use ParagonIE\ConstantTime\Hex::encode() if not available'],
+			['Calling base64_decode() is forbidden, it is not timing-safe, use sodium_base642bin() instead.', 6, 'ext-sodium is bundled with PHP since 7.2 but not always enabled, use ParagonIE\ConstantTime\Base64::decode() if not available'],
+			['Calling base64_encode() is forbidden, it is not timing-safe, use sodium_bin2base64() instead.', 7, 'ext-sodium is bundled with PHP since 7.2 but not always enabled, use ParagonIE\ConstantTime\Base64::encode() if not available'],
+		]);
+	}
+
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__ . '/../../extension.neon',
+			__DIR__ . '/../../disallowed-non-timing-safe-calls.neon',
+		];
+	}
+
+}

--- a/tests/src/configs/nonTimingSafeCalls.php
+++ b/tests/src/configs/nonTimingSafeCalls.php
@@ -1,0 +1,7 @@
+<?php
+declare(strict_types = 1);
+
+hex2bin('foo');
+bin2hex('foo');
+base64_decode('foo');
+base64_encode('foo');


### PR DESCRIPTION
Added `disallowed-non-timing-safe-calls.neon` configuration file to prevent usage of encoding functions that are not timing-safe, specifically `hex2bin`, `bin2hex`, `base64_decode`, and `base64_encode`. The rules recommend `sodium_*` functions instead, or `ParagonIE\ConstantTime\*` functions if ext-sodium is not available.

Updated `docs/configuration-bundled.md` documentation to list the new config file for users whose projects handle secrets.

Also added tests to ensure the configuration file is correctly parsed and evaluated by PHPStan.

Closes #432

Follow-ups:
- #434