### PR TITLE
Tidy up after the non-timing-safe calls config

### DIFF
--- a/docs/configuration-bundled.md
+++ b/docs/configuration-bundled.md
@@ -32,14 +32,17 @@ includes:
     - vendor/spaze/phpstan-disallowed-calls/disallowed-insecure-calls.neon
 ```
 
-Some function calls are better when done for example with some parameters set to a defined value ("strict calls"). For example `in_array()` better also check for types to prevent some type juggling bugs. Include `disallowed-loose-calls.neon` to disallow calls without such parameters set ("loose calls").
+Some function calls are better when done for example with some parameters set to a defined value ("strict calls").
+For example `in_array()` should also check for types to prevent some type juggling bugs.
+Include `disallowed-loose-calls.neon` to disallow calls without such parameters set ("loose calls").
 
 ```neon
 includes:
     - vendor/spaze/phpstan-disallowed-calls/disallowed-loose-calls.neon
 ```
 
-For code that works with keys, tokens, passwords, and other secrets: encoding functions whose runtime depends on the processed bytes and can leak information about them. Include `disallowed-non-timing-safe-calls.neon` to disallow these calls.
+For code that works with keys, tokens, passwords, and other secrets: the runtime of some encoding functions depends on the processed bytes and can leak information about them.
+Include `disallowed-non-timing-safe-calls.neon` to disallow these calls.
 
 ```neon
 includes:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -33,3 +33,4 @@ includes:
 	- disallowed-execution-calls.neon
 	- disallowed-insecure-calls.neon
 	- disallowed-loose-calls.neon
+	# disallowed-non-timing-safe-calls.neon is not included intentionally, it's scoped to code that handles secrets, and this project handles none

--- a/tests/Configs/NonTimingSafeConfigFunctionCallsTest.php
+++ b/tests/Configs/NonTimingSafeConfigFunctionCallsTest.php
@@ -10,7 +10,7 @@ use Spaze\PHPStan\Rules\Disallowed\Calls\FunctionCalls;
 /**
  * @extends RuleTestCase<FunctionCalls>
  */
-class NonTimingSafeCallsConfigTest extends RuleTestCase
+class NonTimingSafeConfigFunctionCallsTest extends RuleTestCase
 {
 
 	protected function getRule(): Rule


### PR DESCRIPTION
The project's own `phpstan.neon` now has a comment explaining why `disallowed-non-timing-safe-calls.neon` is not included there, unlike the other bundled configs. Those enforce universal hygiene that applies to any codebase, while this one is scoped to code that handles secrets, which this project has none of, so without the comment the omission would read as an oversight rather than a decision.

The test class is renamed to `NonTimingSafeConfigFunctionCallsTest` to match the `<Name>Config<RuleType>Test` naming pattern used by the other tests in `tests/Configs`, like `LooseConfigFunctionCallsTest` or `DangerousConfigEvalCallsTest`.

The new paragraph in `docs/configuration-bundled.md` opened with a fragment with no main verb and kept two sentences on one line, so it's reworded and split to one sentence per line. The loose-calls paragraph above it had the same layout, so its sentences got their own lines too, with one word changed to be grammatically more correct.

Follow-up to #433.